### PR TITLE
fix: Align bucket-brigade-core build path with setuptools-rust backend

### DIFF
--- a/OPTIMIZATION_NOTES.md
+++ b/OPTIMIZATION_NOTES.md
@@ -131,12 +131,13 @@ cd bucket-brigade-core
 # Clean any stale build artifacts to avoid cffi/PyO3 conflicts
 rm -rf target bucket_brigade_core/__pycache__ bucket_brigade_core/bucket_brigade_core
 
-# Ensure maturin is installed
-uv pip install maturin
+# Ensure setuptools-rust is installed (matches pyproject.toml backend)
+uv pip install setuptools-rust
 
-# Source Rust environment and build with PyO3 feature
+# Source Rust environment and build via setuptools-rust backend
 source "$HOME/.cargo/env"
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+RUSTC_WRAPPER= PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+    uv run python -m pip install -e . --no-build-isolation
 
 cd ..
 ```

--- a/POPULATION_TRAINING.md
+++ b/POPULATION_TRAINING.md
@@ -187,9 +187,9 @@ uv venv
 source .venv/bin/activate
 uv sync --extra rl
 
-# Build Rust core
+# Build Rust core (uses setuptools-rust backend; see bucket-brigade-core/README.md)
 cd bucket-brigade-core
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release
+./build.sh
 cd ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -317,12 +317,20 @@ cd bucket-brigade-core && ./build.sh
 
 This automated build script checks your Python version, compiles the Rust library, and installs it correctly.
 
-Alternatively, manual methods:
+Alternatively, manual method (matches what `build.sh` does — uses the
+setuptools-rust backend declared in `bucket-brigade-core/pyproject.toml`):
 ```bash
-cd bucket-brigade-core && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release
-# or
-cd bucket-brigade-core && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pip install -e .
+cd bucket-brigade-core
+uv pip install setuptools-rust
+RUSTC_WRAPPER= PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+    uv run python -m pip install -e . --no-build-isolation
 ```
+
+> **Pitfall**: many of this repo's example commands set `RUSTC_WRAPPER=sccache`.
+> If sccache is not installed, the build may fail or produce a broken
+> artifact. Either install sccache (`cargo install sccache`) or unset
+> `RUSTC_WRAPPER` before building. See `bucket-brigade-core/README.md` for
+> troubleshooting (e.g. recovering from the CFFI-shadow trap).
 
 🚀 Quickstart
 ```bash

--- a/TRAINING_GUIDE.md
+++ b/TRAINING_GUIDE.md
@@ -239,7 +239,7 @@ The policy must learn to:
 - **Rust backend is now used by default** (100x faster!)
 - Reduce `--batch-size`
 - Reduce `--num-opponents`
-- Ensure Rust core is installed: `cd bucket-brigade-core && maturin develop --release`
+- Ensure Rust core is installed: `cd bucket-brigade-core && ./build.sh`
 
 ### Policy Not Learning
 - Increase `--num-steps` (try 500K-1M)

--- a/bucket-brigade-core/README.md
+++ b/bucket-brigade-core/README.md
@@ -24,25 +24,69 @@ This Rust implementation serves as the authoritative game logic, with Python and
 ./build.sh
 ```
 
-This script:
-- Checks your Python version
-- Builds the Rust library with `cargo`
-- Copies the `.so` file to the correct location
-- Verifies the installation
+This script uses the **setuptools-rust** build backend declared in
+`pyproject.toml`. It installs `setuptools-rust`, removes any stale
+CFFI-shadow artifacts, and runs `pip install -e . --no-build-isolation`.
+It sets the env vars described below defensively, so it works on a fresh
+machine with no extra configuration.
+
+### Required environment variables
+
+The build relies on two environment settings. `build.sh` exports both for
+you; if you are running a build command manually, set them yourself:
+
+- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` — required so PyO3 0.22.x builds
+  against newer Python versions (e.g. 3.13).
+- `RUSTC_WRAPPER=` (i.e. unset) — many other docs in this repo export
+  `RUSTC_WRAPPER=sccache` for caching. **If `sccache` is not installed on
+  your machine, the build will fail or produce a broken artifact.** Either
+  install sccache (`cargo install sccache`) or unset `RUSTC_WRAPPER` before
+  building.
 
 ### Manual Build
 
 If you prefer manual installation:
 
 ```bash
-# Using pip (may not trigger Rust build correctly)
-pip install -e .
-
-# Using cargo directly (more reliable)
-export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
-cargo build --release --features python
-# Then manually copy target/release/libbucket_brigade_core.so to bucket_brigade_core/
+# Recommended: uses the setuptools-rust backend declared in pyproject.toml.
+# This matches what build.sh does.
+uv pip install setuptools-rust
+RUSTC_WRAPPER= PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+    uv run python -m pip install -e . --no-build-isolation
 ```
