### PR TITLE
feat: Add scenario-specific policy training support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,18 @@
       "Bash(make test-python:*)",
       "WebFetch(domain:github.com)",
       "Bash(pre-commit autoupdate:*)",
-      "Bash(./.venv/bin/pre-commit autoupdate:*)"
+      "Bash(./.venv/bin/pre-commit autoupdate:*)",
+      "Bash(VITE_BASE_PATH=/ pnpm run build:*)",
+      "Bash(then source .venv/bin/activate)",
+      "Bash(for i in {1..30})",
+      "Bash(do echo \"Check $i:\")",
+      "Bash(for:*)",
+      "Bash(do echo \"=== $f ===\")",
+      "Bash(PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo build:*)",
+      "Bash(make build-wasm:*)",
+      "WebFetch(domain:rjwalters.github.io)",
+      "Bash(VITE_BASE_PATH=/bucket-brigade/ pnpm run build:*)",
+      "Bash(export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1)"
     ],
     "deny": [],
     "ask": []

--- a/bucket_brigade/envs/__init__.py
+++ b/bucket_brigade/envs/__init__.py
@@ -44,6 +44,10 @@ from .scenarios import (
     sample_crisis_scenario,
     sample_sparse_work_scenario,
     sample_deception_scenario,
+    # Scenario registry
+    get_scenario_by_name,
+    list_scenarios,
+    SCENARIO_REGISTRY,
 )
 
 __all__ = [
@@ -72,4 +76,8 @@ __all__ = [
     "sample_crisis_scenario",
     "sample_sparse_work_scenario",
     "sample_deception_scenario",
+    # Scenario registry
+    "get_scenario_by_name",
+    "list_scenarios",
+    "SCENARIO_REGISTRY",
 ]

--- a/bucket_brigade/envs/scenarios.py
+++ b/bucket_brigade/envs/scenarios.py
@@ -419,9 +419,7 @@ def get_scenario_by_name(name: str, num_agents: int) -> Scenario:
     """
     if name not in SCENARIO_REGISTRY:
         valid_names = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
-        raise ValueError(
-            f"Unknown scenario '{name}'. Valid options: {valid_names}"
-        )
+        raise ValueError(f"Unknown scenario '{name}'. Valid options: {valid_names}")
 
     return SCENARIO_REGISTRY[name](num_agents)
 

--- a/bucket_brigade/envs/scenarios.py
+++ b/bucket_brigade/envs/scenarios.py
@@ -379,3 +379,63 @@ def sample_deception_scenario(num_agents: int, seed: Optional[int] = None) -> Sc
         N_spark=15,
         num_agents=num_agents,
     )
+
+
+# Scenario Registry
+
+SCENARIO_REGISTRY = {
+    "default": default_scenario,
+    "easy": easy_scenario,
+    "hard": hard_scenario,
+    "trivial_cooperation": trivial_cooperation_scenario,
+    "early_containment": early_containment_scenario,
+    "greedy_neighbor": greedy_neighbor_scenario,
+    "sparse_heroics": sparse_heroics_scenario,
+    "rest_trap": rest_trap_scenario,
+    "chain_reaction": chain_reaction_scenario,
+    "deceptive_calm": deceptive_calm_scenario,
+    "overcrowding": overcrowding_scenario,
+    "mixed_motivation": mixed_motivation_scenario,
+}
+
+
+def get_scenario_by_name(name: str, num_agents: int) -> Scenario:
+    """
+    Get a scenario by name.
+
+    Args:
+        name: Scenario name (e.g., "trivial_cooperation", "default")
+        num_agents: Number of agents in the scenario
+
+    Returns:
+        Scenario object
+
+    Raises:
+        ValueError: If scenario name is invalid
+
+    Example:
+        >>> scenario = get_scenario_by_name("trivial_cooperation", num_agents=4)
+        >>> env = PufferBucketBrigade(scenario=scenario)
+    """
+    if name not in SCENARIO_REGISTRY:
+        valid_names = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
+        raise ValueError(
+            f"Unknown scenario '{name}'. Valid options: {valid_names}"
+        )
+
+    return SCENARIO_REGISTRY[name](num_agents)
+
+
+def list_scenarios() -> list:
+    """
+    Get list of available scenario names.
+
+    Returns:
+        Sorted list of scenario names
+
+    Example:
+        >>> scenarios = list_scenarios()
+        >>> print(scenarios)
+        ['chain_reaction', 'deceptive_calm', 'default', ...]
+    """
+    return sorted(SCENARIO_REGISTRY.keys())

--- a/scripts/evaluate_simple.py
+++ b/scripts/evaluate_simple.py
@@ -81,6 +81,12 @@ def main():
     )
     parser.add_argument("--render", action="store_true", help="Render the environment")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        default="default",
+        help="Scenario name for evaluation (e.g., 'default', 'trivial_cooperation')",
+    )
 
     args = parser.parse_args()
 
@@ -105,9 +111,15 @@ def main():
     print(f"   Action dims: {action_dims}")
     print(f"   Hidden size: {hidden_size}")
 
-    # Create environment
-    print(f"\n🎮 Creating environment with {args.num_opponents} opponents")
-    env = PufferBucketBrigade(num_opponents=args.num_opponents)
+    # Create environment with scenario
+    from bucket_brigade.envs import get_scenario_by_name
+
+    print(f"\n🎮 Creating environment")
+    print(f"   Scenario: {args.scenario}")
+    print(f"   Number of opponents: {args.num_opponents}")
+
+    scenario = get_scenario_by_name(args.scenario, num_agents=args.num_opponents + 1)
+    env = PufferBucketBrigade(scenario=scenario, num_opponents=args.num_opponents)
 
     # Evaluate
     print(f"\n🔍 Evaluating for {args.num_episodes} episodes...")

--- a/scripts/evaluate_transfer.sh
+++ b/scripts/evaluate_transfer.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Evaluate cross-scenario transfer learning
+#
+# This script tests how well a policy trained on one scenario
+# performs when evaluated on different scenarios. This helps identify:
+# - Which skills transfer across scenarios
+# - Which scenarios require specialized strategies
+# - Optimal curriculum ordering
+#
+# Usage:
+#   ./scripts/evaluate_transfer.sh <train_scenario>
+#
+# Example:
+#   ./scripts/evaluate_transfer.sh trivial_cooperation
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <train_scenario>"
+    echo ""
+    echo "Available scenarios:"
+    uv run python scripts/train_simple.py --list-scenarios
+    exit 1
+fi
+
+TRAIN_SCENARIO=$1
+MODEL_PATH="models/policy_${TRAIN_SCENARIO}.pt"
+
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "❌ Error: Model not found at $MODEL_PATH"
+    echo "Train the model first with:"
+    echo "  uv run python scripts/train_simple.py --scenario $TRAIN_SCENARIO --save-path $MODEL_PATH"
+    exit 1
+fi
+
+# Test scenarios (excluding meta-scenarios)
+TEST_SCENARIOS=(
+    "trivial_cooperation"
+    "early_containment"
+    "greedy_neighbor"
+    "sparse_heroics"
+    "rest_trap"
+    "chain_reaction"
+    "deceptive_calm"
+    "overcrowding"
+    "mixed_motivation"
+)
+
+NUM_EPISODES=100
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔬 Cross-Scenario Transfer Evaluation"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Model trained on: $TRAIN_SCENARIO"
+echo "Model path: $MODEL_PATH"
+echo "Episodes per scenario: $NUM_EPISODES"
+echo ""
+
+mkdir -p results
+
+# Create results file
+RESULTS_FILE="results/transfer_${TRAIN_SCENARIO}.txt"
+echo "Transfer Learning Results" > "$RESULTS_FILE"
+echo "Trained on: $TRAIN_SCENARIO" >> "$RESULTS_FILE"
+echo "Date: $(date)" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+echo "Scenario                  Mean Reward    Std Dev" >> "$RESULTS_FILE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >> "$RESULTS_FILE"
+
+for test_scenario in "${TEST_SCENARIOS[@]}"; do
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "📊 Testing on: $test_scenario"
+
+    # Capture output and parse statistics
+    OUTPUT=$(uv run python scripts/evaluate_simple.py \
+        --model-path "$MODEL_PATH" \
+        --scenario "$test_scenario" \
+        --num-episodes "$NUM_EPISODES" 2>&1)
+
+    echo "$OUTPUT"
+
+    # Extract mean reward (this assumes the output format from evaluate_simple.py)
+    MEAN_REWARD=$(echo "$OUTPUT" | grep "Mean Reward:" | awk '{print $3}')
+    STD_DEV=$(echo "$OUTPUT" | grep "Mean Reward:" | awk '{print $5}')
+
+    # Log to results file
+    printf "%-25s %12s   %s\n" "$test_scenario" "$MEAN_REWARD" "$STD_DEV" >> "$RESULTS_FILE"
+
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Transfer evaluation complete!"
+echo "Results saved to: $RESULTS_FILE"
+echo ""
+echo "Next steps:"
+echo "  1. View results: cat $RESULTS_FILE"
+echo "  2. Compare with other models: ./scripts/evaluate_transfer.sh <other_scenario>"
+echo "  3. Analyze difficulty: uv run python scripts/analyze_scenarios.py"

--- a/scripts/train_all_scenarios.sh
+++ b/scripts/train_all_scenarios.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Train policies for all named Bucket Brigade scenarios
+#
+# This script trains a policy on each of the 9 predefined scenarios
+# using consistent hyperparameters. Training duration: ~9 hours total
+# (can be parallelized if you have multiple cores).
+#
+# Usage:
+#   ./scripts/train_all_scenarios.sh
+
+set -e  # Exit on error
+
+# Training hyperparameters
+NUM_STEPS=200000
+NUM_OPPONENTS=3
+BATCH_SIZE=2048
+HIDDEN_SIZE=128
+SEED=42
+
+# Scenarios to train (excluding meta-scenarios like 'default', 'easy', 'hard')
+SCENARIOS=(
+    "trivial_cooperation"
+    "early_containment"
+    "greedy_neighbor"
+    "sparse_heroics"
+    "rest_trap"
+    "chain_reaction"
+    "deceptive_calm"
+    "overcrowding"
+    "mixed_motivation"
+)
+
+echo "🚀 Starting batch training for ${#SCENARIOS[@]} scenarios"
+echo "   Steps per scenario: $NUM_STEPS"
+echo "   Estimated time: ~$(( ${#SCENARIOS[@]} * 60 )) minutes total"
+echo ""
+
+mkdir -p models
+
+for scenario in "${SCENARIOS[@]}"; do
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🎮 Training on scenario: $scenario"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    uv run python scripts/train_simple.py \
+        --scenario "$scenario" \
+        --num-steps "$NUM_STEPS" \
+        --num-opponents "$NUM_OPPONENTS" \
+        --batch-size "$BATCH_SIZE" \
+        --hidden-size "$HIDDEN_SIZE" \
+        --seed "$SEED" \
+        --save-path "models/policy_${scenario}.pt"
+
+    echo "✅ Completed: $scenario"
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🎉 All scenarios trained successfully!"
+echo ""
+echo "Trained models saved to:"
+for scenario in "${SCENARIOS[@]}"; do
+    echo "  - models/policy_${scenario}.pt"
+done
+echo ""
+echo "Next steps:"
+echo "  1. Evaluate models: ./scripts/evaluate_transfer.sh"
+echo "  2. Analyze scenarios: uv run python scripts/analyze_scenarios.py"

--- a/scripts/train_simple.py
+++ b/scripts/train_simple.py
@@ -248,16 +248,40 @@ def main():
         default="models/simple_policy.pt",
         help="Path to save trained model",
     )
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        default="default",
+        help="Scenario name (e.g., 'default', 'trivial_cooperation', 'chain_reaction')",
+    )
+    parser.add_argument(
+        "--list-scenarios",
+        action="store_true",
+        help="List available scenarios and exit",
+    )
 
     args = parser.parse_args()
+
+    # Handle --list-scenarios
+    if args.list_scenarios:
+        from bucket_brigade.envs import list_scenarios
+        print("Available scenarios:")
+        for name in list_scenarios():
+            print(f"  - {name}")
+        return
 
     # Set seeds
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
-    # Create environment
-    print(f"🎮 Creating environment with {args.num_opponents} opponents")
-    env = PufferBucketBrigade(num_opponents=args.num_opponents)
+    # Create environment with scenario
+    from bucket_brigade.envs import get_scenario_by_name
+
+    print(f"🎮 Creating environment with scenario: {args.scenario}")
+    print(f"   Number of opponents: {args.num_opponents}")
+
+    scenario = get_scenario_by_name(args.scenario, num_agents=args.num_opponents + 1)
+    env = PufferBucketBrigade(scenario=scenario, num_opponents=args.num_opponents)
 
     # Create policy
     obs_dim = env.observation_space.shape[0]


### PR DESCRIPTION
## Summary

Implement scenario-specific policy training to enable developing specialized strategies for different Bucket Brigade scenarios.

## Changes

### Core Functionality
- **Scenario Registry** (`scenarios.py:384-441`): Added `SCENARIO_REGISTRY` dictionary mapping scenario names to constructor functions
- **Helper Functions**: `get_scenario_by_name()` and `list_scenarios()` for convenient scenario access
- **Module Exports**: Updated `__init__.py` to export registry functions

### Training Scripts
- **Training CLI** (`train_simple.py`): Added `--scenario` flag and `--list-scenarios` to select specific scenarios
- **Evaluation CLI** (`evaluate_simple.py`): Added `--scenario` flag for cross-scenario evaluation

### Batch Scripts
- **`scripts/train_all_scenarios.sh`**: Automates training on all 9 named scenarios
- **`scripts/evaluate_transfer.sh`**: Evaluates cross-scenario transfer learning

## Test Plan

Manually tested:
- ✅ `--list-scenarios` flag lists all 12 scenarios correctly
- ✅ Scenario registry correctly maps all scenario names
- ✅ Scripts are executable and have proper error handling

Note: Full training runs take 2-8 hours per scenario and are left for future testing.

## Example Usage

```bash
# List available scenarios
uv run python scripts/train_simple.py --list-scenarios

# Train on specific scenario
uv run python scripts/train_simple.py \
    --scenario trivial_cooperation \
    --num-steps 200000 \
    --save-path models/policy_trivial_coop.pt

# Evaluate cross-scenario transfer
uv run python scripts/evaluate_simple.py \
    --model-path models/policy_trivial_coop.pt \
    --scenario chain_reaction \
    --num-episodes 100
```

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>