### PR TITLE
fix: Repair CI by removing dead-code field and adding setup-uv to build-web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+      with:
+        version: "latest"
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: Set up pnpm
       uses: pnpm/action-setup@v2
       with:
@@ -147,6 +155,8 @@ jobs:
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build WASM package
       run: cd bucket-brigade-core && wasm-pack build --target web
+    - name: Create virtual environment
+      run: uv venv
     - name: Install dependencies
       run: cd web && pnpm install --frozen-lockfile
     - name: Build

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -301,7 +301,6 @@ impl PyGameResult {
 pub struct PyVectorEnv {
     envs: Vec<BucketBrigade>,
     num_envs: usize,
-    num_agents: usize,
 }
 
 #[pymethods]
@@ -317,7 +316,7 @@ impl PyVectorEnv {
             })
             .collect();
 
-        Self { envs, num_envs, num_agents }
+        Self { envs, num_envs }
     }
 
     /// Reset all environments and return batched observations for agent 0


### PR DESCRIPTION
## Summary

Hotfix for completely-broken CI on `main`. 5 of 6 CI jobs are failing; this PR makes two minimal targeted changes to restore green CI.

## Changes

- **`bucket-brigade-core/src/python.rs`**: Removed the unused `num_agents: usize` field from the `PyVectorEnv` struct. The field was assigned in the constructor but never read elsewhere, triggering `error: field \`num_agents\` is never read` under `RUSTFLAGS: -D warnings` (the default for `actions-rust-lang/setup-rust-toolchain@v1`). The `num_agents` constructor parameter is preserved (it's used to construct each inner `BucketBrigade`).
- **`.github/workflows/ci.yml`** (`build-web` job): Added `astral-sh/setup-uv@v1`, `actions/setup-python@v4`, and a `uv venv` step. The job runs `pnpm run build`, which invokes the `generate:types` script (`uv run python scripts/generate_typescript.py`), so `uv` must be on PATH. The new steps mirror the pattern used by `test-python`, `lint-python`, `integration-test`, and `pre-commit` in the same file.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rust dead-code error fixed | ✅ | `cd bucket-brigade-core && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 RUSTFLAGS="-D warnings" cargo check --features python` succeeds with no warnings |
| `num_envs` field still in use | ✅ | Confirmed via grep — read at multiple sites (lines 340, 343, 348, 349, 406, 407) |
| `build-web` job gets `uv` | ✅ | Added `astral-sh/setup-uv@v1` step (matches version used by 4 other jobs in same file) |
| YAML syntactically valid | ✅ | `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` succeeds |
| Minimal scope (no unrelated changes) | ✅ | `git diff --stat`: 2 files, +11/-2 |

## Test Plan

- Local Rust check passed (see above)
- CI will validate all 5 currently-failing jobs flip to green on this PR
- `test-web` (currently the only passing job) should remain unaffected — no changes to that job

Closes #142