+
+Note: the `--features python` flag is configured in `pyproject.toml`
+(`[tool.setuptools-rust] features = ["python"]`) so you do not need to
+pass it explicitly when using the setuptools-rust path.
+
+### Troubleshooting
+
+**`ImportError: cannot import name 'PyBucketBrigade' from 'bucket_brigade_core.bucket_brigade_core'`**
+
+You have hit the CFFI-shadow trap. An older `maturin develop` build (or
+one that ran without `--features python`) produced a nested
+`bucket_brigade_core/bucket_brigade_core/` directory containing CFFI shim
+files that shadow the real PyO3 module. Clean and rebuild:
+
+```bash
+cd bucket-brigade-core
+rm -rf bucket_brigade_core/bucket_brigade_core
+./build.sh
+```
+
+After a successful build, the artifact layout should be:
+
+- `bucket_brigade_core/bucket_brigade_core.cpython-<TAG>-<PLATFORM>.so` (the real PyO3 module)
+- `bucket_brigade_core/__init__.py`
+- **No** `bucket_brigade_core/bucket_brigade_core/` directory
+- **No** `ffi.py`, **no** `libbucket_brigade_core.dylib`/`.so` next to `__init__.py`
+
+**Build hangs or fails complaining about `sccache`**
+
+Your shell has `RUSTC_WRAPPER=sccache` exported but sccache is not
+installed. Either `cargo install sccache` or `unset RUSTC_WRAPPER` before
+running `build.sh`. `build.sh` unsets it for its own invocation but cannot
+clean up your interactive shell environment.
 
 ## Usage
 
@@ -94,7 +138,11 @@ This crate is the **source of truth** for Bucket Brigade game mechanics:
 # Build Rust library
 cargo build
 
-# Build Python extension
+# Build Python extension (the importable Python module).
+# See "Installation" above for the canonical recipe.
+./build.sh
+
+# Build the underlying staticlib/cdylib via cargo only (no Python install).
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo build --features python
 
 # Run tests

--- a/bucket-brigade-core/build.sh
+++ b/bucket-brigade-core/build.sh
@@ -1,11 +1,27 @@
 #!/bin/bash
 set -e
 
-echo "🔧 Building bucket-brigade-core Rust extension..."
+# Build script for bucket-brigade-core (Rust PyO3 extension).
+#
+# IMPORTANT: This script uses the setuptools-rust build path declared in
+# pyproject.toml (build-backend = "setuptools.build_meta"). The previous
+# maturin-based path silently fell back to CFFI bindings when --features python
+# was not passed, producing a non-importable package. See issue #134.
+#
+# Environment variables (set defensively in this script):
+#   PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+#     Allow PyO3 0.22.x to build against newer Python versions.
+#   RUSTC_WRAPPER=
+#     Unset sccache wrapper. Many docs in this repo export RUSTC_WRAPPER=sccache,
+#     but on systems without sccache installed the build either fails or
+#     silently produces a broken artifact. We unset it here to guarantee a
+#     reproducible build.
+
+echo "Building bucket-brigade-core Rust extension..."
 
 # Check if Rust is installed
 if ! command -v rustc &> /dev/null; then
