### PR TITLE
Add loom:changes-requested label for Judge workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -41,6 +41,10 @@
   description: PR approved by Judge, ready for human to merge
   color: "3B82F6"  # blue-500
 
+- name: loom:changes-requested
+  description: PR requires changes before approval (Judge has requested revisions)
+  color: "F59E0B"  # amber-500 (matches other in-progress states)
+
 # Agent Proposal Labels
 - name: loom:architect
   description: Architect proposal awaiting user approval


### PR DESCRIPTION
## Summary

Add the missing `loom:changes-requested` label to enable Judge agents to properly mark PRs requiring revisions.

## Problem

The Judge role documentation (`.loom/roles/judge.md`) references a `loom:changes-requested` label that doesn't exist in the repository. This blocks Judge agents from functioning correctly when reviewing PRs.

## Solution

Added the `loom:changes-requested` label definition to `.github/labels.yml` and created it in the GitHub repository.

## Changes

- Added label definition to `.github/labels.yml` (lines 44-46)
- Color: amber-500 (F59E0B) to match other in-progress states
- Description: "PR requires changes before approval (Judge has requested revisions)"
- Created label in GitHub via `gh label create`

## Test Plan

✅ Verified label exists: `gh label list | grep loom:changes-requested`
✅ Confirmed color and description match specification
✅ Label can be applied to PRs: `gh pr edit <number> --add-label "loom:changes-requested"`

## Acceptance Criteria

- [x] Label `loom:changes-requested` exists in repository
- [x] Judge role can successfully apply label to PRs
- [x] Label color matches other in-progress states (amber)
- [x] No conflicts with other workflow labels

Closes #42