### PR TITLE
Fix pre-commit CI job by installing dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+      with:
+        version: "latest"
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: Install pre-commit
-      run: pip install pre-commit
+    - name: Create virtual environment
+      run: uv venv
+    - name: Install dependencies
+      run: uv pip install -e .[dev]
     - name: Run pre-commit
-      run: pre-commit run --all-files
+      run: uv run pre-commit run --all-files

--- a/bucket_brigade/equilibrium/best_response.py
+++ b/bucket_brigade/equilibrium/best_response.py
@@ -123,7 +123,7 @@ def compute_best_response_global(
         maxiter=maxiter,
         polish=True,
         workers=1,  # Sequential to avoid pickling issues
-        updating='immediate',
+        updating="immediate",
         atol=0.01,
         tol=0.005,
     )
@@ -188,7 +188,7 @@ def compute_best_response_to_mixture(
             maxiter=15,  # Reduced from 50 for faster convergence
             polish=True,
             workers=1,  # Sequential to avoid pickling issues; Rust provides parallelization
-            updating='immediate',
+            updating="immediate",
             atol=0.01,  # Absolute tolerance for convergence
             tol=0.005,  # Relative tolerance for convergence
         )

--- a/experiments/scripts/analyze_evolved_experts.py
+++ b/experiments/scripts/analyze_evolved_experts.py
@@ -211,7 +211,7 @@ def plot_cross_scenario_comparison(all_stats: Dict[str, Dict], output_dir: Path)
     fig, ax = plt.subplots(figsize=(14, 8))
 
     x = np.arange(len(scenarios))
-    bars = ax.bar(x, means, yerr=stds, capsize=5, alpha=0.7, color='steelblue')
+    ax.bar(x, means, yerr=stds, capsize=5, alpha=0.7, color='steelblue')
 
     ax.set_xlabel('Scenario', fontsize=12)
     ax.set_ylabel('Mean Best Fitness', fontsize=12)
@@ -260,8 +260,8 @@ def plot_strategy_heatmap(all_stats: Dict[str, Dict], output_dir: Path):
     # Add text annotations
     for i in range(len(scenarios)):
         for j in range(len(PARAM_NAMES)):
-            text = ax.text(j, i, f'{param_matrix[i, j]:.2f}',
-                          ha="center", va="center", color="black", fontsize=8)
+            ax.text(j, i, f'{param_matrix[i, j]:.2f}',
+                    ha="center", va="center", color="black", fontsize=8)
 
     ax.set_title('Evolved Strategy Parameters Across Scenarios\n(Mean across 10 seeds)', fontsize=14)
     plt.tight_layout()


### PR DESCRIPTION
## Summary

Fixes intermittent pre-commit CI check failures by ensuring all required Python dependencies are installed before running pre-commit hooks.

## Changes

- Add `uv` package manager setup to pre-commit job
- Install project dev dependencies (`uv pip install -e .[dev]`) before running hooks
- Use `uv run pre-commit` for consistent environment
- Matches approach used in other Python CI jobs (`test-python`, `lint-python`)

## Problem

The pre-commit CI job was only installing the `pre-commit` package itself via pip, but individual hooks (like `ruff`, `bandit`, etc.) require their own dependencies. This caused intermittent failures, especially on documentation-only PRs where developers might not have run pre-commit locally.

## Solution

Implemented Option 1 from the issue guidance - install all dev dependencies in the pre-commit job so the CI environment matches local development and all hooks have their required tools available.

## Test Plan

The CI run for this PR will verify:
- Pre-commit job completes successfully with new setup
- All hooks run without dependency errors
- Runtime is reasonable (<2 minutes expected)

Closes #103