-    echo "📦 Installing Rust..."
+    echo "Installing Rust..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     source "$HOME/.cargo/env"
 fi
@@ -13,32 +29,41 @@ fi
 # Ensure Rust is in PATH
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# Defensive: unset RUSTC_WRAPPER (e.g. sccache) so absence of sccache cannot
+# cause silent fallback to the CFFI build path.
+export RUSTC_WRAPPER=
+
+# Required for PyO3 0.22.x ABI3 forward compatibility (Python >= 3.13)
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+
 # Check Rust version
-echo "✅ Rust version: $(rustc --version)"
+echo "Rust version: $(rustc --version)"
 
-# Install Python build dependencies
-echo "📦 Installing Python dependencies..."
-uv pip install cffi maturin
+# Install Python build dependencies (setuptools-rust matches pyproject.toml)
+echo "Installing Python build dependencies..."
+uv pip install setuptools-rust
 
-# Clean CFFI artifacts but keep main .so file
-echo "🧹 Cleaning CFFI artifacts..."
+# Clean previous CFFI-shadow artifacts (from earlier maturin-based builds) and
+# any stale wheel output. The PyO3 .so file lives at
+#   bucket_brigade_core/bucket_brigade_core.cpython-*.so
+# whereas the broken CFFI shadow lives in the nested directory
+#   bucket_brigade_core/bucket_brigade_core/
+# Removing the nested directory is safe and required to recover from a
+# previously broken build.
+echo "Cleaning stale CFFI-shadow artifacts..."
 if [ -d bucket_brigade_core/bucket_brigade_core ]; then
     rm -rf bucket_brigade_core/bucket_brigade_core
+    echo "  Removed nested CFFI-shadow directory"
 fi
 rm -rf target/wheels
 
-# Build with maturin
-echo "🔨 Building with maturin..."
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run maturin develop --release
+# Build via the setuptools-rust backend declared in pyproject.toml.
+# --no-build-isolation lets the build use the active venv's toolchain
+# (avoids re-resolving setuptools-rust in an isolated environment).
+echo "Building with setuptools-rust (pip install -e .)..."
+uv run python -m pip install -e . --no-build-isolation
 
-# Clean up CFFI artifacts created during build
-echo "🧹 Cleaning up CFFI artifacts..."
-if [ -d bucket_brigade_core/bucket_brigade_core ]; then
-    rm -rf bucket_brigade_core/bucket_brigade_core
-    echo "   Removed nested CFFI directory"
-fi
-
-echo "✅ Build complete!"
+echo "Build complete."
 echo ""
 echo "Test import with:"
-echo "  cd /tmp && uv run python -c 'from bucket_brigade_core import VectorEnv; print(VectorEnv)'"
+echo "  uv run python -c 'from bucket_brigade_core import BucketBrigade; print(BucketBrigade)'"

--- a/bucket_brigade/evolution/__init__.py
+++ b/bucket_brigade/evolution/__init__.py
@@ -4,7 +4,7 @@ This module provides genetic algorithms for evolving agent parameters
 through tournament-based fitness evaluation.
 
 Requires Rust-backed fitness evaluation for acceptable performance.
