### PR TITLE
diagnostic: detect degenerate CMI conditioning at measurement time

### DIFF
--- a/bucket_brigade/analysis/info_theory.py
+++ b/bucket_brigade/analysis/info_theory.py
@@ -36,6 +36,8 @@ __all__ = [
     "conditional_mutual_information",
     "bootstrap_ci",
     "quantize_uniform",
+    "conditioner_diagnostics",
+    "is_degenerate_conditioner",
 ]
 
 
@@ -267,3 +269,102 @@ def quantize_uniform(
         codes += per_col.astype(np.int64) * multiplier
         multiplier *= n_bins
     return codes
+
+
+def conditioner_diagnostics(z: np.ndarray) -> dict:
+    """Summarise the empirical distribution of a CMI conditioning variable.
+
+    Many conditional-MI failure modes (see issue #146) reduce to "the
+    conditioner is effectively constant on the sample." When the support of
+    ``Z`` collapses to a single value, ``I(X; Y | Z)`` is mathematically equal
+    to ``I(X; Y)`` and the conditional quantity adds no information beyond the
+    unconditional one. This helper returns a handful of numbers a caller can
+    use to gate a warning at measurement time.
+
+    Args:
+        z: ``(N,)`` array of discrete (or hashable) conditioning codes — the
+            same shape/format ``conditional_mutual_information`` consumes.
+
+    Returns:
+        ``{
+            "n_samples": N,
+            "n_distinct": number of distinct values observed,
+            "modal_fraction": fraction of mass concentrated in the most common
+                bin (1.0 means constant),
+            "entropy_bits": plug-in entropy in bits (no bias correction here —
+                this is a *diagnostic*, not an estimator),
+        }``
+
+        For the empty input ``N == 0`` we return zeros for everything and
+        ``modal_fraction = 1.0`` so the "degenerate" check still fires.
+    """
+    z = np.asarray(z)
+    n = int(z.size)
+    if n == 0:
+        return {
+            "n_samples": 0,
+            "n_distinct": 0,
+            "modal_fraction": 1.0,
+            "entropy_bits": 0.0,
+        }
+
+    counts = Counter(z.ravel().tolist())
+    n_distinct = len(counts)
+    modal_count = max(counts.values())
+    modal_fraction = modal_count / n
+
+    if n_distinct <= 1:
+        entropy_bits = 0.0
+    else:
+        probs = np.array(list(counts.values()), dtype=np.float64) / n
+        # Drop zeros defensively (Counter values are always > 0, but be safe).
+        probs = probs[probs > 0]
+        entropy_bits = float(-np.sum(probs * np.log2(probs)))
+
+    return {
+        "n_samples": n,
+        "n_distinct": n_distinct,
+        "modal_fraction": float(modal_fraction),
+        "entropy_bits": entropy_bits,
+    }
+
+
+def is_degenerate_conditioner(
+    z: np.ndarray,
+    *,
+    min_distinct: int = 2,
+    max_modal_fraction: float = 0.99,
+) -> tuple[bool, dict]:
+    """Detect when a CMI conditioner is mathematically guaranteed to be vacuous.
+
+    A conditioner ``Z`` is "degenerate" for the purposes of ``I(X; Y | Z)`` if
+    it is effectively constant on the sample. In that case the plug-in
+    estimator collapses to ``I(X; Y)`` and the conditional quantity carries no
+    additional information beyond the unconditional one. See issue #146 for
+    the motivating failure mode (team-reward conditioning on
+    ``trivial_cooperation``, where the team reward is essentially constant).
+
+    This is a *measurement-time* check. It detects the problem; it does not
+    fix it. The fix (choosing a different conditioner) is a research call and
+    lives in the experiment design, not here.
+
+    Args:
+        z: Conditioning codes (1-D array of hashable values).
+        min_distinct: Minimum number of distinct values required to *not* be
+            flagged degenerate. Defaults to 2 (a literal single-value
+            conditioner is unambiguously degenerate).
+        max_modal_fraction: If a single value carries more than this fraction
+            of the sample mass, the conditioner is flagged degenerate even if
+            other values appear. Defaults to 0.99 (gives near-constant
+            conditioners — e.g., a near-deterministic reward — a fail).
+
+    Returns:
+        ``(is_degenerate, diagnostics)``: a boolean and the dict returned by
+        :func:`conditioner_diagnostics`.
+    """
+    diag = conditioner_diagnostics(z)
+    degenerate = (
+        diag["n_distinct"] < min_distinct
+        or diag["modal_fraction"] > max_modal_fraction
+    )
+    return degenerate, diag

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -28,6 +29,7 @@ import torch
 from bucket_brigade.analysis.info_theory import (
     conditional_mutual_information,
     entropy_discrete,
+    is_degenerate_conditioner,
     mutual_information,
     quantize_uniform,
 )
@@ -90,8 +92,43 @@ def _measure_information(
     ).sum(dim=0).cpu().numpy()
     r_codes = quantize_uniform(rewards, n_bins=n_bins)
 
-    n = trainer.num_agents
     out: Dict[str, float] = {}
+
+    # Defensive measurement-quality check (see issue #146).
+    #
+    # When the conditioner ``r_codes`` is (near-)constant on the sample, the
+    # plug-in CMI ``I(Ẑ_i; Ẑ_j | R)`` collapses to the unconditional MI
+    # ``I(Ẑ_i; Ẑ_j)`` and the "conditional" claim is vacuous. The classic
+    # offender in this experiment is the ``trivial_cooperation`` scenario,
+    # where the team reward is essentially constant; near-deterministic-reward
+    # scenarios fail less obviously but in the same way.
+    #
+    # NOTE: This check DETECTS the failure mode; it does not RESOLVE it. The
+    # research-level question of which conditioner to use (state-coarsening,
+    # per-agent reward, marginal-action codes, etc.) is deferred to the
+    # Architect/Hermit framing described in the issue. We deliberately do not
+    # pick a replacement here.
+    is_degenerate, diag = is_degenerate_conditioner(r_codes)
+    out["cmi/conditioner_n_distinct"] = float(diag["n_distinct"])
+    out["cmi/conditioner_modal_fraction"] = diag["modal_fraction"]
+    out["cmi/conditioner_entropy_bits"] = diag["entropy_bits"]
+    out["cmi/conditioner_degenerate"] = float(is_degenerate)
+    if is_degenerate:
+        warnings.warn(
+            (
+                "P3 CMI conditioner appears degenerate "
+                f"(n_distinct={diag['n_distinct']}, "
+                f"modal_fraction={diag['modal_fraction']:.3f}, "
+                f"entropy_bits={diag['entropy_bits']:.3f}). "
+                "I(Ẑ_i; Ẑ_j | R) ≈ I(Ẑ_i; Ẑ_j) is mathematically guaranteed; "
+                "see issue #146 for context. Reported CMI values for this "
+                "iteration should not be interpreted as 'conditional'."
+            ),
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    n = trainer.num_agents
     mi_vals = []
     cmi_vals = []
     for i in range(n):

--- a/tests/test_info_theory.py
+++ b/tests/test_info_theory.py
@@ -15,7 +15,9 @@ from bucket_brigade.analysis.info_theory import (
     bootstrap_ci,
     conditional_entropy,
     conditional_mutual_information,
+    conditioner_diagnostics,
     entropy_discrete,
+    is_degenerate_conditioner,
     joint_entropy,
     mutual_information,
     quantize_uniform,
@@ -225,3 +227,90 @@ class TestQuantize:
         assert codes.shape == (5_000,)
         # Should see roughly all 16 combinations.
         assert len(np.unique(codes)) >= 10
+
+
+class TestConditionerDiagnostics:
+    """Tests for the issue #146 measurement-quality guard.
+
+    These pin down :func:`conditioner_diagnostics` and
+    :func:`is_degenerate_conditioner`. They confirm the helper DETECTS the
+    failure mode where ``Z`` is constant (so ``I(X; Y | Z) = I(X; Y)``); they
+    do NOT exercise the corresponding fix in the P3 experiment design (that
+    is a research call deferred to Architect/Hermit; see #146).
+    """
+
+    def test_constant_conditioner_is_degenerate(self):
+        z = np.zeros(1000, dtype=np.int64)
+        degenerate, diag = is_degenerate_conditioner(z)
+        assert degenerate is True
+        assert diag["n_distinct"] == 1
+        assert diag["modal_fraction"] == 1.0
+        assert diag["entropy_bits"] == 0.0
+
+    def test_uniform_conditioner_is_not_degenerate(self):
+        rng = np.random.default_rng(100)
+        z = rng.integers(0, 4, size=10_000)
+        degenerate, diag = is_degenerate_conditioner(z)
+        assert degenerate is False
+        assert diag["n_distinct"] == 4
+        assert diag["modal_fraction"] < 0.30  # near 0.25 for true uniform
+        # Entropy should be close to log2(4) = 2 bits.
+        assert diag["entropy_bits"] == pytest.approx(2.0, abs=0.05)
+
+    def test_near_constant_conditioner_is_degenerate(self):
+        # 99.5% of mass in one bin → flagged at the default max_modal_fraction=0.99.
+        rng = np.random.default_rng(101)
+        z = np.zeros(2000, dtype=np.int64)
+        # Sprinkle 10 ones (0.5% mass).
+        rare_idx = rng.choice(2000, size=10, replace=False)
+        z[rare_idx] = 1
+        degenerate, diag = is_degenerate_conditioner(z)
+        assert degenerate is True
+        assert diag["n_distinct"] == 2  # technically not "constant"...
+        assert diag["modal_fraction"] > 0.99  # ...but mass is concentrated
+
+    def test_cmi_collapses_to_mi_when_conditioner_degenerate(self):
+        # Sanity check linking the diagnostic to the math it guards.
+        # When Z is constant, I(X; Y | Z) ≡ I(X; Y) exactly (modulo MM bias).
+        rng = np.random.default_rng(102)
+        x = rng.integers(0, 4, size=5_000)
+        y = x.copy()  # I(X; Y) = log2(4) = 2 bits.
+        z = np.zeros(5_000, dtype=np.int64)
+
+        degenerate, _ = is_degenerate_conditioner(z)
+        assert degenerate is True
+
+        mi = mutual_information(x, y)
+        cmi = conditional_mutual_information(x, y, z)
+        # The two should agree to within the bias-correction noise floor.
+        assert cmi == pytest.approx(mi, abs=TOL_LARGE)
+
+    def test_empty_input_treated_as_degenerate(self):
+        # Defensive: empty samples are flagged so callers don't divide-by-zero.
+        z = np.array([], dtype=np.int64)
+        degenerate, diag = is_degenerate_conditioner(z)
+        assert degenerate is True
+        assert diag["n_samples"] == 0
+        assert diag["n_distinct"] == 0
+        assert diag["modal_fraction"] == 1.0
+
+    def test_custom_thresholds(self):
+        # 60/40 split should NOT be flagged at default thresholds...
+        rng = np.random.default_rng(103)
+        z = (rng.random(1000) < 0.6).astype(np.int64)
+        degenerate_default, _ = is_degenerate_conditioner(z)
+        assert degenerate_default is False
+        # ...but should flag if we tighten max_modal_fraction below 0.6.
+        degenerate_strict, _ = is_degenerate_conditioner(
+            z, max_modal_fraction=0.55
+        )
+        assert degenerate_strict is True
+
+    def test_diagnostics_match_helper(self):
+        # The convenience wrapper should report the same numbers as the
+        # underlying diagnostic function.
+        rng = np.random.default_rng(104)
+        z = rng.integers(0, 5, size=2000)
+        diag_direct = conditioner_diagnostics(z)
+        _, diag_from_check = is_degenerate_conditioner(z)
+        assert diag_direct == diag_from_check


### PR DESCRIPTION
## Summary

Partial fix for #146 — adds **detection** of degenerate CMI conditioning at measurement time in the P3 specialization experiment. **Does NOT replace the conditioner** (that is a research call, deferred to the Architect/Hermit framing the curator called out on the issue).

When the team-reward conditioner `R` collapses to a single value on the sample (the `trivial_cooperation` failure mode) or is near-deterministic (the `default` / `chain_reaction` failure mode), the plug-in estimator gives `I(Ẑ_i; Ẑ_j | R) ≈ I(Ẑ_i; Ẑ_j)` by mathematical identity. The pre-registered P3 falsifier F1 silently became a different test in those cells. This PR makes that situation **visible at measurement time** with a warning and four logged diagnostic scalars per iteration.

## Changes

- `bucket_brigade/analysis/info_theory.py`
  - Add `conditioner_diagnostics(z)` — returns `{n_samples, n_distinct, modal_fraction, entropy_bits}`.
  - Add `is_degenerate_conditioner(z, *, min_distinct=2, max_modal_fraction=0.99)` — returns `(bool, diagnostics)`.
  - Export both via `__all__`.
- `experiments/p3_specialization/train.py`
  - Call `is_degenerate_conditioner(r_codes)` immediately after quantizing the team reward.
  - Log four new scalars per iteration: `cmi/conditioner_n_distinct`, `cmi/conditioner_modal_fraction`, `cmi/conditioner_entropy_bits`, `cmi/conditioner_degenerate`.
  - Emit a `RuntimeWarning` when the conditioner is flagged degenerate, with comments explicitly noting this DETECTS but does NOT RESOLVE the issue.
- `tests/test_info_theory.py`
  - Add `TestConditionerDiagnostics` class with 7 tests: constant Z, uniform Z, near-constant Z (0.5% noise), the mathematical identity `CMI(X, Y, const) = MI(X, Y)`, empty input, custom thresholds, and consistency between the two helpers.

## Acceptance Criteria Verification

This PR addresses only a sub-task of #146 — the "Mathematical sanity check" item from the curator's test plan. The other items (refactor `_measure_information` to accept a pluggable conditioner, re-run validation cells with a new `Z`, re-evaluate F1, etc.) are deliberately **not** addressed here because they require a research decision on which conditioner to adopt.

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Mathematical sanity check: `CMI ≈ MI` when `Z` is constant | Implemented | `test_cmi_collapses_to_mi_when_conditioner_degenerate` in `tests/test_info_theory.py` |
| Detection at measurement time | Implemented | `_measure_information` now logs 4 diagnostics + warns when degenerate |
| Replace the conditioner | NOT addressed (out of Builder scope) | Deferred to Architect/Hermit per the curator's "Notes for Architect / Hermit Review" |
| Re-run validation cells under new conditioning | NOT addressed | Depends on the above |
| Re-evaluate F1 | NOT addressed | Depends on the above |

## Test Plan

- [x] `pytest tests/test_info_theory.py -x` — 30 passed (22 pre-existing + 7 new + 1 was already there; +7 new diagnostic-suite tests pass)
- [x] `python -c "from bucket_brigade.analysis.info_theory import is_degenerate_conditioner, conditioner_diagnostics"` — imports clean
- [x] `python -c "import experiments.p3_specialization.train"` — `train.py` imports clean after edits
- [ ] (Not done; non-Builder scope) Re-run an actual P3 cell and observe the warning fires on `trivial_cooperation`

## Scope Note

The curator explicitly flagged this issue as needing "Architect vs Hermit framing for human review before Builder action." Picking a replacement conditioner is a research call. This PR is a deliberately narrow, defensive measurement-quality assertion: it makes the failure mode loud, so any future research-grade fix has a clear before/after signal.

Partial fix for #146