### PR TITLE
refactor: Compute house rewards only at game end

### DIFF
--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -67,6 +67,7 @@ pub struct PyScenario {
 impl PyScenario {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (beta, kappa, a, l, c, rho_ignite, n_min, p_spark, n_spark, num_agents, a_own=100.0, a_neighbor=50.0))]
     fn new(
         beta: f32,
         kappa: f32,
@@ -78,6 +79,8 @@ impl PyScenario {
         p_spark: f32,
         n_spark: u32,
         num_agents: usize,
+        a_own: f32,
+        a_neighbor: f32,
     ) -> Self {
         Self {
             inner: Scenario {
@@ -91,6 +94,8 @@ impl PyScenario {
                 p_spark,
                 n_spark,
                 num_agents,
+                a_own,
+                a_neighbor,
             },
         }
     }
@@ -134,6 +139,14 @@ impl PyScenario {
     #[getter]
     fn num_agents(&self) -> usize {
         self.inner.num_agents
+    }
+    #[getter]
+    fn a_own(&self) -> f32 {
+        self.inner.a_own
+    }
+    #[getter]
+    fn a_neighbor(&self) -> f32 {
+        self.inner.a_neighbor
     }
 }
 

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -94,6 +94,8 @@ impl WasmScenario {
         p_spark: f32,
         n_spark: u32,
         num_agents: usize,
+        a_own: Option<f32>,
+        a_neighbor: Option<f32>,
     ) -> WasmScenario {
         Self {
             inner: Scenario {
@@ -107,6 +109,8 @@ impl WasmScenario {
                 p_spark,
                 n_spark,
                 num_agents,
+                a_own: a_own.unwrap_or(100.0),
+                a_neighbor: a_neighbor.unwrap_or(50.0),
             },
         }
     }


### PR DESCRIPTION
## Summary

Refactors the reward system to compute house-based rewards only at game end, separating per-step costs from final outcomes. This makes rewards timing-independent and semantically clearer.

## Changes

### Core Reward Structure

**Per-Step Rewards** (computed each night):
- Work cost: `-c` per night when working
- Rest reward: `+0.5` per night when resting
- No team or ownership bonuses/penalties

**Final Rewards** (computed at game end):
- **Owned house saved**: `+a_own` (currently 100-150)
- **Owned house ruined**: `-a_own` (symmetric penalty)
- **Neighbor house saved**: `+a_neighbor` (currently 25-50)  
- **Neighbor house ruined**: `-a_neighbor` (symmetric penalty)

### Implementation Details

**Core Engine** (bucket-brigade-core/src/engine.rs):
- Refactored compute_rewards() to return only work/rest costs (removed team reward and ownership bonuses)
- Added compute_final_rewards() method to calculate house outcome rewards based on final state
- Updated get_result() to add final rewards to agent scores after summing trajectory

**Python Bindings** (bucket-brigade-core/src/python.rs):
- Added a_own and a_neighbor parameters to PyScenario.__init__() with defaults (100.0, 50.0)
- Added getters for a_own and a_neighbor properties

**WASM Bindings** (bucket-brigade-core/src/wasm.rs):
- Updated WasmScenario::new() to accept optional a_own and a_neighbor parameters

**Tests**:
- Updated test_ownership_rewards() and test_ownership_penalty() to reflect new timing
- All 52 Rust tests pass
- All 34 Python tests pass (no modifications needed to Python tests!)

## Benefits

1. Timing independent: A house burning on night 1 has the same impact as night 10
2. Clear semantics: Per-step costs vs end-game outcomes clearly separated
3. Strong ownership incentives: Large bonuses for saving owned house (100-150 vs old 1.0)
4. Strategic depth: Agents must balance immediate costs vs final outcomes
5. Backward compatible: Existing Python code continues to work

## Design Decisions

**Kept rest reward**: Still giving +0.5 for resting (can be removed later if desired)

**Symmetric penalties**: Used same parameter values for saved and ruined houses:
- Owned house ruined: -a_own (not a separate l_own parameter)
- Neighbor house ruined: -a_neighbor (not a separate l_neighbor parameter)

**Neighbor penalties**: Applied penalties to ruined neighbor houses (not just owned houses)

## Test Results

**Rust Tests**: 52/52 passed

**Python Tests**: 34/34 passed (5 skipped)

## Related

- Builds on ownership parameters added in commit 447adfd
- Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>