-Build the Rust module with: maturin develop
+Build the Rust module with: cd bucket-brigade-core && ./build.sh
 """
 
 try:
@@ -14,11 +14,9 @@ except (ImportError, ModuleNotFoundError) as e:
         "Rust fitness evaluator required but not found. "
         "The Python fallback is too slow for practical use (100x slower). "
         "Please build the Rust module:\n\n"
-        "  export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1\n"
-        "  maturin develop\n\n"
-        "Or if using uv:\n"
-        "  export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1\n"
-        "  uv run maturin develop\n"
+        "  cd bucket-brigade-core && ./build.sh\n\n"
+        "See bucket-brigade-core/README.md for troubleshooting (e.g. the "
+        "CFFI-shadow trap if you see 'cannot import name PyBucketBrigade')."
     ) from e
 
 from .genetic_algorithm import EvolutionConfig, EvolutionResult, GeneticAlgorithm

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -100,10 +100,11 @@ Located in `bucket-brigade-core/`:
 - WebAssembly support for browser deployment
 - Maintains identical game logic to Python version
 
-**Building**:
+**Building** (uses the setuptools-rust backend declared in pyproject.toml;
+sets `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` and unsets `RUSTC_WRAPPER`):
 ```bash
 cd bucket-brigade-core
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release
+./build.sh
 ```
 
 ### Python Wrappers

--- a/docs/VECTORIZED_TRAINING_FIX.md
+++ b/docs/VECTORIZED_TRAINING_FIX.md
@@ -53,12 +53,18 @@ ImportError: cannot import name 'VectorEnv' from 'bucket_brigade_core'
 
 ### Step 1: Enable Python Feature Flag
 
-Rebuild with the `python` feature flag:
+Rebuild via the canonical `build.sh` script. The script uses the
+setuptools-rust backend in `pyproject.toml`, which has
+`features = ["python"]` configured, so the PyO3 binding is always enabled:
 ```bash
 cd bucket-brigade-core
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
-  maturin develop --release --features=python
+./build.sh
 ```
+
+> Historical note: this issue originally surfaced because a raw
+> `maturin develop --release` (no `--features python`) silently produced
+> CFFI shim files instead of the PyO3 module. The canonical build path is
+> now `./build.sh`, which avoids that pitfall. See issue #134.
 
 ### Step 2: Update __init__.py
 
@@ -195,14 +201,16 @@ num_houses = (obs_dim - 3 * 4) // 3  # (40 - 12) // 3 = 9
 
 ### 1. Always Use Feature Flags for Rust Builds
 
-When developing with PyO3:
+When developing with PyO3, prefer the canonical build script which uses
+the setuptools-rust backend (it has `features = ["python"]` configured in
+`pyproject.toml`):
 ```bash
-# Wrong (misses conditional features)
-maturin develop --release
+# Right: setuptools-rust backend, features baked into pyproject.toml
+cd bucket-brigade-core
+./build.sh
 
-# Right (includes all Python bindings)
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
-  maturin develop --release --features=python
+# Wrong (silently produces CFFI shim instead of PyO3 module — see #134)
+maturin develop --release
 ```
 
 ### 2. Verify Exports After Rust Changes

--- a/experiments/generalist/README.md
+++ b/experiments/generalist/README.md
@@ -53,9 +53,9 @@ tmux new -s generalist
 cd bucket-brigade
 git pull
 
-# Ensure Rust module is built
+# Ensure Rust module is built (uses setuptools-rust backend)
 source .venv/bin/activate
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop
+(cd bucket-brigade-core && ./build.sh)
 
 # Run evolution with logging
 uv run python experiments/scripts/run_generalist_evolution.py \

--- a/experiments/marl/QUICKSTART.md
+++ b/experiments/marl/QUICKSTART.md
@@ -125,10 +125,10 @@ ssh rwalters-sandbox-2 'cd bucket-brigade && tail -f experiments/marl/latest_tra
 # Check environment
 uv run python -c "from bucket_brigade.envs.puffer_env_rust import make_rust_env; print('OK')"
 
-# Rebuild if needed
+# Rebuild if needed (build.sh handles env vars and CFFI-shadow cleanup)
 cd bucket-brigade-core
 cargo clean
-VIRTUAL_ENV=../.venv PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+./build.sh
 ```
 
 **No GPU detected:**

--- a/experiments/marl/README.md
+++ b/experiments/marl/README.md
@@ -306,11 +306,10 @@ nvidia-smi
 
 ### Build Failures
 ```bash
-# Clean rebuild
+# Clean rebuild (build.sh handles env vars and CFFI-shadow cleanup)
 cd bucket-brigade-core
 cargo clean
-VIRTUAL_ENV=../. venv PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
-    maturin develop --release --features python
+./build.sh
 ```
 
 ### Import Errors

--- a/experiments/marl/setup_gpu.sh
+++ b/experiments/marl/setup_gpu.sh
@@ -56,12 +56,10 @@ source .venv/bin/activate
 echo "📚 Installing dependencies (this may take a few minutes)..."
 uv sync --extra rl
 
-# Build Rust core with PyO3 bindings
+# Build Rust core with PyO3 bindings (uses setuptools-rust per pyproject.toml)
 echo "🦀 Building Rust core..."
 cd bucket-brigade-core
-VIRTUAL_ENV="$(pwd)/../.venv" \
-  PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
-  uv tool run maturin develop --release --features python
+./build.sh
 cd ..
 
 # Verify installation

--- a/experiments/nash/REMOTE_EXECUTION_GUIDE.md
+++ b/experiments/nash/REMOTE_EXECUTION_GUIDE.md
@@ -57,9 +57,9 @@ uv venv
 source .venv/bin/activate  # Linux
 uv sync --extra rl
 
-# 5. Build Rust core
+# 5. Build Rust core (uses setuptools-rust backend per pyproject.toml)
 cd bucket-brigade-core
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+./build.sh
 cd ..
 
 # 6. Run full batch (in tmux for persistence)
@@ -210,21 +210,24 @@ tar xzf nash_v2_results.tar.gz
 **Problem**: Rust core won't build
 
 ```bash
-# Solution: Ensure Python feature is enabled
+# Solution: Use the canonical build script (sets env vars defensively)
 cd bucket-brigade-core
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+./build.sh
 cd ..
 ```
 
 **Problem**: Import errors
 
 ```bash
-# Solution: Rebuild and reinstall
+# Solution: Full rebuild and reinstall
 cd bucket-brigade-core
-rm -rf target/
-PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+rm -rf target/ bucket_brigade_core/bucket_brigade_core
+./build.sh
 cd ..
 ```
+
+> See `bucket-brigade-core/README.md` for the CFFI-shadow troubleshooting
+> note ("cannot import name 'PyBucketBrigade'").
 
 ### Missing Evolved Agents
 

--- a/experiments/scripts/run_generalist_remote.sh
+++ b/experiments/scripts/run_generalist_remote.sh
@@ -72,10 +72,9 @@ ssh "$REMOTE_HOST" bash <<EOF
 
     source .venv/bin/activate
 
-    # Build Rust module
+    # Build Rust module (uses setuptools-rust backend per pyproject.toml)
     echo "Building Rust module..."
-    export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
-    maturin develop --quiet
+    (cd bucket-brigade-core && ./build.sh)
 
     # Verify Rust module
     python -c "import bucket_brigade_core; print('✅ Rust module loaded')"

--- a/scripts/sandbox.sh
+++ b/scripts/sandbox.sh
@@ -65,19 +65,17 @@ setup_environment() {
         source "$HOME/.cargo/env"
     fi
 
-    # Build Rust module with PyO3
+    # Build Rust module with PyO3 via the canonical build script
+    # (uses setuptools-rust backend per pyproject.toml; see issue #134).
     echo "🔧 Building Rust module (bucket-brigade-core)..."
     cd bucket-brigade-core
 
     # Clean any stale build artifacts to avoid cffi/PyO3 conflicts
     rm -rf target bucket_brigade_core/__pycache__ bucket_brigade_core/bucket_brigade_core
 
-    # Ensure maturin is installed
-    uv pip install maturin
-
-    # Source Rust environment and build with PyO3 feature
+    # Source Rust environment and run the canonical build script
     source "$HOME/.cargo/env"
-    PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop --release --features python
+    ./build.sh
 
     cd ..
 

--- a/scripts/setup_and_launch_v7.sh
+++ b/scripts/setup_and_launch_v7.sh
@@ -47,20 +47,17 @@ echo ""
 # Step 4: Build Rust module
 echo "[4/5] Building bucket-brigade-core Rust module..."
 
-# Install build dependencies (from parent dir to use correct venv)
-uv pip install cffi maturin
-
-# Build and install the Rust module
+# Build and install the Rust module via the canonical build script.
+# build.sh installs setuptools-rust, unsets RUSTC_WRAPPER, sets
+# PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1, and uses the setuptools-rust
+# backend declared in pyproject.toml. See issue #134.
 cd bucket-brigade-core
 
 # Clean any previous CFFI build artifacts
 rm -rf bucket_brigade_core/bucket_brigade_core/
 
-export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 export VIRTUAL_ENV="$(pwd)/../.venv"
-
-# Build with PyO3 (not CFFI)
-~/.local/bin/maturin develop --release --features python
+./build.sh
 
 echo "  ✓ Rust module built and installed"
 cd ..


### PR DESCRIPTION
## Summary
Fixes the broken `bucket-brigade-core/build.sh` (Option A from the curator note). The script now uses the setuptools-rust backend declared in `pyproject.toml` instead of the maturin path that silently fell back to CFFI shim bindings. Docs and helper scripts that referenced `maturin develop --release` are updated to point at the canonical `./build.sh` (or the equivalent setuptools-rust one-liner).

## Changes
- `bucket-brigade-core/build.sh` — rewritten to install `setuptools-rust` and run `pip install -e . --no-build-isolation`. Defensively `export RUSTC_WRAPPER=` (avoids sccache-missing fallback) and `export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`. Cleans the CFFI-shadow nested directory before building.
- `bucket-brigade-core/README.md` — replaces the misleading "Quick Build / Manual Build" sections with the working recipe, documents the required env vars (`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`, `RUSTC_WRAPPER=`), and adds a Troubleshooting section covering the CFFI-shadow trap (`cannot import name 'PyBucketBrigade'`) and the sccache pitfall.
- Root `README.md`, `TRAINING_GUIDE.md`, `POPULATION_TRAINING.md`, `OPTIMIZATION_NOTES.md`, `docs/PERFORMANCE.md`, `docs/VECTORIZED_TRAINING_FIX.md` — update build references to point at `./build.sh` or the setuptools-rust one-liner.
- `experiments/marl/{setup_gpu.sh,README.md,QUICKSTART.md}`, `experiments/generalist/README.md`, `experiments/scripts/run_generalist_remote.sh`, `experiments/nash/REMOTE_EXECUTION_GUIDE.md`, `scripts/sandbox.sh`, `scripts/setup_and_launch_v7.sh` — same update.
- `bucket_brigade/evolution/__init__.py` — the `ImportError` message now points users at `./build.sh` instead of `maturin develop`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `build.sh` produces a working install (no manual cleanup needed) | Yes (by construction) | Uses the same setuptools-rust path the curator confirmed works; `pyproject.toml` already sets `features = ["python"]`. Full Rust compile not run locally per instructions (heavy). |
| `pyproject.toml` and `build.sh` are internally consistent | Yes | Both now use the setuptools-rust backend. |
| `bucket-brigade-core/README.md` documents env vars, CFFI trap, sccache pitfall | Yes | New "Required environment variables" and "Troubleshooting" sections. |
| All other docs reference the chosen path | Yes | `grep -rn "maturin"` shows only historical/explanatory mentions remain (no live `maturin develop` commands users would copy-paste). |
| `build.sh` syntax check | Yes | `bash -n build.sh` passes; same for all other modified shell scripts. |

## Test Plan
- [x] Syntax check all modified shell scripts (`bash -n`).
- [x] Python syntax check on `bucket_brigade/evolution/__init__.py`.
- [x] `grep -rn maturin` confirms no remaining live `maturin develop` invocations (only historical mentions in narrative).
- [ ] Full Rust compile and Python import test — **not run locally per task instructions** (heavy build). Recommended verification on a fresh remote machine: `cd bucket-brigade-core && ./build.sh && python -c "from bucket_brigade_core import BucketBrigade; print(BucketBrigade)"`.

Closes #134