### PR TITLE
fix: Resolve 88 ruff lint errors blocking CI

### DIFF
--- a/bucket_brigade/analysis/info_theory.py
+++ b/bucket_brigade/analysis/info_theory.py
@@ -20,11 +20,12 @@ Bias correction:
     entropy, MI, CMI) are corrected as differences of MM-corrected entropies.
     For very small samples consider Panzeri-Treves or NSB instead.
 """
+
 from __future__ import annotations
 
 import math
 from collections import Counter
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Sequence
 
 import numpy as np
 
@@ -364,7 +365,6 @@ def is_degenerate_conditioner(
     """
     diag = conditioner_diagnostics(z)
     degenerate = (
-        diag["n_distinct"] < min_distinct
-        or diag["modal_fraction"] > max_modal_fraction
+        diag["n_distinct"] < min_distinct or diag["modal_fraction"] > max_modal_fraction
     )
     return degenerate, diag

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -191,7 +191,11 @@ class BucketBrigadeEnv:
 
             # Probability of extinguishing: independent probabilities model
             # P(at least one success) = 1 - P(all fail) = 1 - (1-p)^k
-            p_extinguish = 1.0 - (1.0 - self.scenario.prob_solo_agent_extinguishes_fire) ** workers_here
+            p_extinguish = (
+                1.0
+                - (1.0 - self.scenario.prob_solo_agent_extinguishes_fire)
+                ** workers_here
+            )
 
             if self.rng.random() < p_extinguish:
                 self.houses[house_idx] = self.SAFE
@@ -253,7 +257,9 @@ class BucketBrigadeEnv:
         for agent_idx in range(self.num_agents):
             # Work/rest component
             if actions[agent_idx, 1] == self.WORK:
-                individual_rewards[agent_idx] -= self.scenario.cost_to_work_one_night  # Cost of working
+                individual_rewards[agent_idx] -= (
+                    self.scenario.cost_to_work_one_night
+                )  # Cost of working
             else:
                 individual_rewards[agent_idx] += 0.5  # Rest reward
 

--- a/bucket_brigade/envs/puffer_env.py
+++ b/bucket_brigade/envs/puffer_env.py
@@ -84,9 +84,7 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
         self.episode_rewards: List[float] = []
         self.episode_lengths: List[int] = []
 
-    def reset(
-        self, seed: Optional[int] = None
-    ) -> Tuple[np.ndarray, List[Dict]]:
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, List[Dict]]:
         """Reset the environment. Returns (observations, list of info dicts)."""
         if seed is not None:
             np.random.seed(seed)
@@ -112,7 +110,9 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
         # Must return info as LIST of dicts (one per agent)
         return self.observations, [{}]
 
-    def step(self, action: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, List[Dict]]:
+    def step(
+        self, action: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, List[Dict]]:
         """
         Take a step in the environment.
 
@@ -238,11 +238,11 @@ class PufferBucketBrigadeVectorized(PufferBucketBrigade):
 
         # Vectorized observation space
         obs_size = 10 + self.num_agents + self.num_agents + (self.num_agents * 2) + 10
-        self.observation_space = spaces.Box(
+        self.observation_space = gym_spaces.Box(
             low=-np.inf, high=np.inf, shape=(num_envs, obs_size), dtype=np.float32
         )
 
-        self.action_space = spaces.MultiDiscrete([num_envs, 10, 2])
+        self.action_space = gym_spaces.MultiDiscrete([num_envs, 10, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/bucket_brigade/envs/puffer_env_rust.py
+++ b/bucket_brigade/envs/puffer_env_rust.py
@@ -17,8 +17,6 @@ from ..agents import create_random_agent, create_archetype_agent
 logger = logging.getLogger(__name__)
 
 
-
-
 def _heuristic_action(
     theta: np.ndarray,
     obs_dict: dict[str, np.ndarray],
@@ -133,7 +131,9 @@ class RustPufferBucketBrigade(gym.Env):
 
         # Create new Rust environment for this episode
         episode_seed = self.rng.randint(0, 2**31 - 1) if seed is not None else None
-        self.env = core.BucketBrigade(self.rust_scenario, self.num_agents, seed=episode_seed)
+        self.env = core.BucketBrigade(
+            self.rust_scenario, self.num_agents, seed=episode_seed
+        )
 
         # Create new opponent agents for this episode
         self._create_opponent_agents()
@@ -324,7 +324,9 @@ def make_rust_env(
 
 
 def make_rust_vectorized_env(
-    num_envs: int = 8, scenario_name: str = "trivial_cooperation", num_opponents: int = 3
+    num_envs: int = 8,
+    scenario_name: str = "trivial_cooperation",
+    num_opponents: int = 3,
 ) -> RustPufferBucketBrigadeVectorized:
     """Create a vectorized Rust-backed environment for parallel training.
 

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -283,7 +283,6 @@ def mixed_motivation_scenario(num_agents: int) -> Scenario:
     )
 
 
-
 # Registry of all scenarios
 SCENARIO_REGISTRY = {
     "default": default_scenario,
@@ -299,7 +298,6 @@ SCENARIO_REGISTRY = {
     "overcrowding": overcrowding_scenario,
     "mixed_motivation": mixed_motivation_scenario,
 }
-
 
 
 def get_scenario_by_name(name: str, num_agents: int) -> Scenario:

--- a/bucket_brigade/evolution/fitness_rust.py
+++ b/bucket_brigade/evolution/fitness_rust.py
@@ -164,7 +164,10 @@ class RustFitnessEvaluator:
             seeds = [None] * self.games_per_individual
 
         # Prepare arguments
-        args_list = [(individual.genome, self.scenario_name, self.num_agents, seed) for seed in seeds]
+        args_list = [
+            (individual.genome, self.scenario_name, self.num_agents, seed)
+            for seed in seeds
+        ]
 
         if self.parallel:
             # Parallel execution
@@ -206,7 +209,9 @@ class RustFitnessEvaluator:
                     seeds = [None] * self.games_per_individual
 
                 for seed in seeds:
-                    all_args.append((individual.genome, self.scenario_name, self.num_agents, seed))  # type: ignore[attr-defined]
+                    all_args.append(
+                        (individual.genome, self.scenario_name, self.num_agents, seed)
+                    )  # type: ignore[attr-defined]
 
             # Run all games in parallel
             with Pool(processes=self.num_workers) as pool:

--- a/bucket_brigade/evolution/heterogeneous_evaluator.py
+++ b/bucket_brigade/evolution/heterogeneous_evaluator.py
@@ -91,7 +91,7 @@ class HeterogeneousEvaluator:
         scenario_name: str,
         num_agents: int = 4,
         opponent_types: Optional[list[str]] = None,
-        seed: Optional[int] = None
+        seed: Optional[int] = None,
     ):
         """Initialize heterogeneous evaluator.
 
@@ -124,10 +124,7 @@ class HeterogeneousEvaluator:
         self.rng = np.random.RandomState(seed)
 
     def evaluate(
-        self,
-        candidate_genome: np.ndarray,
-        num_games: int = 100,
-        verbose: bool = False
+        self, candidate_genome: np.ndarray, num_games: int = 100, verbose: bool = False
     ) -> float:
         """Evaluate candidate in heterogeneous tournament.
 
@@ -148,9 +145,7 @@ class HeterogeneousEvaluator:
             # Sample teammates (candidate is always agent 0)
             num_teammates = self.num_agents - 1
             teammate_types = self.rng.choice(
-                self.opponent_types,
-                size=num_teammates,
-                replace=True
+                self.opponent_types, size=num_teammates, replace=True
             )
 
             # Track opponent usage
@@ -167,7 +162,9 @@ class HeterogeneousEvaluator:
             total_payoff += payoff
 
             if verbose and game_idx < 5:  # Show first 5 games
-                print(f"  Game {game_idx}: team={['candidate'] + list(teammate_types)}, payoff={payoff:.2f}")
+                print(
+                    f"  Game {game_idx}: team={['candidate'] + list(teammate_types)}, payoff={payoff:.2f}"
+                )
 
         mean_payoff = total_payoff / num_games
 
@@ -188,11 +185,7 @@ class HeterogeneousEvaluator:
             Payoff for agent 0 (candidate)
         """
         # Create Rust game
-        game = core.BucketBrigade(
-            self.rust_scenario,
-            self.num_agents,
-            seed=seed
-        )
+        game = core.BucketBrigade(self.rust_scenario, self.num_agents, seed=seed)
 
         # Python RNG for heuristic decisions
         rng = np.random.RandomState(seed)
@@ -231,9 +224,7 @@ class HeterogeneousEvaluator:
         return candidate_total_reward
 
     def evaluate_batch(
-        self,
-        genomes: list[np.ndarray],
-        num_games: int = 100
+        self, genomes: list[np.ndarray], num_games: int = 100
     ) -> list[float]:
         """Evaluate multiple candidates (for parallel evolution).
 
@@ -276,7 +267,7 @@ def create_heterogeneous_evaluator(
     scenario_name: str,
     num_agents: int = 4,
     opponent_types: Optional[list[str]] = None,
-    seed: Optional[int] = None
+    seed: Optional[int] = None,
 ) -> HeterogeneousEvaluator:
     """Factory function for creating heterogeneous evaluator.
 
@@ -293,5 +284,5 @@ def create_heterogeneous_evaluator(
         scenario_name=scenario_name,
         num_agents=num_agents,
         opponent_types=opponent_types,
-        seed=seed
+        seed=seed,
     )

--- a/bucket_brigade/training/__init__.py
+++ b/bucket_brigade/training/__init__.py
@@ -9,7 +9,11 @@ from .networks import PolicyNetwork, TransformerPolicyNetwork, compute_gae
 from .game_simulator import GameSimulator, Matchmaker
 from .policy_learner import PolicyLearner, learner_process
 from .population_trainer import PopulationTrainer
-from .observation_utils import flatten_observation, get_observation_dim, create_scenario_info
+from .observation_utils import (
+    flatten_observation,
+    get_observation_dim,
+    create_scenario_info,
+)
 
 __all__ = [
     "PolicyNetwork",

--- a/bucket_brigade/training/game_simulator.py
+++ b/bucket_brigade/training/game_simulator.py
@@ -22,7 +22,10 @@ import torch
 import numpy as np
 
 from bucket_brigade_core import BucketBrigade, Scenario
-from bucket_brigade.training.observation_utils import flatten_observation, create_scenario_info
+from bucket_brigade.training.observation_utils import (
+    flatten_observation,
+    create_scenario_info,
+)
 
 
 class Matchmaker:
@@ -31,7 +34,9 @@ class Matchmaker:
     def __init__(self, population_size: int, num_agents_per_game: int = 4):
         self.population_size = population_size
         self.num_agents_per_game = num_agents_per_game
-        self.match_counts = [0] * population_size  # Track how many times each agent has played
+        self.match_counts = [
+            0
+        ] * population_size  # Track how many times each agent has played
 
     def sample_agents(self, strategy: str = "round_robin") -> List[int]:
         """
@@ -45,15 +50,19 @@ class Matchmaker:
         """
         if strategy == "round_robin":
             # Sample agents with lowest play counts to ensure even distribution
-            sorted_agents = sorted(range(self.population_size), key=lambda i: self.match_counts[i])
-            agents = sorted_agents[:self.num_agents_per_game]
+            sorted_agents = sorted(
+                range(self.population_size), key=lambda i: self.match_counts[i]
+            )
+            agents = sorted_agents[: self.num_agents_per_game]
             for agent_id in agents:
                 self.match_counts[agent_id] += 1
             return agents
 
         elif strategy == "random":
             # Completely random sampling
-            agents = random.sample(range(self.population_size), k=self.num_agents_per_game)
+            agents = random.sample(
+                range(self.population_size), k=self.num_agents_per_game
+            )
             for agent_id in agents:
                 self.match_counts[agent_id] += 1
             return agents
@@ -108,7 +117,9 @@ class GameSimulator:
         # Create Rust environments
         print(f"Creating {num_games} Rust environments...")
         self.envs = [
-            BucketBrigade(scenario, num_agents_per_game, seed=seed + i if seed else None)
+            BucketBrigade(
+                scenario, num_agents_per_game, seed=seed + i if seed else None
+            )
             for i in range(num_games)
         ]
 
@@ -128,7 +139,9 @@ class GameSimulator:
         # Statistics
         self.total_steps = 0
         self.total_episodes = 0
-        self.episode_rewards: Dict[int, List[float]] = {i: [] for i in range(population_size)}
+        self.episode_rewards: Dict[int, List[float]] = {
+            i: [] for i in range(population_size)
+        }
 
     def register_policy(self, agent_id: int, policy: torch.nn.Module):
         """Register a policy for an agent in the population."""
@@ -140,7 +153,9 @@ class GameSimulator:
         if agent_id in self.policies:
             self.policies[agent_id].load_state_dict(state_dict)
 
-    def select_action(self, agent_id: int, observation: np.ndarray) -> Tuple[int, int, float]:
+    def select_action(
+        self, agent_id: int, observation: np.ndarray
+    ) -> Tuple[int, int, float]:
         """
         Select action for an agent given observation.
 
@@ -225,12 +240,12 @@ class GameSimulator:
             # Record experience for each agent
             for i, agent_id in enumerate(agent_ids):
                 experience = {
-                    'obs': observations[i],
-                    'action': actions[i],
-                    'reward': rewards_list[i],
-                    'next_obs': next_observations[i] if not done else None,
-                    'done': done,
-                    'logprob': logprobs[i],
+                    "obs": observations[i],
+                    "action": actions[i],
+                    "reward": rewards_list[i],
+                    "next_obs": next_observations[i] if not done else None,
+                    "done": done,
+                    "logprob": logprobs[i],
                 }
                 trajectories[agent_id].append(experience)
 
@@ -242,7 +257,7 @@ class GameSimulator:
         self.total_episodes += 1
 
         for agent_id in agent_ids:
-            episode_reward = sum(exp['reward'] for exp in trajectories[agent_id])
+            episode_reward = sum(exp["reward"] for exp in trajectories[agent_id])
             self.episode_rewards[agent_id].append(episode_reward)
 
         return trajectories
@@ -282,15 +297,15 @@ class GameSimulator:
             num_episodes: Number of episodes to run
             update_interval: Check for policy updates every N episodes
         """
-        print(f"\n{'='*60}")
-        print(f"🎮 Starting Game Simulator")
-        print(f"{'='*60}")
+        print(f"\n{'=' * 60}")
+        print("🎮 Starting Game Simulator")
+        print(f"{'=' * 60}")
         print(f"Num games: {self.num_games}")
         print(f"Population size: {self.population_size}")
         print(f"Agents per game: {self.num_agents_per_game}")
         print(f"Matchmaking: {self.matchmaking_strategy}")
         print(f"Target episodes: {num_episodes}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
 
         start_time = time.time()
         last_report = start_time
@@ -318,27 +333,29 @@ class GameSimulator:
                 }
                 mean_reward = np.mean(list(avg_rewards.values()))
 
-                print(f"Episode {episode + 1}/{num_episodes} | "
-                      f"Speed: {eps_per_sec:.1f} eps/s | "
-                      f"Avg Reward: {mean_reward:.3f} | "
-                      f"Total Steps: {self.total_steps:,}")
+                print(
+                    f"Episode {episode + 1}/{num_episodes} | "
+                    f"Speed: {eps_per_sec:.1f} eps/s | "
+                    f"Avg Reward: {mean_reward:.3f} | "
+                    f"Total Steps: {self.total_steps:,}"
+                )
 
                 last_report = time.time()
 
         total_time = time.time() - start_time
-        print(f"\n{'='*60}")
-        print(f"✅ Simulation Complete!")
+        print(f"\n{'=' * 60}")
+        print("✅ Simulation Complete!")
         print(f"Total episodes: {self.total_episodes:,}")
         print(f"Total steps: {self.total_steps:,}")
-        print(f"Time: {total_time/60:.1f} minutes")
-        print(f"Speed: {self.total_episodes/total_time:.1f} eps/s")
-        print(f"{'='*60}\n")
+        print(f"Time: {total_time / 60:.1f} minutes")
+        print(f"Speed: {self.total_episodes / total_time:.1f} eps/s")
+        print(f"{'=' * 60}\n")
 
     def get_statistics(self) -> Dict:
         """Get simulation statistics."""
         return {
-            'total_steps': self.total_steps,
-            'total_episodes': self.total_episodes,
-            'episode_rewards': self.episode_rewards,
-            'match_counts': self.matchmaker.match_counts,
+            "total_steps": self.total_steps,
+            "total_episodes": self.total_episodes,
+            "episode_rewards": self.episode_rewards,
+            "match_counts": self.matchmaker.match_counts,
         }

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -31,6 +31,7 @@ Typical use::
         rollout = trainer.collect_rollout(num_steps=2048)
         stats = trainer.update(rollout)
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -306,7 +307,7 @@ class JointPPOTrainer:
         for i in range(n):
             for j in range(i + 1, n):
                 cross = standardized[i].t() @ standardized[j] / batch_size
-                total = total + (cross ** 2).sum()
+                total = total + (cross**2).sum()
                 num_pairs += 1
         return total / (num_pairs * d * d)
 
@@ -417,7 +418,9 @@ class JointPPOTrainer:
                 red_pen = encoder_outputs[0].new_tensor(0.0)
             stats["redundancy_loss"] += red_pen.item() / self.ppo_epochs
 
-            total_loss = torch.stack(per_agent_losses).sum() + self.redundancy_coef * red_pen
+            total_loss = (
+                torch.stack(per_agent_losses).sum() + self.redundancy_coef * red_pen
+            )
             stats["total_loss"] += total_loss.item() / self.ppo_epochs
 
             for opt in self.optimizers:

--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -4,12 +4,10 @@ This module provides neural network architectures for multi-discrete action
 spaces, commonly used in reinforcement learning scenarios.
 """
 
-import math
 from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class PolicyNetwork(nn.Module):
@@ -352,7 +350,7 @@ class TransformerPolicyNetwork(nn.Module):
             nhead=nhead,
             dim_feedforward=dim_feedforward,
             dropout=dropout,
-            activation='gelu',
+            activation="gelu",
             batch_first=True,
             norm_first=True,  # Pre-norm for better training stability
         )
@@ -363,15 +361,17 @@ class TransformerPolicyNetwork(nn.Module):
         )
 
         # Action heads (2-layer MLPs)
-        self.action_heads = nn.ModuleList([
-            nn.Sequential(
-                nn.Linear(d_model, d_model // 2),
-                nn.GELU(),
-                nn.Dropout(dropout),
-                nn.Linear(d_model // 2, dim),
-            )
-            for dim in action_dims
-        ])
+        self.action_heads = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(d_model, d_model // 2),
+                    nn.GELU(),
+                    nn.Dropout(dropout),
+                    nn.Linear(d_model // 2, dim),
+                )
+                for dim in action_dims
+            ]
+        )
 
         # Value head (2-layer MLP)
         self.value_head = nn.Sequential(
@@ -420,7 +420,9 @@ class TransformerPolicyNetwork(nn.Module):
         # If we have global features, embed and prepend as [CLS] token
         if self.global_dim > 0:
             global_obs = x[:, self.num_houses * self.house_features :]
-            global_embed = self.global_embed(global_obs).unsqueeze(1)  # (batch, 1, d_model)
+            global_embed = self.global_embed(global_obs).unsqueeze(
+                1
+            )  # (batch, 1, d_model)
 
             # Concatenate: [global, house_0, house_1, ...]
             tokens = torch.cat([global_embed, house_embeds], dim=1)

--- a/bucket_brigade/training/observation_utils.py
+++ b/bucket_brigade/training/observation_utils.py
@@ -6,7 +6,9 @@ import numpy as np
 from bucket_brigade_core import AgentObservation
 
 
-def flatten_observation(obs: AgentObservation, scenario_info: np.ndarray = None) -> np.ndarray:
+def flatten_observation(
+    obs: AgentObservation, scenario_info: np.ndarray = None
+) -> np.ndarray:
     """
     Convert PyAgentObservation to flat numpy array for neural network input.
 
@@ -39,13 +41,15 @@ def flatten_observation(obs: AgentObservation, scenario_info: np.ndarray = None)
         scenario_info = np.array(scenario_info, dtype=np.float32)
 
     # Concatenate all components
-    flat_obs = np.concatenate([
-        houses,
-        signals,
-        locations,
-        last_actions,
-        scenario_info,
-    ])
+    flat_obs = np.concatenate(
+        [
+            houses,
+            signals,
+            locations,
+            last_actions,
+            scenario_info,
+        ]
+    )
 
     return flat_obs
 
@@ -62,11 +66,11 @@ def get_observation_dim(num_houses: int, num_agents: int) -> int:
         Total observation dimension
     """
     return (
-        num_houses +      # houses
-        num_agents +      # signals
-        num_agents +      # locations
-        num_agents * 2 +  # last_actions (house + mode per agent)
-        10                # scenario_info
+        num_houses  # houses
+        + num_agents  # signals
+        + num_agents  # locations
+        + num_agents * 2  # last_actions (house + mode per agent)
+        + 10  # scenario_info
     )
 
 
@@ -80,15 +84,18 @@ def create_scenario_info(scenario) -> np.ndarray:
     Returns:
         10-element array with scenario parameters
     """
-    return np.array([
-        scenario.prob_fire_spreads_to_neighbor,
-        scenario.prob_solo_agent_extinguishes_fire,
-        scenario.prob_house_catches_fire,
-        scenario.team_reward_house_survives,
-        scenario.team_penalty_house_burns,
-        scenario.cost_to_work_one_night,
-        float(scenario.min_nights),
-        0.0,  # Padding
-        0.0,  # Padding
-        0.0,  # Padding
-    ], dtype=np.float32)
+    return np.array(
+        [
+            scenario.prob_fire_spreads_to_neighbor,
+            scenario.prob_solo_agent_extinguishes_fire,
+            scenario.prob_house_catches_fire,
+            scenario.team_reward_house_survives,
+            scenario.team_penalty_house_burns,
+            scenario.cost_to_work_one_night,
+            float(scenario.min_nights),
+            0.0,  # Padding
+            0.0,  # Padding
+            0.0,  # Padding
+        ],
+        dtype=np.float32,
+    )

--- a/bucket_brigade/training/policy_learner.py
+++ b/bucket_brigade/training/policy_learner.py
@@ -159,20 +159,28 @@ class PolicyLearner:
         batch = [self.experience_buffer.popleft() for _ in range(batch_size)]
 
         # Convert to tensors
-        observations = torch.FloatTensor(np.array([exp['obs'] for exp in batch])).to(self.device)
-        actions = torch.LongTensor(np.array([exp['action'] for exp in batch])).to(self.device)
-        rewards = torch.FloatTensor([exp['reward'] for exp in batch]).to(self.device)
-        dones = torch.FloatTensor([float(exp['done']) for exp in batch]).to(self.device)
-        old_logprobs = torch.FloatTensor([exp['logprob'] for exp in batch]).to(self.device)
+        observations = torch.FloatTensor(np.array([exp["obs"] for exp in batch])).to(
+            self.device
+        )
+        actions = torch.LongTensor(np.array([exp["action"] for exp in batch])).to(
+            self.device
+        )
+        rewards = torch.FloatTensor([exp["reward"] for exp in batch]).to(self.device)
+        dones = torch.FloatTensor([float(exp["done"]) for exp in batch]).to(self.device)
+        old_logprobs = torch.FloatTensor([exp["logprob"] for exp in batch]).to(
+            self.device
+        )
 
         # Handle next observations (may be None if done)
         next_observations = []
         for exp in batch:
-            if exp['next_obs'] is not None:
-                next_observations.append(exp['next_obs'])
+            if exp["next_obs"] is not None:
+                next_observations.append(exp["next_obs"])
             else:
-                next_observations.append(np.zeros_like(exp['obs']))
-        next_observations = torch.FloatTensor(np.array(next_observations)).to(self.device)
+                next_observations.append(np.zeros_like(exp["obs"]))
+        next_observations = torch.FloatTensor(np.array(next_observations)).to(
+            self.device
+        )
 
         return observations, actions, rewards, next_observations, dones, old_logprobs
 
@@ -215,7 +223,10 @@ class PolicyLearner:
         # PPO policy loss
         ratio = torch.exp(new_logprobs - old_logprobs)
         surr1 = ratio * advantages
-        surr2 = torch.clamp(ratio, 1 - self.clip_epsilon, 1 + self.clip_epsilon) * advantages
+        surr2 = (
+            torch.clamp(ratio, 1 - self.clip_epsilon, 1 + self.clip_epsilon)
+            * advantages
+        )
         policy_loss = -torch.min(surr1, surr2).mean()
 
         # Value loss
@@ -225,7 +236,9 @@ class PolicyLearner:
         entropy = (house_dist.entropy() + mode_dist.entropy()).mean()
 
         # Total loss
-        total_loss = policy_loss + self.value_coef * value_loss - self.entropy_coef * entropy
+        total_loss = (
+            policy_loss + self.value_coef * value_loss - self.entropy_coef * entropy
+        )
 
         return total_loss, policy_loss, value_loss, entropy
 
@@ -237,7 +250,9 @@ class PolicyLearner:
             Dictionary of training statistics
         """
         # Prepare batch
-        observations, actions, rewards, next_observations, dones, old_logprobs = self.prepare_batch()
+        observations, actions, rewards, next_observations, dones, old_logprobs = (
+            self.prepare_batch()
+        )
 
         # Compute values for GAE
         with torch.no_grad():
@@ -301,11 +316,11 @@ class PolicyLearner:
         self.entropy_history.append(mean_entropy)
 
         return {
-            'batch': self.total_batches,
-            'policy_loss': mean_policy_loss,
-            'value_loss': mean_value_loss,
-            'entropy': mean_entropy,
-            'mean_reward': rewards.mean().item(),
+            "batch": self.total_batches,
+            "policy_loss": mean_policy_loss,
+            "value_loss": mean_value_loss,
+            "entropy": mean_entropy,
+            "mean_reward": rewards.mean().item(),
         }
 
     def send_policy_update(self):
@@ -322,14 +337,14 @@ class PolicyLearner:
         Args:
             max_batches: Maximum number of batches to train (None for infinite)
         """
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"🧠 Starting Policy Learner for Agent {self.agent_id}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Device: {self.device}")
         print(f"Batch size: {self.batch_size}")
         print(f"PPO epochs: {self.num_epochs}")
         print(f"Update interval: {self.update_interval}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
 
         start_time = time.time()
         last_report = start_time
@@ -352,32 +367,34 @@ class PolicyLearner:
                 elapsed = time.time() - last_report
                 batches_per_sec = self.update_interval / elapsed
 
-                print(f"[Agent {self.agent_id}] Batch {stats['batch']:,} | "
-                      f"Policy Loss: {stats['policy_loss']:.4f} | "
-                      f"Value Loss: {stats['value_loss']:.4f} | "
-                      f"Entropy: {stats['entropy']:.4f} | "
-                      f"Reward: {stats['mean_reward']:.3f} | "
-                      f"Speed: {batches_per_sec:.1f} batch/s")
+                print(
+                    f"[Agent {self.agent_id}] Batch {stats['batch']:,} | "
+                    f"Policy Loss: {stats['policy_loss']:.4f} | "
+                    f"Value Loss: {stats['value_loss']:.4f} | "
+                    f"Entropy: {stats['entropy']:.4f} | "
+                    f"Reward: {stats['mean_reward']:.3f} | "
+                    f"Speed: {batches_per_sec:.1f} batch/s"
+                )
 
                 last_report = time.time()
 
         total_time = time.time() - start_time
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"✅ Training Complete for Agent {self.agent_id}!")
         print(f"Total batches: {self.total_batches:,}")
         print(f"Total policy updates sent: {self.total_updates}")
-        print(f"Time: {total_time/60:.1f} minutes")
-        print(f"Speed: {self.total_batches/total_time:.1f} batches/s")
-        print(f"{'='*60}\n")
+        print(f"Time: {total_time / 60:.1f} minutes")
+        print(f"Speed: {self.total_batches / total_time:.1f} batches/s")
+        print(f"{'=' * 60}\n")
 
     def get_statistics(self) -> dict:
         """Get training statistics."""
         return {
-            'total_batches': self.total_batches,
-            'total_updates': self.total_updates,
-            'policy_loss_history': self.policy_loss_history,
-            'value_loss_history': self.value_loss_history,
-            'entropy_history': self.entropy_history,
+            "total_batches": self.total_batches,
+            "total_updates": self.total_updates,
+            "policy_loss_history": self.policy_loss_history,
+            "value_loss_history": self.value_loss_history,
+            "entropy_history": self.entropy_history,
         }
 
 

--- a/bucket_brigade/training/population_trainer.py
+++ b/bucket_brigade/training/population_trainer.py
@@ -21,18 +21,17 @@ Architecture:
 
 import multiprocessing as mp
 from pathlib import Path
-from typing import List, Optional, Dict
+from typing import List, Optional
 import time
 import json
 
 import torch
-import numpy as np
 
-from bucket_brigade_core import SCENARIOS, Scenario
+from bucket_brigade_core import SCENARIOS
 from bucket_brigade.training import PolicyNetwork
 from bucket_brigade.training.game_simulator import GameSimulator
 from bucket_brigade.training.policy_learner import learner_process
-from bucket_brigade.training.observation_utils import flatten_observation, get_observation_dim, create_scenario_info
+from bucket_brigade.training.observation_utils import get_observation_dim
 
 
 class PopulationTrainer:
@@ -112,6 +111,7 @@ class PopulationTrainer:
         # Initialize dimensions (from scenario)
         # For now, we'll infer these from a test environment
         from bucket_brigade_core import BucketBrigade
+
         test_env = BucketBrigade(self.scenario, num_agents_per_game, seed=seed)
 
         # Get number of houses from a test observation
@@ -124,7 +124,7 @@ class PopulationTrainer:
         # Action dimensions: [num_houses, 3 modes (idle, fill, pass)]
         self.action_dims = [num_houses, 3]
 
-        print(f"Inferred dimensions:")
+        print("Inferred dimensions:")
         print(f"  Observation: {self.obs_dim}")
         print(f"  Actions: {self.action_dims} (houses={num_houses}, modes=3)")
 
@@ -144,24 +144,26 @@ class PopulationTrainer:
 
     def setup_infrastructure(self):
         """Set up multiprocessing queues and processes."""
-        print(f"\n{'='*60}")
-        print(f"🔧 Setting Up Training Infrastructure")
-        print(f"{'='*60}")
+        print(f"\n{'=' * 60}")
+        print("🔧 Setting Up Training Infrastructure")
+        print(f"{'=' * 60}")
 
         # Create experience queues (one per agent)
         print(f"Creating {self.population_size} experience queues...")
-        self.experience_queues = [mp.Queue(maxsize=1000) for _ in range(self.population_size)]
+        self.experience_queues = [
+            mp.Queue(maxsize=1000) for _ in range(self.population_size)
+        ]
 
         # Create policy update queue (shared)
         print("Creating policy update queue...")
         self.policy_update_queue = mp.Queue(maxsize=100)
 
-        print(f"✅ Queues created\n")
+        print("✅ Queues created\n")
 
     def spawn_learners(self):
         """Spawn GPU learner processes."""
         print(f"🚀 Spawning {self.population_size} GPU Learner Processes")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         for agent_id in range(self.population_size):
             # Determine device for this learner
@@ -173,18 +175,18 @@ class PopulationTrainer:
             process = mp.Process(
                 target=learner_process,
                 kwargs={
-                    'agent_id': agent_id,
-                    'obs_dim': self.obs_dim,
-                    'action_dims': self.action_dims,
-                    'hidden_size': self.hidden_size,
-                    'learning_rate': self.learning_rate,
-                    'device': learner_device,
-                    'experience_queue': self.experience_queues[agent_id],
-                    'policy_update_queue': self.policy_update_queue,
-                    'batch_size': self.batch_size,
-                    'num_epochs': self.num_epochs,
-                    'update_interval': self.update_interval,
-                }
+                    "agent_id": agent_id,
+                    "obs_dim": self.obs_dim,
+                    "action_dims": self.action_dims,
+                    "hidden_size": self.hidden_size,
+                    "learning_rate": self.learning_rate,
+                    "device": learner_device,
+                    "experience_queue": self.experience_queues[agent_id],
+                    "policy_update_queue": self.policy_update_queue,
+                    "batch_size": self.batch_size,
+                    "num_epochs": self.num_epochs,
+                    "update_interval": self.update_interval,
+                },
             )
             process.start()
             self.learner_processes.append(process)
@@ -193,8 +195,8 @@ class PopulationTrainer:
 
     def initialize_simulator(self):
         """Initialize the CPU game simulator."""
-        print(f"🎮 Initializing CPU Game Simulator")
-        print(f"{'='*60}")
+        print("🎮 Initializing CPU Game Simulator")
+        print(f"{'=' * 60}")
 
         # Create simulator
         self.simulator = GameSimulator(
@@ -221,7 +223,7 @@ class PopulationTrainer:
                 torch.manual_seed(self.seed + agent_id)
             self.simulator.register_policy(agent_id, policy)
 
-        print(f"✅ Simulator initialized\n")
+        print("✅ Simulator initialized\n")
 
     def train(self, num_episodes: int):
         """
@@ -230,15 +232,15 @@ class PopulationTrainer:
         Args:
             num_episodes: Number of episodes to simulate
         """
-        print(f"\n{'='*60}")
-        print(f"🚀 Starting Population-Based Training")
-        print(f"{'='*60}")
+        print(f"\n{'=' * 60}")
+        print("🚀 Starting Population-Based Training")
+        print(f"{'=' * 60}")
         print(f"Scenario: {self.scenario_name}")
         print(f"Population: {self.population_size} agents")
         print(f"Parallel games: {self.num_games}")
         print(f"Target episodes: {num_episodes:,}")
         print(f"Device: {self.device}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
 
         self.start_time = time.time()
 
@@ -256,7 +258,7 @@ class PopulationTrainer:
         self.initialize_simulator()
 
         # Run simulation
-        print(f"▶️  Starting game simulation...")
+        print("▶️  Starting game simulation...")
         self.simulator.run(
             num_episodes=num_episodes,
             update_interval=self.log_interval,
@@ -268,9 +270,9 @@ class PopulationTrainer:
 
     def cleanup(self):
         """Clean up processes and resources."""
-        print(f"\n{'='*60}")
-        print(f"🧹 Cleaning Up")
-        print(f"{'='*60}")
+        print(f"\n{'=' * 60}")
+        print("🧹 Cleaning Up")
+        print(f"{'=' * 60}")
 
         # Terminate learner processes
         print(f"Terminating {len(self.learner_processes)} learner processes...")
@@ -289,17 +291,19 @@ class PopulationTrainer:
             stats = self.simulator.get_statistics()
             total_time = time.time() - self.start_time
 
-            print(f"{'='*60}")
-            print(f"📊 Final Statistics")
-            print(f"{'='*60}")
+            print(f"{'=' * 60}")
+            print("📊 Final Statistics")
+            print(f"{'=' * 60}")
             print(f"Total episodes: {stats['total_episodes']:,}")
             print(f"Total steps: {stats['total_steps']:,}")
-            print(f"Training time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)")
-            print(f"Episodes/sec: {stats['total_episodes']/total_time:.1f}")
-            print(f"\nMatch counts per agent:")
-            for agent_id, count in enumerate(stats['match_counts']):
+            print(
+                f"Training time: {total_time / 60:.1f} minutes ({total_time / 3600:.2f} hours)"
+            )
+            print(f"Episodes/sec: {stats['total_episodes'] / total_time:.1f}")
+            print("\nMatch counts per agent:")
+            for agent_id, count in enumerate(stats["match_counts"]):
                 print(f"  Agent {agent_id}: {count:,} games")
-            print(f"{'='*60}\n")
+            print(f"{'=' * 60}\n")
 
     def save_checkpoint(self, path: Path):
         """
@@ -313,11 +317,11 @@ class PopulationTrainer:
             return
 
         checkpoint = {
-            'scenario_name': self.scenario_name,
-            'population_size': self.population_size,
-            'total_episodes': self.total_episodes,
-            'statistics': self.simulator.get_statistics(),
-            'policies': {
+            "scenario_name": self.scenario_name,
+            "population_size": self.population_size,
+            "total_episodes": self.total_episodes,
+            "statistics": self.simulator.get_statistics(),
+            "policies": {
                 agent_id: policy.state_dict()
                 for agent_id, policy in self.simulator.policies.items()
             },
@@ -330,23 +334,23 @@ class PopulationTrainer:
     def save_config(self, path: Path):
         """Save training configuration."""
         config = {
-            'scenario_name': self.scenario_name,
-            'population_size': self.population_size,
-            'num_games': self.num_games,
-            'num_agents_per_game': self.num_agents_per_game,
-            'hidden_size': self.hidden_size,
-            'learning_rate': self.learning_rate,
-            'device': self.device,
-            'matchmaking_strategy': self.matchmaking_strategy,
-            'seed': self.seed,
-            'batch_size': self.batch_size,
-            'num_epochs': self.num_epochs,
-            'update_interval': self.update_interval,
-            'obs_dim': self.obs_dim,
-            'action_dims': self.action_dims,
+            "scenario_name": self.scenario_name,
+            "population_size": self.population_size,
+            "num_games": self.num_games,
+            "num_agents_per_game": self.num_agents_per_game,
+            "hidden_size": self.hidden_size,
+            "learning_rate": self.learning_rate,
+            "device": self.device,
+            "matchmaking_strategy": self.matchmaking_strategy,
+            "seed": self.seed,
+            "batch_size": self.batch_size,
+            "num_epochs": self.num_epochs,
+            "update_interval": self.update_interval,
+            "obs_dim": self.obs_dim,
+            "action_dims": self.action_dims,
         }
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             json.dump(config, f, indent=2)
         print(f"💾 Saved config: {path}")

--- a/experiments/marl/test_population_training.py
+++ b/experiments/marl/test_population_training.py
@@ -21,7 +21,7 @@ def main():
 
     # Create trainer
     trainer = PopulationTrainer(
-        scenario_name='trivial_cooperation',
+        scenario_name="trivial_cooperation",
         population_size=8,
         num_games=64,
         num_agents_per_game=4,
@@ -29,15 +29,15 @@ def main():
         hidden_size=512,
         learning_rate=3e-4,
         # Training parameters
-        device='cuda',  # Use GPU
-        matchmaking_strategy='round_robin',
+        device="cuda",  # Use GPU
+        matchmaking_strategy="round_robin",
         seed=42,
         # Learner parameters
         batch_size=256,
         num_epochs=4,
         update_interval=100,
         # Checkpoint and logging
-        checkpoint_dir=Path('experiments/marl/checkpoints/population_test'),
+        checkpoint_dir=Path("experiments/marl/checkpoints/population_test"),
         log_interval=50,
     )
 
@@ -46,11 +46,11 @@ def main():
     trainer.train(num_episodes=1000)
 
     # Save final checkpoint
-    checkpoint_path = Path('experiments/marl/checkpoints/population_test/final.pt')
+    checkpoint_path = Path("experiments/marl/checkpoints/population_test/final.pt")
     trainer.save_checkpoint(checkpoint_path)
 
     # Save config
-    config_path = Path('experiments/marl/checkpoints/population_test/config.json')
+    config_path = Path("experiments/marl/checkpoints/population_test/config.json")
     trainer.save_config(config_path)
 
     print("\n" + "=" * 80)
@@ -60,5 +60,5 @@ def main():
     print("=" * 80)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/experiments/marl/train_gpu.py
+++ b/experiments/marl/train_gpu.py
@@ -22,6 +22,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -30,13 +31,12 @@ from datetime import datetime
 import json
 
 import torch
-import torch.nn as nn
 import torch.optim as optim
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from bucket_brigade.envs.puffer_env_rust import make_rust_env
-from bucket_brigade.training import PolicyNetwork, TransformerPolicyNetwork, compute_gae
+from bucket_brigade.training import PolicyNetwork, TransformerPolicyNetwork
 
 
 def train_ppo(
@@ -60,16 +60,16 @@ def train_ppo(
     if device is None:
         device = next(policy.parameters()).device
 
-    print(f"\n{'='*60}")
-    print(f"🚀 Starting PPO Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🚀 Starting PPO Training")
+    print(f"{'=' * 60}")
     print(f"📊 Total steps: {num_steps:,}")
     print(f"📦 Batch size: {batch_size:,}")
     print(f"🔁 Epochs per batch: {num_epochs}")
     print(f"💾 Checkpoint interval: {checkpoint_interval:,} steps")
     print(f"📈 Eval interval: {eval_interval:,} steps")
     print(f"🖥️  Device: {device}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     obs, _ = env.reset()
     obs = torch.FloatTensor(obs).to(device)
@@ -134,61 +134,102 @@ def train_ppo(
                 steps_per_sec = eval_interval / elapsed
                 progress = (step + 1) / num_steps * 100
 
-                print(f"Step {step+1:,}/{num_steps:,} ({progress:.1f}%) | "
-                      f"Reward: {avg_reward:.2f} | "
-                      f"Length: {avg_length:.1f} | "
-                      f"Episodes: {len(episode_rewards)} | "
-                      f"Speed: {steps_per_sec:.0f} steps/s")
+                print(
+                    f"Step {step + 1:,}/{num_steps:,} ({progress:.1f}%) | "
+                    f"Reward: {avg_reward:.2f} | "
+                    f"Length: {avg_length:.1f} | "
+                    f"Episodes: {len(episode_rewards)} | "
+                    f"Speed: {steps_per_sec:.0f} steps/s"
+                )
 
                 if writer:
                     writer.add_scalar("train/avg_reward_100ep", avg_reward, step)
                     writer.add_scalar("train/avg_length_100ep", avg_length, step)
                     writer.add_scalar("train/steps_per_sec", steps_per_sec, step)
-                    writer.add_scalar("train/total_episodes", len(episode_rewards), step)
+                    writer.add_scalar(
+                        "train/total_episodes", len(episode_rewards), step
+                    )
 
         # Checkpointing
         if checkpoint_dir and (step + 1) % checkpoint_interval == 0:
-            checkpoint_path = checkpoint_dir / f"checkpoint_step_{step+1}.pt"
-            torch.save({
-                'step': step + 1,
-                'model_state_dict': policy.state_dict(),
-                'optimizer_state_dict': optimizer.state_dict(),
-                'episode_rewards': episode_rewards,
-                'episode_lengths': episode_lengths,
-            }, checkpoint_path)
+            checkpoint_path = checkpoint_dir / f"checkpoint_step_{step + 1}.pt"
+            torch.save(
+                {
+                    "step": step + 1,
+                    "model_state_dict": policy.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "episode_rewards": episode_rewards,
+                    "episode_lengths": episode_lengths,
+                },
+                checkpoint_path,
+            )
             print(f"💾 Saved checkpoint: {checkpoint_path}")
 
     total_time = time.time() - start_time
-    print(f"\n{'='*60}")
-    print(f"✅ Training Complete!")
-    print(f"⏱️  Total time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)")
+    print(f"\n{'=' * 60}")
+    print("✅ Training Complete!")
+    print(
+        f"⏱️  Total time: {total_time / 60:.1f} minutes ({total_time / 3600:.2f} hours)"
+    )
     print(f"📊 Total episodes: {len(episode_rewards)}")
     if episode_rewards:
         print(f"📈 Final avg reward (last 100): {np.mean(episode_rewards[-100:]):.2f}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     return episode_rewards, episode_lengths
 
 
 def main():
     parser = argparse.ArgumentParser(description="Train PPO on Bucket Brigade (GPU)")
-    parser.add_argument("--steps", type=int, default=10000000, help="Total training steps")
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation", help="Scenario name")
-    parser.add_argument("--opponents", type=int, default=3, help="Number of opponent agents")
+    parser.add_argument(
+        "--steps", type=int, default=10000000, help="Total training steps"
+    )
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
+    parser.add_argument(
+        "--opponents", type=int, default=3, help="Number of opponent agents"
+    )
     parser.add_argument("--run-name", type=str, default=None, help="Name for this run")
     parser.add_argument("--batch-size", type=int, default=2048, help="Batch size")
     parser.add_argument("--epochs", type=int, default=4, help="Epochs per batch")
     parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate")
-    parser.add_argument("--checkpoint-interval", type=int, default=100000, help="Steps between checkpoints")
-    parser.add_argument("--eval-interval", type=int, default=10000, help="Steps between eval prints")
-    parser.add_argument("--cpu", action="store_true", help="Force CPU usage (default: auto-detect GPU)")
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100000,
+        help="Steps between checkpoints",
+    )
+    parser.add_argument(
+        "--eval-interval", type=int, default=10000, help="Steps between eval prints"
+    )
+    parser.add_argument(
+        "--cpu", action="store_true", help="Force CPU usage (default: auto-detect GPU)"
+    )
 
     # Architecture options
-    parser.add_argument("--architecture", type=str, default="mlp", choices=["mlp", "transformer"],
-                        help="Network architecture: 'mlp' (default, ~4K params) or 'transformer' (~650K params)")
-    parser.add_argument("--d-model", type=int, default=192, help="Transformer embedding dimension (default: 192)")
-    parser.add_argument("--num-layers", type=int, default=2, help="Number of transformer layers (default: 2)")
-    parser.add_argument("--nhead", type=int, default=4, help="Number of attention heads (default: 4)")
+    parser.add_argument(
+        "--architecture",
+        type=str,
+        default="mlp",
+        choices=["mlp", "transformer"],
+        help="Network architecture: 'mlp' (default, ~4K params) or 'transformer' (~650K params)",
+    )
+    parser.add_argument(
+        "--d-model",
+        type=int,
+        default=192,
+        help="Transformer embedding dimension (default: 192)",
+    )
+    parser.add_argument(
+        "--num-layers",
+        type=int,
+        default=2,
+        help="Number of transformer layers (default: 2)",
+    )
+    parser.add_argument(
+        "--nhead", type=int, default=4, help="Number of attention heads (default: 4)"
+    )
 
     args = parser.parse_args()
 
@@ -205,8 +246,8 @@ def main():
 
     # Save config
     config = vars(args).copy()
-    config['timestamp'] = timestamp
-    with open(runs_dir / "config.json", 'w') as f:
+    config["timestamp"] = timestamp
+    with open(runs_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
 
     print(f"\n🎮 Creating environment: {args.scenario}")
@@ -230,7 +271,7 @@ def main():
     obs_space = env.observation_space
     action_space = env.action_space
 
-    print(f"\n🧠 Creating policy network")
+    print("\n🧠 Creating policy network")
     print(f"   Architecture: {args.architecture}")
     print(f"   Observation dim: {obs_space.shape[0]}")
     print(f"   Action dims: {action_space.nvec.tolist()}")
@@ -245,8 +286,7 @@ def main():
         ).to(device)
     else:
         policy = PolicyNetwork(
-            obs_dim=obs_space.shape[0],
-            action_dims=action_space.nvec.tolist()
+            obs_dim=obs_space.shape[0], action_dims=action_space.nvec.tolist()
         ).to(device)
 
     # Print parameter count
@@ -258,7 +298,7 @@ def main():
     # TensorBoard
     writer = SummaryWriter(runs_dir)
     print(f"📊 TensorBoard: {runs_dir}")
-    print(f"   View with: tensorboard --logdir experiments/marl/runs/")
+    print("   View with: tensorboard --logdir experiments/marl/runs/")
 
     # Train
     episode_rewards, episode_lengths = train_ppo(

--- a/experiments/marl/train_gpu_vectorized.py
+++ b/experiments/marl/train_gpu_vectorized.py
@@ -22,6 +22,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -94,9 +95,9 @@ def train_ppo_vectorized(
 
     num_envs = vec_env.num_envs
 
-    print(f"\n{'='*60}")
-    print(f"🚀 Starting Vectorized PPO Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🚀 Starting Vectorized PPO Training")
+    print(f"{'=' * 60}")
     print(f"📊 Total steps: {num_steps:,}")
     print(f"🌍 Parallel environments: {num_envs}")
     print(f"📦 Rollout length: {rollout_length}")
@@ -105,8 +106,8 @@ def train_ppo_vectorized(
     print(f"💾 Checkpoint interval: {checkpoint_interval:,} steps")
     print(f"📈 Eval interval: {eval_interval:,} steps")
     print(f"🖥️  Device: {device}")
-    print(f"⚡ Expected GPU util: 80-90%")
-    print(f"{'='*60}\n")
+    print("⚡ Expected GPU util: 80-90%")
+    print(f"{'=' * 60}\n")
 
     # Initialize
     obs = vec_env.reset()
@@ -156,7 +157,9 @@ def train_ppo_vectorized(
                 actions = torch.stack([house_actions, mode_actions], dim=1)
 
             # Step environments (all at once)
-            next_obs, rewards, terminateds, truncateds, infos = vec_env.step(actions.cpu().numpy())
+            next_obs, rewards, terminateds, truncateds, infos = vec_env.step(
+                actions.cpu().numpy()
+            )
             dones = terminateds | truncateds
 
             # Store rollout data
@@ -179,8 +182,12 @@ def train_ppo_vectorized(
                     episode_lengths[i] = 0
 
                     if writer:
-                        writer.add_scalar("episode/reward", completed_rewards[-1], total_env_steps)
-                        writer.add_scalar("episode/length", completed_lengths[-1], total_env_steps)
+                        writer.add_scalar(
+                            "episode/reward", completed_rewards[-1], total_env_steps
+                        )
+                        writer.add_scalar(
+                            "episode/length", completed_lengths[-1], total_env_steps
+                        )
 
             obs_tensor = torch.FloatTensor(next_obs).to(device)
             total_env_steps += num_envs
@@ -191,7 +198,9 @@ def train_ppo_vectorized(
         # === LEARNING PHASE: Update policy ===
         if len(rollout_obs) > 0:
             # Stack rollout data
-            rollout_obs_batch = torch.stack(rollout_obs)  # [rollout_length, num_envs, obs_dim]
+            rollout_obs_batch = torch.stack(
+                rollout_obs
+            )  # [rollout_length, num_envs, obs_dim]
             rollout_actions_batch = torch.stack(rollout_actions)
             rollout_logprobs_batch = torch.stack(rollout_logprobs)
             rollout_values_batch = torch.stack(rollout_values)
@@ -216,20 +225,30 @@ def train_ppo_vectorized(
                         nextnonterminal = 1.0 - rollout_dones_batch[t + 1]
                         nextvalues = rollout_values_batch[t + 1]
 
-                    delta = rollout_rewards_batch[t] + 0.99 * nextvalues * nextnonterminal - rollout_values_batch[t]
-                    advantages[t] = lastgaelam = delta + 0.99 * 0.95 * nextnonterminal * lastgaelam
+                    delta = (
+                        rollout_rewards_batch[t]
+                        + 0.99 * nextvalues * nextnonterminal
+                        - rollout_values_batch[t]
+                    )
+                    advantages[t] = lastgaelam = (
+                        delta + 0.99 * 0.95 * nextnonterminal * lastgaelam
+                    )
             returns = advantages + rollout_values_batch
 
             # Flatten batch [rollout_length, num_envs, ...] -> [rollout_length * num_envs, ...]
             b_obs = rollout_obs_batch.reshape(-1, rollout_obs_batch.shape[-1])
-            b_actions = rollout_actions_batch.reshape(-1, rollout_actions_batch.shape[-1])
+            b_actions = rollout_actions_batch.reshape(
+                -1, rollout_actions_batch.shape[-1]
+            )
             b_logprobs = rollout_logprobs_batch.reshape(-1)
             b_advantages = advantages.reshape(-1)
             b_returns = returns.reshape(-1)
             b_values = rollout_values_batch.reshape(-1)
 
             # Normalize advantages
-            b_advantages = (b_advantages - b_advantages.mean()) / (b_advantages.std() + 1e-8)
+            b_advantages = (b_advantages - b_advantages.mean()) / (
+                b_advantages.std() + 1e-8
+            )
 
             # Multiple epochs over the data
             batch_size = b_obs.shape[0]
@@ -248,7 +267,7 @@ def train_ppo_vectorized(
                     mb_logprobs = b_logprobs[mb_indices]
                     mb_advantages = b_advantages[mb_indices]
                     mb_returns = b_returns[mb_indices]
-                    mb_values = b_values[mb_indices]
+                    _mb_values = b_values[mb_indices]
 
                     # Forward pass
                     action_logits, new_values = policy(mb_obs)
@@ -271,7 +290,9 @@ def train_ppo_vectorized(
 
                     # Policy loss
                     pg_loss1 = -mb_advantages * ratio
-                    pg_loss2 = -mb_advantages * torch.clamp(ratio, 1 - clip_epsilon, 1 + clip_epsilon)
+                    pg_loss2 = -mb_advantages * torch.clamp(
+                        ratio, 1 - clip_epsilon, 1 + clip_epsilon
+                    )
                     pg_loss = torch.max(pg_loss1, pg_loss2).mean()
 
                     # Value loss
@@ -309,57 +330,103 @@ def train_ppo_vectorized(
                 steps_per_sec = eval_interval / elapsed if elapsed > 0 else 0
                 progress = total_env_steps / num_steps * 100
 
-                print(f"Step {total_env_steps:,}/{num_steps:,} ({progress:.1f}%) | "
-                      f"Reward: {avg_reward:.2f} | "
-                      f"Length: {avg_length:.1f} | "
-                      f"Episodes: {len(completed_rewards)} | "
-                      f"Speed: {steps_per_sec:.0f} steps/s")
+                print(
+                    f"Step {total_env_steps:,}/{num_steps:,} ({progress:.1f}%) | "
+                    f"Reward: {avg_reward:.2f} | "
+                    f"Length: {avg_length:.1f} | "
+                    f"Episodes: {len(completed_rewards)} | "
+                    f"Speed: {steps_per_sec:.0f} steps/s"
+                )
 
                 if writer:
-                    writer.add_scalar("train/avg_reward_100ep", avg_reward, total_env_steps)
-                    writer.add_scalar("train/avg_length_100ep", avg_length, total_env_steps)
-                    writer.add_scalar("train/steps_per_sec", steps_per_sec, total_env_steps)
-                    writer.add_scalar("train/total_episodes", len(completed_rewards), total_env_steps)
+                    writer.add_scalar(
+                        "train/avg_reward_100ep", avg_reward, total_env_steps
+                    )
+                    writer.add_scalar(
+                        "train/avg_length_100ep", avg_length, total_env_steps
+                    )
+                    writer.add_scalar(
+                        "train/steps_per_sec", steps_per_sec, total_env_steps
+                    )
+                    writer.add_scalar(
+                        "train/total_episodes", len(completed_rewards), total_env_steps
+                    )
 
         # === CHECKPOINTING ===
-        if checkpoint_dir and total_env_steps % checkpoint_interval < num_envs * rollout_length:
+        if (
+            checkpoint_dir
+            and total_env_steps % checkpoint_interval < num_envs * rollout_length
+        ):
             checkpoint_path = checkpoint_dir / f"checkpoint_step_{total_env_steps}.pt"
-            torch.save({
-                'step': total_env_steps,
-                'model_state_dict': policy.state_dict(),
-                'optimizer_state_dict': optimizer.state_dict(),
-                'episode_rewards': completed_rewards,
-                'episode_lengths': completed_lengths,
-            }, checkpoint_path)
+            torch.save(
+                {
+                    "step": total_env_steps,
+                    "model_state_dict": policy.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "episode_rewards": completed_rewards,
+                    "episode_lengths": completed_lengths,
+                },
+                checkpoint_path,
+            )
             print(f"💾 Saved checkpoint: {checkpoint_path}")
 
     total_time = time.time() - start_time
-    print(f"\n{'='*60}")
-    print(f"✅ Training Complete!")
-    print(f"⏱️  Total time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)")
+    print(f"\n{'=' * 60}")
+    print("✅ Training Complete!")
+    print(
+        f"⏱️  Total time: {total_time / 60:.1f} minutes ({total_time / 3600:.2f} hours)"
+    )
     print(f"📊 Total episodes: {len(completed_rewards)}")
     if completed_rewards:
-        print(f"📈 Final avg reward (last 100): {np.mean(completed_rewards[-100:]):.2f}")
-    print(f"⚡ Average speed: {total_env_steps/total_time:.0f} steps/s")
-    print(f"{'='*60}\n")
+        print(
+            f"📈 Final avg reward (last 100): {np.mean(completed_rewards[-100:]):.2f}"
+        )
+    print(f"⚡ Average speed: {total_env_steps / total_time:.0f} steps/s")
+    print(f"{'=' * 60}\n")
 
     return completed_rewards, completed_lengths
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Vectorized PPO Training (High GPU Utilization)")
-    parser.add_argument("--steps", type=int, default=10000000, help="Total training steps")
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation", help="Scenario name")
-    parser.add_argument("--opponents", type=int, default=3, help="Number of opponent agents")
-    parser.add_argument("--num-envs", type=int, default=64, help="Number of parallel environments")
-    parser.add_argument("--rollout-length", type=int, default=128, help="Steps per rollout")
-    parser.add_argument("--minibatch-size", type=int, default=256, help="Minibatch size for updates")
+    parser = argparse.ArgumentParser(
+        description="Vectorized PPO Training (High GPU Utilization)"
+    )
+    parser.add_argument(
+        "--steps", type=int, default=10000000, help="Total training steps"
+    )
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
+    parser.add_argument(
+        "--opponents", type=int, default=3, help="Number of opponent agents"
+    )
+    parser.add_argument(
+        "--num-envs", type=int, default=64, help="Number of parallel environments"
+    )
+    parser.add_argument(
+        "--rollout-length", type=int, default=128, help="Steps per rollout"
+    )
+    parser.add_argument(
+        "--minibatch-size", type=int, default=256, help="Minibatch size for updates"
+    )
     parser.add_argument("--epochs", type=int, default=4, help="Epochs per batch")
     parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate")
-    parser.add_argument("--hidden-size", type=int, default=2048, help="Hidden layer size (larger = more GPU usage)")
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=2048,
+        help="Hidden layer size (larger = more GPU usage)",
+    )
     parser.add_argument("--run-name", type=str, default=None, help="Name for this run")
-    parser.add_argument("--checkpoint-interval", type=int, default=100000, help="Steps between checkpoints")
-    parser.add_argument("--eval-interval", type=int, default=10000, help="Steps between eval prints")
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100000,
+        help="Steps between checkpoints",
+    )
+    parser.add_argument(
+        "--eval-interval", type=int, default=10000, help="Steps between eval prints"
+    )
     parser.add_argument("--cpu", action="store_true", help="Force CPU usage")
 
     args = parser.parse_args()
@@ -377,9 +444,9 @@ def main():
 
     # Save config
     config = vars(args).copy()
-    config['timestamp'] = timestamp
-    config['vectorized'] = True
-    with open(runs_dir / "config.json", 'w') as f:
+    config["timestamp"] = timestamp
+    config["vectorized"] = True
+    with open(runs_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
 
     print(f"\n🎮 Creating vectorized environment: {args.scenario}")
@@ -407,7 +474,7 @@ def main():
     obs_space = vec_env.observation_space
     action_space = vec_env.action_space
 
-    print(f"\n🧠 Creating policy network")
+    print("\n🧠 Creating policy network")
     print(f"   Observation dim: {obs_space.shape[0]}")
     print(f"   Action dims: {action_space.nvec.tolist()}")
 
@@ -415,18 +482,20 @@ def main():
     policy = PolicyNetwork(
         obs_dim=obs_space.shape[0],
         action_dims=action_space.nvec.tolist(),
-        hidden_size=args.hidden_size
+        hidden_size=args.hidden_size,
     ).to(device)
 
     total_params = sum(p.numel() for p in policy.parameters())
-    print(f"   Model parameters: {total_params:,} ({total_params * 4 / 1024 / 1024:.1f} MB)")
+    print(
+        f"   Model parameters: {total_params:,} ({total_params * 4 / 1024 / 1024:.1f} MB)"
+    )
 
     optimizer = optim.Adam(policy.parameters(), lr=args.lr)
 
     # TensorBoard
     writer = SummaryWriter(runs_dir)
     print(f"📊 TensorBoard: {runs_dir}")
-    print(f"   View with: tensorboard --logdir experiments/marl/runs/")
+    print("   View with: tensorboard --logdir experiments/marl/runs/")
 
     # Train
     episode_rewards, episode_lengths = train_ppo_vectorized(

--- a/experiments/marl/train_population.py
+++ b/experiments/marl/train_population.py
@@ -41,6 +41,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -54,47 +55,76 @@ def main():
     parser = argparse.ArgumentParser(description="Train agent population with PPO")
 
     # Scenario and population
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation",
-                        help="Scenario name")
-    parser.add_argument("--population-size", type=int, default=8,
-                        help="Number of agents in population")
-    parser.add_argument("--num-games", type=int, default=64,
-                        help="Number of parallel game environments")
-    parser.add_argument("--num-agents-per-game", type=int, default=4,
-                        help="Number of agents per game")
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
+    parser.add_argument(
+        "--population-size", type=int, default=8, help="Number of agents in population"
+    )
+    parser.add_argument(
+        "--num-games", type=int, default=64, help="Number of parallel game environments"
+    )
+    parser.add_argument(
+        "--num-agents-per-game", type=int, default=4, help="Number of agents per game"
+    )
 
     # Training
-    parser.add_argument("--num-episodes", type=int, default=10000,
-                        help="Total simulation episodes")
-    parser.add_argument("--hidden-size", type=int, default=512,
-                        help="Hidden layer size for policy networks")
-    parser.add_argument("--learning-rate", type=float, default=3e-4,
-                        help="Learning rate")
+    parser.add_argument(
+        "--num-episodes", type=int, default=10000, help="Total simulation episodes"
+    )
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=512,
+        help="Hidden layer size for policy networks",
+    )
+    parser.add_argument(
+        "--learning-rate", type=float, default=3e-4, help="Learning rate"
+    )
 
     # Learner parameters
-    parser.add_argument("--batch-size", type=int, default=256,
-                        help="Batch size for learners")
-    parser.add_argument("--num-epochs", type=int, default=4,
-                        help="PPO epochs per batch")
-    parser.add_argument("--update-interval", type=int, default=100,
-                        help="Learners send policy updates every N batches")
+    parser.add_argument(
+        "--batch-size", type=int, default=256, help="Batch size for learners"
+    )
+    parser.add_argument(
+        "--num-epochs", type=int, default=4, help="PPO epochs per batch"
+    )
+    parser.add_argument(
+        "--update-interval",
+        type=int,
+        default=100,
+        help="Learners send policy updates every N batches",
+    )
 
     # System
-    parser.add_argument("--device", type=str, default="cuda",
-                        help="Device for GPU learners (cuda or cpu)")
-    parser.add_argument("--matchmaking", type=str, default="round_robin",
-                        choices=["round_robin", "random"],
-                        help="Matchmaking strategy")
-    parser.add_argument("--seed", type=int, default=None,
-                        help="Random seed")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Device for GPU learners (cuda or cpu)",
+    )
+    parser.add_argument(
+        "--matchmaking",
+        type=str,
+        default="round_robin",
+        choices=["round_robin", "random"],
+        help="Matchmaking strategy",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Random seed")
 
     # Logging and checkpoints
-    parser.add_argument("--run-name", type=str, default=None,
-                        help="Run name for logging")
-    parser.add_argument("--log-interval", type=int, default=100,
-                        help="Log progress every N episodes")
-    parser.add_argument("--checkpoint-interval", type=int, default=1000,
-                        help="Save checkpoint every N episodes")
+    parser.add_argument(
+        "--run-name", type=str, default=None, help="Run name for logging"
+    )
+    parser.add_argument(
+        "--log-interval", type=int, default=100, help="Log progress every N episodes"
+    )
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=1000,
+        help="Save checkpoint every N episodes",
+    )
 
     args = parser.parse_args()
 
@@ -107,9 +137,9 @@ def main():
     checkpoint_dir = exp_dir / "checkpoints" / run_name
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"\n{'='*60}")
-    print(f"🎮 Population-Based Multi-Agent Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🎮 Population-Based Multi-Agent Training")
+    print(f"{'=' * 60}")
     print(f"Run: {run_name}")
     print(f"Scenario: {args.scenario}")
     print(f"Population: {args.population_size} agents")
@@ -118,7 +148,7 @@ def main():
     print(f"Device: {args.device}")
     print(f"Matchmaking: {args.matchmaking}")
     print(f"Seed: {args.seed}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     # Create trainer
     trainer = PopulationTrainer(
@@ -147,7 +177,7 @@ def main():
         trainer.train(num_episodes=args.num_episodes)
 
         # Save final checkpoint
-        final_checkpoint = checkpoint_dir / f"final_checkpoint.pt"
+        final_checkpoint = checkpoint_dir / "final_checkpoint.pt"
         trainer.save_checkpoint(final_checkpoint)
 
     except KeyboardInterrupt:
@@ -157,6 +187,7 @@ def main():
     except Exception as e:
         print(f"\n\n❌ Training failed with error: {e}")
         import traceback
+
         traceback.print_exc()
         trainer.cleanup()
         raise
@@ -166,5 +197,5 @@ def main():
 
 if __name__ == "__main__":
     # Required for multiprocessing on some platforms
-    mp.set_start_method('spawn', force=True)
+    mp.set_start_method("spawn", force=True)
     main()

--- a/experiments/marl/train_puffer_hybrid.py
+++ b/experiments/marl/train_puffer_hybrid.py
@@ -25,6 +25,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -70,9 +71,9 @@ def train_ppo_hybrid(
     # PufferLib vecenv interface
     num_envs = vec_env.num_envs
 
-    print(f"\n{'='*60}")
-    print(f"🚀 Starting Hybrid PPO Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🚀 Starting Hybrid PPO Training")
+    print(f"{'=' * 60}")
     print(f"📊 Total steps: {num_steps:,}")
     print(f"🌍 Parallel environments: {num_envs} (multiprocessing)")
     print(f"📦 Rollout length: {rollout_length}")
@@ -81,8 +82,8 @@ def train_ppo_hybrid(
     print(f"💾 Checkpoint interval: {checkpoint_interval:,} steps")
     print(f"📈 Eval interval: {eval_interval:,} steps")
     print(f"🖥️  Device: {device}")
-    print(f"⚡ Expected GPU util: 60-80%")
-    print(f"{'='*60}\n")
+    print("⚡ Expected GPU util: 60-80%")
+    print(f"{'=' * 60}\n")
 
     # Initialize
     obs = vec_env.reset()
@@ -154,8 +155,12 @@ def train_ppo_hybrid(
                     episode_lengths[i] = 0
 
                     if writer:
-                        writer.add_scalar("episode/reward", completed_rewards[-1], total_env_steps)
-                        writer.add_scalar("episode/length", completed_lengths[-1], total_env_steps)
+                        writer.add_scalar(
+                            "episode/reward", completed_rewards[-1], total_env_steps
+                        )
+                        writer.add_scalar(
+                            "episode/length", completed_lengths[-1], total_env_steps
+                        )
 
             obs_tensor = torch.FloatTensor(next_obs).to(device)
             total_env_steps += num_envs
@@ -190,21 +195,31 @@ def train_ppo_hybrid(
                         nextnonterminal = 1.0 - rollout_dones_batch[t + 1]
                         nextvalues = rollout_values_batch[t + 1]
 
-                    delta = rollout_rewards_batch[t] + 0.99 * nextvalues * nextnonterminal - rollout_values_batch[t]
-                    advantages[t] = lastgaelam = delta + 0.99 * 0.95 * nextnonterminal * lastgaelam
+                    delta = (
+                        rollout_rewards_batch[t]
+                        + 0.99 * nextvalues * nextnonterminal
+                        - rollout_values_batch[t]
+                    )
+                    advantages[t] = lastgaelam = (
+                        delta + 0.99 * 0.95 * nextnonterminal * lastgaelam
+                    )
 
             returns = advantages + rollout_values_batch
 
             # Flatten batch
             b_obs = rollout_obs_batch.reshape(-1, rollout_obs_batch.shape[-1])
-            b_actions = rollout_actions_batch.reshape(-1, rollout_actions_batch.shape[-1])
+            b_actions = rollout_actions_batch.reshape(
+                -1, rollout_actions_batch.shape[-1]
+            )
             b_logprobs = rollout_logprobs_batch.reshape(-1)
             b_advantages = advantages.reshape(-1)
             b_returns = returns.reshape(-1)
             b_values = rollout_values_batch.reshape(-1)
 
             # Normalize advantages
-            b_advantages = (b_advantages - b_advantages.mean()) / (b_advantages.std() + 1e-8)
+            b_advantages = (b_advantages - b_advantages.mean()) / (
+                b_advantages.std() + 1e-8
+            )
 
             # Multiple epochs over the data
             batch_size = b_obs.shape[0]
@@ -220,7 +235,7 @@ def train_ppo_hybrid(
                     mb_logprobs = b_logprobs[mb_indices]
                     mb_advantages = b_advantages[mb_indices]
                     mb_returns = b_returns[mb_indices]
-                    mb_values = b_values[mb_indices]
+                    _mb_values = b_values[mb_indices]
 
                     # Forward pass
                     action_logits, new_values = policy(mb_obs)
@@ -242,7 +257,9 @@ def train_ppo_hybrid(
                     ratio = logratio.exp()
 
                     pg_loss1 = -mb_advantages * ratio
-                    pg_loss2 = -mb_advantages * torch.clamp(ratio, 1 - clip_epsilon, 1 + clip_epsilon)
+                    pg_loss2 = -mb_advantages * torch.clamp(
+                        ratio, 1 - clip_epsilon, 1 + clip_epsilon
+                    )
                     pg_loss = torch.max(pg_loss1, pg_loss2).mean()
 
                     value_loss = 0.5 * ((new_values - mb_returns) ** 2).mean()
@@ -276,56 +293,96 @@ def train_ppo_hybrid(
                 steps_per_sec = eval_interval / elapsed if elapsed > 0 else 0
                 progress = total_env_steps / num_steps * 100
 
-                print(f"Step {total_env_steps:,}/{num_steps:,} ({progress:.1f}%) | "
-                      f"Reward: {avg_reward:.2f} | "
-                      f"Length: {avg_length:.1f} | "
-                      f"Episodes: {len(completed_rewards)} | "
-                      f"Speed: {steps_per_sec:.0f} steps/s")
+                print(
+                    f"Step {total_env_steps:,}/{num_steps:,} ({progress:.1f}%) | "
+                    f"Reward: {avg_reward:.2f} | "
+                    f"Length: {avg_length:.1f} | "
+                    f"Episodes: {len(completed_rewards)} | "
+                    f"Speed: {steps_per_sec:.0f} steps/s"
+                )
 
                 if writer:
-                    writer.add_scalar("train/avg_reward_100ep", avg_reward, total_env_steps)
-                    writer.add_scalar("train/avg_length_100ep", avg_length, total_env_steps)
-                    writer.add_scalar("train/steps_per_sec", steps_per_sec, total_env_steps)
+                    writer.add_scalar(
+                        "train/avg_reward_100ep", avg_reward, total_env_steps
+                    )
+                    writer.add_scalar(
+                        "train/avg_length_100ep", avg_length, total_env_steps
+                    )
+                    writer.add_scalar(
+                        "train/steps_per_sec", steps_per_sec, total_env_steps
+                    )
 
         # === CHECKPOINTING ===
-        if checkpoint_dir and total_env_steps % checkpoint_interval < num_envs * rollout_length:
+        if (
+            checkpoint_dir
+            and total_env_steps % checkpoint_interval < num_envs * rollout_length
+        ):
             checkpoint_path = checkpoint_dir / f"checkpoint_step_{total_env_steps}.pt"
-            torch.save({
-                'step': total_env_steps,
-                'model_state_dict': policy.state_dict(),
-                'optimizer_state_dict': optimizer.state_dict(),
-                'episode_rewards': completed_rewards,
-                'episode_lengths': completed_lengths,
-            }, checkpoint_path)
+            torch.save(
+                {
+                    "step": total_env_steps,
+                    "model_state_dict": policy.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "episode_rewards": completed_rewards,
+                    "episode_lengths": completed_lengths,
+                },
+                checkpoint_path,
+            )
             print(f"💾 Saved checkpoint: {checkpoint_path}")
 
     total_time = time.time() - start_time
-    print(f"\n{'='*60}")
-    print(f"✅ Training Complete!")
-    print(f"⏱️  Total time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)")
+    print(f"\n{'=' * 60}")
+    print("✅ Training Complete!")
+    print(
+        f"⏱️  Total time: {total_time / 60:.1f} minutes ({total_time / 3600:.2f} hours)"
+    )
     print(f"📊 Total episodes: {len(completed_rewards)}")
     if completed_rewards:
-        print(f"📈 Final avg reward (last 100): {np.mean(completed_rewards[-100:]):.2f}")
-    print(f"⚡ Average speed: {total_env_steps/total_time:.0f} steps/s")
-    print(f"{'='*60}\n")
+        print(
+            f"📈 Final avg reward (last 100): {np.mean(completed_rewards[-100:]):.2f}"
+        )
+    print(f"⚡ Average speed: {total_env_steps / total_time:.0f} steps/s")
+    print(f"{'=' * 60}\n")
 
     return completed_rewards, completed_lengths
 
 
 def main():
     parser = argparse.ArgumentParser(description="Hybrid PufferLib + GPU PPO Training")
-    parser.add_argument("--steps", type=int, default=10000000, help="Total training steps")
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation", help="Scenario name")
+    parser.add_argument(
+        "--steps", type=int, default=10000000, help="Total training steps"
+    )
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
     parser.add_argument("--opponents", type=int, default=3, help="Number of opponents")
-    parser.add_argument("--num-envs", type=int, default=128, help="Parallel environments")
-    parser.add_argument("--num-cores", type=int, default=8, help="CPU cores for multiprocessing")
-    parser.add_argument("--rollout-length", type=int, default=128, help="Steps per rollout")
-    parser.add_argument("--minibatch-size", type=int, default=1024, help="Minibatch size for PPO updates")
+    parser.add_argument(
+        "--num-envs", type=int, default=128, help="Parallel environments"
+    )
+    parser.add_argument(
+        "--num-cores", type=int, default=8, help="CPU cores for multiprocessing"
+    )
+    parser.add_argument(
+        "--rollout-length", type=int, default=128, help="Steps per rollout"
+    )
+    parser.add_argument(
+        "--minibatch-size",
+        type=int,
+        default=1024,
+        help="Minibatch size for PPO updates",
+    )
     parser.add_argument("--epochs", type=int, default=4, help="Epochs per batch")
     parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate")
     parser.add_argument("--run-name", type=str, default=None, help="Run name")
-    parser.add_argument("--checkpoint-interval", type=int, default=100000, help="Steps between checkpoints")
-    parser.add_argument("--eval-interval", type=int, default=10000, help="Steps between eval prints")
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100000,
+        help="Steps between checkpoints",
+    )
+    parser.add_argument(
+        "--eval-interval", type=int, default=10000, help="Steps between eval prints"
+    )
     parser.add_argument("--cpu", action="store_true", help="Force CPU")
 
     args = parser.parse_args()
@@ -343,12 +400,12 @@ def main():
 
     # Save config
     config = vars(args).copy()
-    config['timestamp'] = timestamp
-    config['hybrid_pufferlib'] = True
-    with open(runs_dir / "config.json", 'w') as f:
+    config["timestamp"] = timestamp
+    config["hybrid_pufferlib"] = True
+    with open(runs_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
 
-    print(f"\n🎮 Creating PufferLib multiprocessing vectorized environment")
+    print("\n🎮 Creating PufferLib multiprocessing vectorized environment")
     print(f"   Scenario: {args.scenario}")
     print(f"   Opponents: {args.opponents}")
     print(f"   Num envs: {args.num_envs}")
@@ -359,7 +416,7 @@ def main():
         return make_rust_env(args.scenario, num_opponents=args.opponents)
 
     # Create PufferLib vectorized environment with multiprocessing
-    backend = 'multiprocessing' if args.num_cores > 1 else 'serial'
+    backend = "multiprocessing" if args.num_cores > 1 else "serial"
     print(f"   Backend: {backend}")
 
     vecenv = pufferlib.vector.make(
@@ -372,26 +429,25 @@ def main():
     # Device
     if args.cpu:
         device = torch.device("cpu")
-        print(f"🖥️  Using CPU (forced)")
+        print("🖥️  Using CPU (forced)")
     else:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         if device.type == "cuda":
             print(f"🚀 Using GPU: {torch.cuda.get_device_name(0)}")
         else:
-            print(f"🖥️  Using CPU (no GPU available)")
+            print("🖥️  Using CPU (no GPU available)")
 
     # Policy network
     single_env = env_creator()
     obs_space = single_env.observation_space
     action_space = single_env.action_space
 
-    print(f"\n🧠 Creating policy network")
+    print("\n🧠 Creating policy network")
     print(f"   Observation dim: {obs_space.shape[0]}")
     print(f"   Action dims: {action_space.nvec.tolist()}")
 
     policy = PolicyNetwork(
-        obs_dim=obs_space.shape[0],
-        action_dims=action_space.nvec.tolist()
+        obs_dim=obs_space.shape[0], action_dims=action_space.nvec.tolist()
     ).to(device)
 
     optimizer = optim.Adam(policy.parameters(), lr=args.lr)
@@ -399,7 +455,7 @@ def main():
     # TensorBoard
     writer = SummaryWriter(runs_dir)
     print(f"📊 TensorBoard: {runs_dir}")
-    print(f"   View with: tensorboard --logdir experiments/marl/runs/")
+    print("   View with: tensorboard --logdir experiments/marl/runs/")
 
     # Train
     episode_rewards, episode_lengths = train_ppo_hybrid(

--- a/experiments/marl/train_pufferlib.py
+++ b/experiments/marl/train_pufferlib.py
@@ -20,6 +20,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -37,13 +38,31 @@ from bucket_brigade.training import PolicyNetwork
 
 def main():
     parser = argparse.ArgumentParser(description="PufferLib Native Training")
-    parser.add_argument("--total-timesteps", type=int, default=10000000, help="Total training timesteps")
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation", help="Scenario name")
+    parser.add_argument(
+        "--total-timesteps", type=int, default=10000000, help="Total training timesteps"
+    )
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
     parser.add_argument("--opponents", type=int, default=3, help="Number of opponents")
-    parser.add_argument("--num-envs", type=int, default=64, help="Parallel environments")
-    parser.add_argument("--num-cores", type=int, default=1, help="CPU cores (1=serial, >1=multiprocessing)")
-    parser.add_argument("--batch-size", type=int, default=65536, help="Batch size (num_envs * num_steps)")
-    parser.add_argument("--learning-rate", type=float, default=3e-4, help="Learning rate")
+    parser.add_argument(
+        "--num-envs", type=int, default=64, help="Parallel environments"
+    )
+    parser.add_argument(
+        "--num-cores",
+        type=int,
+        default=1,
+        help="CPU cores (1=serial, >1=multiprocessing)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=65536,
+        help="Batch size (num_envs * num_steps)",
+    )
+    parser.add_argument(
+        "--learning-rate", type=float, default=3e-4, help="Learning rate"
+    )
     parser.add_argument("--run-name", type=str, default=None, help="Run name")
     parser.add_argument("--cpu", action="store_true", help="Force CPU")
 
@@ -62,23 +81,25 @@ def main():
 
     # Save config
     config = vars(args).copy()
-    config['timestamp'] = timestamp
-    config['pufferlib_native'] = True
-    with open(runs_dir / "config.json", 'w') as f:
+    config["timestamp"] = timestamp
+    config["pufferlib_native"] = True
+    with open(runs_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
 
-    print(f"\n🎮 Creating PufferLib vectorized environment")
+    print("\n🎮 Creating PufferLib vectorized environment")
     print(f"   Scenario: {args.scenario}")
     print(f"   Opponents: {args.opponents}")
     print(f"   Num envs: {args.num_envs}")
-    print(f"   Cores: {args.num_cores} ({'serial' if args.num_cores == 1 else 'multiprocessing'})")
+    print(
+        f"   Cores: {args.num_cores} ({'serial' if args.num_cores == 1 else 'multiprocessing'})"
+    )
 
     # Environment creator
     def env_creator(name=None):
         return make_rust_env(args.scenario, num_opponents=args.opponents)
 
     # Create vectorized environment using PufferLib
-    backend = 'serial' if args.num_cores == 1 else 'multiprocessing'
+    backend = "serial" if args.num_cores == 1 else "multiprocessing"
     vecenv = pufferlib.vector.make(
         env_creator,
         num_envs=args.num_envs,
@@ -89,44 +110,41 @@ def main():
     # Device
     if args.cpu:
         device = "cpu"
-        print(f"🖥️  Using CPU (forced)")
+        print("🖥️  Using CPU (forced)")
     else:
         device = "cuda" if torch.cuda.is_available() else "cpu"
         if device == "cuda":
             print(f"🚀 Using GPU: {torch.cuda.get_device_name(0)}")
         else:
-            print(f"🖥️  Using CPU (no GPU available)")
+            print("🖥️  Using CPU (no GPU available)")
 
     # Policy network
     single_env = env_creator()
     obs_space = single_env.observation_space
     action_space = single_env.action_space
 
-    print(f"\n🧠 Creating policy network")
+    print("\n🧠 Creating policy network")
     print(f"   Observation dim: {obs_space.shape[0]}")
     print(f"   Action dims: {action_space.nvec.tolist()}")
 
     policy = PolicyNetwork(
-        obs_dim=obs_space.shape[0],
-        action_dims=action_space.nvec.tolist()
+        obs_dim=obs_space.shape[0], action_dims=action_space.nvec.tolist()
     ).to(device)
 
     print(f"\n📊 TensorBoard: {runs_dir}")
-    print(f"   View with: tensorboard --logdir experiments/marl/runs/")
+    print("   View with: tensorboard --logdir experiments/marl/runs/")
 
     # PufferLib CleanRL PPO config
     config = pufferlib.namespace(
         # Environment settings
         num_envs=args.num_envs,
         env_pool=False,
-
         # Training settings
         total_timesteps=args.total_timesteps,
         learning_rate=args.learning_rate,
         batch_size=args.batch_size,
         batch_rows=args.batch_size // args.num_envs,  # num_steps
         bptt_horizon=16,
-
         # PPO settings
         num_minibatches=4,
         update_epochs=4,
@@ -136,36 +154,33 @@ def main():
         max_grad_norm=0.5,
         gamma=0.99,
         gae_lambda=0.95,
-
         # Logging
         log_frequency=100,
         eval_frequency=0,
         checkpoint_interval=100000,
-
         # Paths
         runs_dir=str(runs_dir),
         checkpoint_dir=str(checkpoint_dir),
-
         # Device
         device=device,
         compile=False,
-        compile_mode='default',
+        compile_mode="default",
     )
 
-    print(f"\n{'='*60}")
-    print(f"🚀 Starting PufferLib CleanRL PPO Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🚀 Starting PufferLib CleanRL PPO Training")
+    print(f"{'=' * 60}")
     print(f"📊 Total timesteps: {args.total_timesteps:,}")
     print(f"🌍 Parallel environments: {args.num_envs}")
     print(f"📦 Batch size: {args.batch_size:,}")
     print(f"📦 Batch rows (steps per env): {config.batch_rows}")
     print(f"🔁 Update epochs: {config.update_epochs}")
     print(f"🖥️  Device: {device}")
-    print(f"⚡ Expected GPU util: 80-90%")
-    print(f"{'='*60}\n")
+    print("⚡ Expected GPU util: 80-90%")
+    print(f"{'=' * 60}\n")
 
     # Train using PufferLib's CleanRL PPO
-    data = pufferlib.frameworks.cleanrl.train(
+    pufferlib.frameworks.cleanrl.train(
         vecenv=vecenv,
         agent=policy,
         config=config,

--- a/experiments/marl/train_rust_vectorized.py
+++ b/experiments/marl/train_rust_vectorized.py
@@ -26,6 +26,7 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
@@ -36,7 +37,6 @@ import time
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from bucket_brigade_core import VectorEnv, SCENARIOS
@@ -50,7 +50,7 @@ def collect_rollout(
     device,
 ):
     """Collect a rollout from vectorized environment."""
-    num_envs = vecenv.num_envs
+    _num_envs = vecenv.num_envs
 
     # Storage
     obs_batch = []
@@ -112,12 +112,12 @@ def collect_rollout(
     logprob_batch = torch.stack(logprob_batch)  # [num_steps, num_envs]
 
     return {
-        'obs': obs_batch,
-        'actions': action_batch,
-        'rewards': reward_batch,
-        'dones': done_batch,
-        'values': value_batch,
-        'logprobs': logprob_batch,
+        "obs": obs_batch,
+        "actions": action_batch,
+        "rewards": reward_batch,
+        "dones": done_batch,
+        "values": value_batch,
+        "logprobs": logprob_batch,
     }
 
 
@@ -149,9 +149,9 @@ def train_ppo(
     num_updates = total_timesteps // (num_steps * num_envs)
     minibatch_size = (num_steps * num_envs) // num_minibatches
 
-    print(f"\n{'='*60}")
-    print(f"🚀 Starting Rust-Vectorized PPO Training")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("🚀 Starting Rust-Vectorized PPO Training")
+    print(f"{'=' * 60}")
     print(f"📊 Total timesteps: {total_timesteps:,}")
     print(f"🌍 Num environments: {num_envs}")
     print(f"📦 Steps per rollout: {num_steps}")
@@ -160,11 +160,11 @@ def train_ppo(
     print(f"💾 Checkpoint interval: {checkpoint_interval:,} steps")
     print(f"📈 Eval interval: {eval_interval:,} steps")
     print(f"🖥️  Device: {device}")
-    print(f"⚡ Using Rust VectorEnv for maximum speed!")
-    print(f"{'='*60}\n")
+    print("⚡ Using Rust VectorEnv for maximum speed!")
+    print(f"{'=' * 60}\n")
 
     global_step = 0
-    episode_rewards = []
+    _episode_rewards = []
     start_time = time.time()
     last_eval_time = start_time
 
@@ -184,25 +184,27 @@ def train_ppo(
             next_values = next_values.squeeze(-1).cpu()
 
         advantages = compute_gae(
-            rollout['rewards'],
-            rollout['values'],
-            rollout['dones'],
+            rollout["rewards"],
+            rollout["values"],
+            rollout["dones"],
             next_values,
             gamma,
             gae_lambda,
         )
-        returns = advantages + rollout['values']
+        returns = advantages + rollout["values"]
 
         # Flatten batch dimensions
-        b_obs = rollout['obs'].reshape(-1, *rollout['obs'].shape[2:])
-        b_actions = rollout['actions'].reshape(-1, *rollout['actions'].shape[2:])
-        b_logprobs = rollout['logprobs'].reshape(-1)
+        b_obs = rollout["obs"].reshape(-1, *rollout["obs"].shape[2:])
+        b_actions = rollout["actions"].reshape(-1, *rollout["actions"].shape[2:])
+        b_logprobs = rollout["logprobs"].reshape(-1)
         b_advantages = advantages.reshape(-1)
         b_returns = returns.reshape(-1)
-        b_values = rollout['values'].reshape(-1)
+        _b_values = rollout["values"].reshape(-1)
 
         # Normalize advantages
-        b_advantages = (b_advantages - b_advantages.mean()) / (b_advantages.std() + 1e-8)
+        b_advantages = (b_advantages - b_advantages.mean()) / (
+            b_advantages.std() + 1e-8
+        )
 
         # PPO update
         update_start = time.time()
@@ -239,7 +241,10 @@ def train_ppo(
                 # PPO loss
                 ratio = torch.exp(new_logprobs - mb_logprobs)
                 surr1 = ratio * mb_advantages
-                surr2 = torch.clamp(ratio, 1 - clip_epsilon, 1 + clip_epsilon) * mb_advantages
+                surr2 = (
+                    torch.clamp(ratio, 1 - clip_epsilon, 1 + clip_epsilon)
+                    * mb_advantages
+                )
                 policy_loss = -torch.min(surr1, surr2).mean()
 
                 # Value loss
@@ -268,7 +273,9 @@ def train_ppo(
             writer.add_scalar("train/entropy", entropy.item(), global_step)
             writer.add_scalar("train/rollout_time", rollout_time, global_step)
             writer.add_scalar("train/update_time", update_time, global_step)
-            writer.add_scalar("train/mean_reward", rollout['rewards'].mean().item(), global_step)
+            writer.add_scalar(
+                "train/mean_reward", rollout["rewards"].mean().item(), global_step
+            )
 
         # Evaluation logging
         if (update + 1) % (eval_interval // (num_steps * num_envs)) == 0:
@@ -277,45 +284,78 @@ def train_ppo(
 
             steps_per_sec = eval_interval / elapsed
             progress = global_step / total_timesteps * 100
-            mean_reward = rollout['rewards'].mean().item()
+            mean_reward = rollout["rewards"].mean().item()
 
-            print(f"Step {global_step:,}/{total_timesteps:,} ({progress:.1f}%) | "
-                  f"Reward: {mean_reward:.3f} | "
-                  f"Rollout: {rollout_time:.2f}s | "
-                  f"Update: {update_time:.2f}s | "
-                  f"Speed: {steps_per_sec:.0f} steps/s")
+            print(
+                f"Step {global_step:,}/{total_timesteps:,} ({progress:.1f}%) | "
+                f"Reward: {mean_reward:.3f} | "
+                f"Rollout: {rollout_time:.2f}s | "
+                f"Update: {update_time:.2f}s | "
+                f"Speed: {steps_per_sec:.0f} steps/s"
+            )
 
         # Checkpointing
         if checkpoint_dir and (global_step % checkpoint_interval == 0):
             checkpoint_path = checkpoint_dir / f"checkpoint_step_{global_step}.pt"
-            torch.save({
-                'step': global_step,
-                'model_state_dict': policy.state_dict(),
-                'optimizer_state_dict': optimizer.state_dict(),
-            }, checkpoint_path)
+            torch.save(
+                {
+                    "step": global_step,
+                    "model_state_dict": policy.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                },
+                checkpoint_path,
+            )
             print(f"💾 Saved checkpoint: {checkpoint_path}")
 
     total_time = time.time() - start_time
-    print(f"\n{'='*60}")
-    print(f"✅ Training Complete!")
-    print(f"⏱️  Total time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)")
-    print(f"⚡ Avg speed: {total_timesteps/total_time:.0f} steps/s")
-    print(f"{'='*60}\n")
+    print(f"\n{'=' * 60}")
+    print("✅ Training Complete!")
+    print(
+        f"⏱️  Total time: {total_time / 60:.1f} minutes ({total_time / 3600:.2f} hours)"
+    )
+    print(f"⚡ Avg speed: {total_timesteps / total_time:.0f} steps/s")
+    print(f"{'=' * 60}\n")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Train PPO with Rust VectorEnv")
-    parser.add_argument("--total-timesteps", type=int, default=10000000, help="Total training timesteps")
-    parser.add_argument("--scenario", type=str, default="trivial_cooperation", help="Scenario name")
-    parser.add_argument("--num-envs", type=int, default=256, help="Number of parallel environments")
-    parser.add_argument("--num-agents", type=int, default=4, help="Number of agents per environment")
+    parser.add_argument(
+        "--total-timesteps", type=int, default=10000000, help="Total training timesteps"
+    )
+    parser.add_argument(
+        "--scenario", type=str, default="trivial_cooperation", help="Scenario name"
+    )
+    parser.add_argument(
+        "--num-envs", type=int, default=256, help="Number of parallel environments"
+    )
+    parser.add_argument(
+        "--num-agents", type=int, default=4, help="Number of agents per environment"
+    )
     parser.add_argument("--num-steps", type=int, default=256, help="Steps per rollout")
-    parser.add_argument("--num-epochs", type=int, default=4, help="PPO epochs per update")
-    parser.add_argument("--num-minibatches", type=int, default=4, help="Number of minibatches")
-    parser.add_argument("--learning-rate", type=float, default=3e-4, help="Learning rate")
-    parser.add_argument("--hidden-size", type=int, default=4096, help="Hidden layer size (large for GPU util)")
-    parser.add_argument("--checkpoint-interval", type=int, default=100000, help="Steps between checkpoints")
-    parser.add_argument("--eval-interval", type=int, default=10000, help="Steps between eval prints")
+    parser.add_argument(
+        "--num-epochs", type=int, default=4, help="PPO epochs per update"
+    )
+    parser.add_argument(
+        "--num-minibatches", type=int, default=4, help="Number of minibatches"
+    )
+    parser.add_argument(
+        "--learning-rate", type=float, default=3e-4, help="Learning rate"
+    )
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=4096,
+        help="Hidden layer size (large for GPU util)",
+    )
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=100000,
+        help="Steps between checkpoints",
+    )
+    parser.add_argument(
+        "--eval-interval", type=int, default=10000, help="Steps between eval prints"
+    )
     parser.add_argument("--run-name", type=str, default=None, help="Run name")
     parser.add_argument("--cpu", action="store_true", help="Force CPU")
     parser.add_argument("--seed", type=int, default=None, help="Random seed")
@@ -335,12 +375,12 @@ def main():
 
     # Save config
     config = vars(args).copy()
-    config['timestamp'] = timestamp
-    config['rust_vectorized'] = True
-    with open(runs_dir / "config.json", 'w') as f:
+    config["timestamp"] = timestamp
+    config["rust_vectorized"] = True
+    with open(runs_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
 
-    print(f"\n🎮 Creating Rust VectorEnv")
+    print("\n🎮 Creating Rust VectorEnv")
     print(f"   Scenario: {args.scenario}")
     print(f"   Num environments: {args.num_envs}")
     print(f"   Num agents: {args.num_agents}")
@@ -362,7 +402,7 @@ def main():
             print("🖥️  Using CPU (no GPU available)")
 
     # Policy network (large for GPU utilization)
-    print(f"\n🧠 Creating policy network")
+    print("\n🧠 Creating policy network")
     print(f"   Hidden size: {args.hidden_size} (large for GPU utilization)")
 
     # Get observation shape from a test reset
@@ -393,7 +433,7 @@ def main():
     # TensorBoard
     writer = SummaryWriter(runs_dir)
     print(f"📊 TensorBoard: {runs_dir}")
-    print(f"   View with: tensorboard --logdir experiments/marl/runs/")
+    print("   View with: tensorboard --logdir experiments/marl/runs/")
 
     # Train
     train_ppo(

--- a/experiments/marl/train_vectorized_population.py
+++ b/experiments/marl/train_vectorized_population.py
@@ -35,16 +35,15 @@ Usage:
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import argparse
 from datetime import datetime
-import json
 import time
-from typing import List, Dict, Tuple
+from typing import List, Dict
 
 import torch
-import torch.nn as nn
 import torch.optim as optim
 import numpy as np
 
@@ -52,7 +51,9 @@ from bucket_brigade_core import VectorEnv, SCENARIOS
 from bucket_brigade.training import PolicyNetwork, compute_gae
 
 
-def sample_matchups(population_size: int, num_envs: int, num_agents_per_game: int) -> np.ndarray:
+def sample_matchups(
+    population_size: int, num_envs: int, num_agents_per_game: int
+) -> np.ndarray:
     """
     Sample agent matchups for parallel games.
 
@@ -64,7 +65,9 @@ def sample_matchups(population_size: int, num_envs: int, num_agents_per_game: in
     Returns:
         assignments: [num_envs, num_agents_per_game] array of agent IDs
     """
-    assignments = np.random.randint(0, population_size, size=(num_envs, num_agents_per_game))
+    assignments = np.random.randint(
+        0, population_size, size=(num_envs, num_agents_per_game)
+    )
     return assignments
 
 
@@ -85,14 +88,17 @@ def collect_vectorized_rollout(
     num_envs, num_agents_per_game = agent_assignments.shape
 
     # Storage per policy
-    policy_data = {i: {
-        'obs': [],
-        'actions': [],
-        'rewards': [],
-        'dones': [],
-        'values': [],
-        'logprobs': [],
-    } for i in range(len(policies))}
+    policy_data = {
+        i: {
+            "obs": [],
+            "actions": [],
+            "rewards": [],
+            "dones": [],
+            "values": [],
+            "logprobs": [],
+        }
+        for i in range(len(policies))
+    }
 
     # Reset environments
     obs = np.array(vecenv.reset())  # [num_envs, num_agents, obs_dim]
@@ -102,8 +108,12 @@ def collect_vectorized_rollout(
         obs_tensor = torch.FloatTensor(obs).to(device)
 
         # Collect actions from all policies
-        houses = torch.zeros(num_envs, num_agents_per_game, dtype=torch.long, device=device)
-        modes = torch.zeros(num_envs, num_agents_per_game, dtype=torch.long, device=device)
+        houses = torch.zeros(
+            num_envs, num_agents_per_game, dtype=torch.long, device=device
+        )
+        modes = torch.zeros(
+            num_envs, num_agents_per_game, dtype=torch.long, device=device
+        )
         all_values = torch.zeros(num_envs, num_agents_per_game, device=device)
         all_logprobs = torch.zeros(num_envs, num_agents_per_game, device=device)
 
@@ -113,7 +123,9 @@ def collect_vectorized_rollout(
                     policy_id = agent_assignments[env_idx, agent_idx]
                     policy = policies[policy_id]
 
-                    agent_obs = obs_tensor[env_idx, agent_idx:agent_idx+1]  # [1, obs_dim]
+                    agent_obs = obs_tensor[
+                        env_idx, agent_idx : agent_idx + 1
+                    ]  # [1, obs_dim]
                     action_logits, value = policy(agent_obs)
 
                     # Sample action
@@ -135,10 +147,9 @@ def collect_vectorized_rollout(
                     all_logprobs[env_idx, agent_idx] = house_logprob + mode_logprob
 
         # Step environments
-        actions = np.stack([
-            houses.cpu().numpy(),
-            modes.cpu().numpy()
-        ], axis=-1)  # [num_envs, num_agents, 2]
+        actions = np.stack(
+            [houses.cpu().numpy(), modes.cpu().numpy()], axis=-1
+        )  # [num_envs, num_agents, 2]
 
         next_obs, rewards, dones, _ = vecenv.step(actions)
         next_obs = np.array(next_obs)
@@ -150,34 +161,38 @@ def collect_vectorized_rollout(
             for agent_idx in range(num_agents_per_game):
                 policy_id = agent_assignments[env_idx, agent_idx]
 
-                policy_data[policy_id]['obs'].append(obs[env_idx, agent_idx])
-                policy_data[policy_id]['actions'].append(actions[env_idx, agent_idx])
-                policy_data[policy_id]['rewards'].append(rewards[env_idx, agent_idx])
-                policy_data[policy_id]['dones'].append(dones[env_idx])
-                policy_data[policy_id]['values'].append(all_values[env_idx, agent_idx].item())
-                policy_data[policy_id]['logprobs'].append(all_logprobs[env_idx, agent_idx].item())
+                policy_data[policy_id]["obs"].append(obs[env_idx, agent_idx])
+                policy_data[policy_id]["actions"].append(actions[env_idx, agent_idx])
+                policy_data[policy_id]["rewards"].append(rewards[env_idx, agent_idx])
+                policy_data[policy_id]["dones"].append(dones[env_idx])
+                policy_data[policy_id]["values"].append(
+                    all_values[env_idx, agent_idx].item()
+                )
+                policy_data[policy_id]["logprobs"].append(
+                    all_logprobs[env_idx, agent_idx].item()
+                )
 
         obs = next_obs
 
     # Compute advantages for each policy
     for policy_id, data in policy_data.items():
-        if len(data['obs']) == 0:
+        if len(data["obs"]) == 0:
             continue
 
-        rewards = np.array(data['rewards'])
-        values = np.array(data['values'])
-        dones = np.array(data['dones'])
+        rewards = np.array(data["rewards"])
+        values = np.array(data["values"])
+        dones = np.array(data["dones"])
 
         # Compute GAE
         advantages = compute_gae(rewards, values, dones, gamma, gae_lambda)
         returns = advantages + values
 
         # Convert to tensors
-        data['obs'] = torch.FloatTensor(np.array(data['obs'])).to(device)
-        data['actions'] = torch.LongTensor(np.array(data['actions'])).to(device)
-        data['old_logprobs'] = torch.FloatTensor(np.array(data['logprobs'])).to(device)
-        data['advantages'] = torch.FloatTensor(advantages).to(device)
-        data['returns'] = torch.FloatTensor(returns).to(device)
+        data["obs"] = torch.FloatTensor(np.array(data["obs"])).to(device)
+        data["actions"] = torch.LongTensor(np.array(data["actions"])).to(device)
+        data["old_logprobs"] = torch.FloatTensor(np.array(data["logprobs"])).to(device)
+        data["advantages"] = torch.FloatTensor(advantages).to(device)
+        data["returns"] = torch.FloatTensor(returns).to(device)
 
     return policy_data
 
@@ -193,14 +208,14 @@ def train_policy_ppo(
     entropy_coef: float = 0.01,
 ):
     """Train single policy with PPO on collected experiences."""
-    if batch_data['obs'].shape[0] == 0:
+    if batch_data["obs"].shape[0] == 0:
         return {}
 
-    obs = batch_data['obs']
-    actions = batch_data['actions']
-    old_logprobs = batch_data['old_logprobs']
-    advantages = batch_data['advantages']
-    returns = batch_data['returns']
+    obs = batch_data["obs"]
+    actions = batch_data["actions"]
+    old_logprobs = batch_data["old_logprobs"]
+    advantages = batch_data["advantages"]
+    returns = batch_data["returns"]
 
     # Normalize advantages
     advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
@@ -268,10 +283,10 @@ def train_policy_ppo(
             num_updates += 1
 
     return {
-        'loss': total_loss / num_updates if num_updates > 0 else 0,
-        'policy_loss': total_policy_loss / num_updates if num_updates > 0 else 0,
-        'value_loss': total_value_loss / num_updates if num_updates > 0 else 0,
-        'entropy': total_entropy / num_updates if num_updates > 0 else 0,
+        "loss": total_loss / num_updates if num_updates > 0 else 0,
+        "policy_loss": total_policy_loss / num_updates if num_updates > 0 else 0,
+        "value_loss": total_value_loss / num_updates if num_updates > 0 else 0,
+        "entropy": total_entropy / num_updates if num_updates > 0 else 0,
     }
 
 
@@ -280,39 +295,50 @@ def main():
 
     # Environment
     parser.add_argument("--scenario", type=str, default="trivial_cooperation")
-    parser.add_argument("--num-envs", type=int, default=256,
-                        help="Number of parallel environments")
-    parser.add_argument("--num-agents-per-game", type=int, default=4,
-                        help="Agents per game (from scenario)")
+    parser.add_argument(
+        "--num-envs", type=int, default=256, help="Number of parallel environments"
+    )
+    parser.add_argument(
+        "--num-agents-per-game",
+        type=int,
+        default=4,
+        help="Agents per game (from scenario)",
+    )
 
     # Population
-    parser.add_argument("--population-size", type=int, default=8,
-                        help="Number of agents in population")
+    parser.add_argument(
+        "--population-size", type=int, default=8, help="Number of agents in population"
+    )
 
     # Training
-    parser.add_argument("--total-timesteps", type=int, default=1000000,
-                        help="Total training timesteps")
-    parser.add_argument("--rollout-length", type=int, default=256,
-                        help="Steps per rollout")
-    parser.add_argument("--batch-size", type=int, default=1024,
-                        help="PPO minibatch size")
-    parser.add_argument("--num-epochs", type=int, default=4,
-                        help="PPO epochs per rollout")
+    parser.add_argument(
+        "--total-timesteps", type=int, default=1000000, help="Total training timesteps"
+    )
+    parser.add_argument(
+        "--rollout-length", type=int, default=256, help="Steps per rollout"
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=1024, help="PPO minibatch size"
+    )
+    parser.add_argument(
+        "--num-epochs", type=int, default=4, help="PPO epochs per rollout"
+    )
 
     # Network
-    parser.add_argument("--hidden-size", type=int, default=1024,
-                        help="Policy network hidden size")
+    parser.add_argument(
+        "--hidden-size", type=int, default=1024, help="Policy network hidden size"
+    )
     parser.add_argument("--learning-rate", type=float, default=3e-4)
 
     # System
-    parser.add_argument("--device", type=str, default="cuda",
-                        choices=["cuda", "cpu"])
+    parser.add_argument("--device", type=str, default="cuda", choices=["cuda", "cpu"])
     parser.add_argument("--seed", type=int, default=None)
 
     # Logging
     parser.add_argument("--run-name", type=str, default=None)
-    parser.add_argument("--log-interval", type=int, default=10,
-                        help="Log every N rollouts")
+    parser.add_argument(
+        "--log-interval", type=int, default=10, help="Log every N rollouts"
+    )
 
     args = parser.parse_args()
 
@@ -379,7 +405,9 @@ def main():
     print()
 
     # Training loop
-    total_rollouts = args.total_timesteps // (args.rollout_length * args.num_envs * args.num_agents_per_game)
+    total_rollouts = args.total_timesteps // (
+        args.rollout_length * args.num_envs * args.num_agents_per_game
+    )
 
     print(f"Starting training: {total_rollouts} rollouts")
     print()
@@ -405,7 +433,7 @@ def main():
 
         # Train each policy
         for policy_id in range(args.population_size):
-            if len(policy_data[policy_id]['obs']) > 0:
+            if len(policy_data[policy_id]["obs"]) > 0:
                 train_policy_ppo(
                     policies[policy_id],
                     optimizers[policy_id],
@@ -417,25 +445,34 @@ def main():
         # Logging
         if (rollout_idx + 1) % args.log_interval == 0:
             elapsed = time.time() - start_time
-            timesteps = (rollout_idx + 1) * args.rollout_length * args.num_envs * args.num_agents_per_game
+            timesteps = (
+                (rollout_idx + 1)
+                * args.rollout_length
+                * args.num_envs
+                * args.num_agents_per_game
+            )
             steps_per_sec = timesteps / elapsed
 
             # Compute average reward across population
-            avg_reward = np.mean([
-                np.mean(policy_data[i]['rewards'])
-                for i in range(args.population_size)
-                if len(policy_data[i]['rewards']) > 0
-            ])
+            avg_reward = np.mean(
+                [
+                    np.mean(policy_data[i]["rewards"])
+                    for i in range(args.population_size)
+                    if len(policy_data[i]["rewards"]) > 0
+                ]
+            )
 
-            print(f"Rollout {rollout_idx + 1}/{total_rollouts} | "
-                  f"Timesteps: {timesteps:,} | "
-                  f"Speed: {steps_per_sec:.0f} steps/s | "
-                  f"Avg Reward: {avg_reward:.3f}")
+            print(
+                f"Rollout {rollout_idx + 1}/{total_rollouts} | "
+                f"Timesteps: {timesteps:,} | "
+                f"Speed: {steps_per_sec:.0f} steps/s | "
+                f"Avg Reward: {avg_reward:.3f}"
+            )
 
     elapsed = time.time() - start_time
     print()
     print("=" * 60)
-    print(f"✓ Training complete!")
+    print("✓ Training complete!")
     print(f"Total time: {elapsed:.1f}s")
     print(f"Average speed: {args.total_timesteps / elapsed:.0f} steps/s")
     print("=" * 60)

--- a/experiments/p3_specialization/analyze.py
+++ b/experiments/p3_specialization/analyze.py
@@ -13,6 +13,7 @@ The falsifiers (from ``research_notebook/2026-05-13_p3_specialization_plan.md``)
 If F1 fails or F2 holds, P3 is falsified --- which is itself a publishable
 result.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -40,7 +41,11 @@ def _bootstrap_mean_ci(
         idx = rng.integers(0, n, size=n)
         boots[b] = values[idx].mean()
     alpha = (1.0 - confidence) / 2.0
-    return point, float(np.quantile(boots, alpha)), float(np.quantile(boots, 1.0 - alpha))
+    return (
+        point,
+        float(np.quantile(boots, alpha)),
+        float(np.quantile(boots, 1.0 - alpha)),
+    )
 
 
 def _load_cell(cell_dir: Path) -> Dict[str, object] | None:
@@ -73,9 +78,7 @@ def _load_cell(cell_dir: Path) -> Dict[str, object] | None:
         with dropout_path.open() as f:
             dr = json.load(f)
         base = dr["none"]["mean"]
-        agent_means = [
-            dr[k]["mean"] for k in dr if k.startswith("agent_")
-        ]
+        agent_means = [dr[k]["mean"] for k in dr if k.startswith("agent_")]
         out["dropout_baseline"] = base
         # Mean drop in team reward when any single agent is removed.
         out["dropout_mean_drop"] = float(base - np.mean(agent_means))
@@ -156,7 +159,9 @@ def evaluate_falsifiers(
         if baseline is None:
             v["F2_reward_always_worse"] = "insufficient"
         else:
-            penalised = {lam: r for lam, r in rewards.items() if lam > 0.0 and r is not None}
+            penalised = {
+                lam: r for lam, r in rewards.items() if lam > 0.0 and r is not None
+            }
             if not penalised:
                 v["F2_reward_always_worse"] = "insufficient"
             else:
@@ -208,22 +213,25 @@ def _print_summary(
 
 def main() -> None:
     p = argparse.ArgumentParser()
-    p.add_argument("--sweep-root", type=Path,
-                   default=Path("experiments/p3_specialization/runs"))
-    p.add_argument("--output", type=Path,
-                   default=Path("experiments/p3_specialization/analysis.json"))
+    p.add_argument(
+        "--sweep-root", type=Path, default=Path("experiments/p3_specialization/runs")
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/p3_specialization/analysis.json"),
+    )
     args = p.parse_args()
 
     agg = aggregate(args.sweep_root)
     verdicts = evaluate_falsifiers(agg)
 
-    serializable = {
-        f"{scenario}__{lam}": data for (scenario, lam), data in agg.items()
-    }
+    serializable = {f"{scenario}__{lam}": data for (scenario, lam), data in agg.items()}
     with args.output.open("w") as f:
         json.dump(
             {"aggregate": serializable, "falsifiers": verdicts},
-            f, indent=2,
+            f,
+            indent=2,
         )
 
     _print_summary(agg, verdicts)

--- a/experiments/p3_specialization/analyze_plateau.py
+++ b/experiments/p3_specialization/analyze_plateau.py
@@ -26,6 +26,7 @@ Usage::
 
     uv run python experiments/p3_specialization/analyze_plateau.py
 """
+
 from __future__ import annotations
 
 import argparse
@@ -35,6 +36,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import matplotlib
+
 matplotlib.use("Agg")  # headless
 import matplotlib.pyplot as plt
 import numpy as np
@@ -140,11 +142,21 @@ def plot_reward_vs_baseline(
 
         bl = BASELINES.get(scen, {})
         if "random" in bl:
-            ax.axhline(bl["random"], color="black", linestyle="--",
-                       alpha=0.6, label=f"random = {bl['random']:.0f}")
+            ax.axhline(
+                bl["random"],
+                color="black",
+                linestyle="--",
+                alpha=0.6,
+                label=f"random = {bl['random']:.0f}",
+            )
         if "heuristic" in bl and bl["heuristic"] != bl.get("random"):
-            ax.axhline(bl["heuristic"], color="dimgray", linestyle=":",
-                       alpha=0.6, label=f"heuristic = {bl['heuristic']:.0f}")
+            ax.axhline(
+                bl["heuristic"],
+                color="dimgray",
+                linestyle=":",
+                alpha=0.6,
+                label=f"heuristic = {bl['heuristic']:.0f}",
+            )
 
         ax.set_title(f"{scen} (lambda_red=0)")
         ax.set_xlabel("iteration")
@@ -179,8 +191,7 @@ def plot_entropy_per_agent(
                 continue
             iters = np.arange(arr.shape[1])
             mean, lo, hi = _mean_iqr(arr)
-            ax.plot(iters, mean, color=agent_colors[ai],
-                    label=f"agent_{ai}")
+            ax.plot(iters, mean, color=agent_colors[ai], label=f"agent_{ai}")
             ax.fill_between(iters, lo, hi, color=agent_colors[ai], alpha=0.15)
         ax.set_title(f"{scen} (lambda_red=0)")
         ax.set_xlabel("iteration")
@@ -255,6 +266,7 @@ def plot_loss_decomposition(
         if scen not in data:
             ax.set_title(f"{scen} (no data)")
             continue
+
         # Aggregate over agents (mean) then over seeds.
         def agg(prefix: str) -> np.ndarray:
             per_agent = []
@@ -307,16 +319,16 @@ def plot_loss_term_scales(
 
     Companion to plot_loss_decomposition for a quick visual on dominance.
     """
-    scenarios = [s for s in ["trivial_cooperation", "default", "chain_reaction"]
-                 if s in data]
+    scenarios = [
+        s for s in ["trivial_cooperation", "default", "chain_reaction"] if s in data
+    ]
     if not scenarios:
         return
     fig, ax = plt.subplots(figsize=(11, 5))
-    xs = np.arange(len(scenarios) * 2)  # iter0 then iter_last per scenario
+    _xs = np.arange(len(scenarios) * 2)  # iter0 then iter_last per scenario
     width = 0.25
 
-    def agg_term(metrics_list: List[List[dict]], prefix: str,
-                 iter_idx: int) -> float:
+    def agg_term(metrics_list: List[List[dict]], prefix: str, iter_idx: int) -> float:
         vals = []
         for m in metrics_list:
             if iter_idx >= len(m):
@@ -344,7 +356,9 @@ def plot_loss_term_scales(
     x = np.arange(len(labels))
     ax.bar(x - width, pol_bars, width, label="|policy_loss|", color="tab:blue")
     ax.bar(x, val_bars, width, label="value_coef * value_loss", color="tab:red")
-    ax.bar(x + width, ent_bars, width, label="entropy_coef * entropy", color="tab:green")
+    ax.bar(
+        x + width, ent_bars, width, label="entropy_coef * entropy", color="tab:green"
+    )
     ax.set_yscale("log")
     ax.set_xticks(x)
     ax.set_xticklabels(labels, fontsize=9, rotation=0)
@@ -394,25 +408,25 @@ def write_summary(
         lines.append(f"## {scen}")
         lines.append(f"- n_seeds = {n_seeds}, n_iters = {n_iters}")
         lines.append(
-            f"- reward iter 0 -> iter {n_iters-1}: "
+            f"- reward iter 0 -> iter {n_iters - 1}: "
             f"{np.nanmean(rewards[:, 0]):.2f} -> "
             f"{np.nanmean(rewards[:, -1]):.2f}"
             f"  (baseline random = {bl.get('random', float('nan'))})"
         )
         lines.append(
-            f"- mean value_loss iter 0 -> iter {n_iters-1}: "
+            f"- mean value_loss iter 0 -> iter {n_iters - 1}: "
             f"{np.nanmean(val_losses[:, 0]):.2e} -> "
             f"{np.nanmean(val_losses[:, -1]):.2e}"
             f"  (scaled by value_coef={VALUE_COEF}: "
             f"{VALUE_COEF * np.nanmean(val_losses[:, 0]):.2e})"
         )
         lines.append(
-            f"- mean |policy_loss| iter 0 -> iter {n_iters-1}: "
+            f"- mean |policy_loss| iter 0 -> iter {n_iters - 1}: "
             f"{np.nanmean(np.abs(pol_losses[:, 0])):.3e} -> "
             f"{np.nanmean(np.abs(pol_losses[:, -1])):.3e}"
         )
         lines.append(
-            f"- mean entropy iter 0 -> iter {n_iters-1}: "
+            f"- mean entropy iter 0 -> iter {n_iters - 1}: "
             f"{np.nanmean(entropies[:, 0]):.3e} -> "
             f"{np.nanmean(entropies[:, -1]):.3e}"
             f"  (scaled by entropy_coef={ENTROPY_COEF}: "
@@ -457,13 +471,15 @@ def _default_sweep_root() -> Path:
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument(
-        "--sweep-root", type=Path,
+        "--sweep-root",
+        type=Path,
         default=None,
         help="root containing {scenario}/lambda_*/seed_*/metrics.json "
-             "(auto-detected if not provided)",
+        "(auto-detected if not provided)",
     )
     p.add_argument(
-        "--out-dir", type=Path,
+        "--out-dir",
+        type=Path,
         default=Path("experiments/p3_specialization/diagnostics"),
     )
     args = p.parse_args()

--- a/experiments/p3_specialization/dropout_eval.py
+++ b/experiments/p3_specialization/dropout_eval.py
@@ -12,6 +12,7 @@ evaluation rollouts. Robustness to specialization shows up as a *smaller*
 team-reward drop when each agent is removed individually --- which is the
 P3 prediction the redundancy penalty should improve.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -138,8 +139,11 @@ def evaluate_cell(
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--cell-dir", type=Path, help="Single cell to evaluate.")
-    p.add_argument("--sweep-root", type=Path,
-                   help="Walk this directory and evaluate every cell with policies/.")
+    p.add_argument(
+        "--sweep-root",
+        type=Path,
+        help="Walk this directory and evaluate every cell with policies/.",
+    )
     p.add_argument("--num-episodes", type=int, default=50)
     p.add_argument("--device", default="cpu")
     args = p.parse_args()

--- a/experiments/p3_specialization/run_sweep.py
+++ b/experiments/p3_specialization/run_sweep.py
@@ -14,6 +14,7 @@ That is 240 cells; rough estimate on Mac Studio (50 iters of 2048 steps each,
 hidden_size=64, 4 PPO epochs) is ~3 min/cell, so the full sweep is ~12 hours
 single-threaded. Use ``--num-iterations`` to shorten for smoke tests.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -41,8 +42,10 @@ def run_sweep(
     skip_existing: bool,
 ) -> None:
     n_cells = len(scenarios) * len(lambdas) * len(seeds)
-    print(f"P3 sweep: {n_cells} cells "
-          f"({len(scenarios)} scenarios x {len(lambdas)} lambdas x {len(seeds)} seeds)")
+    print(
+        f"P3 sweep: {n_cells} cells "
+        f"({len(scenarios)} scenarios x {len(lambdas)} lambdas x {len(seeds)} seeds)"
+    )
     print(f"Output root: {output_root}")
 
     t0 = time.time()
@@ -80,14 +83,15 @@ def run_sweep(
                 elapsed = time.time() - t0
                 eta = elapsed / done * (n_cells - done)
                 print(
-                    f"  cell done in {cell_elapsed:.1f}s | "
-                    f"sweep ETA {eta / 60:.1f} min"
+                    f"  cell done in {cell_elapsed:.1f}s | sweep ETA {eta / 60:.1f} min"
                 )
 
 
 def main() -> None:
     p = argparse.ArgumentParser()
-    p.add_argument("--output-root", type=Path, default=Path("experiments/p3_specialization/runs"))
+    p.add_argument(
+        "--output-root", type=Path, default=Path("experiments/p3_specialization/runs")
+    )
     p.add_argument("--scenarios", nargs="+", default=PREREG_SCENARIOS)
     p.add_argument("--lambdas", nargs="+", type=float, default=PREREG_LAMBDAS)
     p.add_argument("--seeds", nargs="+", type=int, default=PREREG_SEEDS)
@@ -95,8 +99,11 @@ def main() -> None:
     p.add_argument("--rollout-steps", type=int, default=2048)
     p.add_argument("--num-agents", type=int, default=4)
     p.add_argument("--device", default="cpu")
-    p.add_argument("--skip-existing", action="store_true",
-                   help="Skip cells that already have metrics.json on disk.")
+    p.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip cells that already have metrics.json on disk.",
+    )
     args = p.parse_args()
 
     run_sweep(

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -14,6 +14,7 @@ rollout's most recent batch, conditioned on the quantized team reward
 (per the paper's main-text definition ``I(Ẑ_i; Ẑ_j | R)``). Unconditional
 MI is also logged so we can see the PMIC failure mode if it kicks in.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -21,7 +22,7 @@ import json
 import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import numpy as np
 import torch
@@ -87,9 +88,12 @@ def _measure_information(
     codes = [quantize_uniform(f, n_bins=n_bins) for f in feats_np]
 
     # Team reward conditioning variable, also quantized.
-    rewards = torch.stack(
-        [rollout.rewards[i] for i in range(trainer.num_agents)], dim=0
-    ).sum(dim=0).cpu().numpy()
+    rewards = (
+        torch.stack([rollout.rewards[i] for i in range(trainer.num_agents)], dim=0)
+        .sum(dim=0)
+        .cpu()
+        .numpy()
+    )
     r_codes = quantize_uniform(rewards, n_bins=n_bins)
 
     out: Dict[str, float] = {}
@@ -203,9 +207,9 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         )
 
         mean_reward = float(
-            torch.stack(
-                [rollout.rewards[i].sum() for i in range(cfg.num_agents)]
-            ).sum().item()
+            torch.stack([rollout.rewards[i].sum() for i in range(cfg.num_agents)])
+            .sum()
+            .item()
             / cfg.rollout_steps
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ This module provides:
 """
 
 import pytest
-import sys
 
 
 def pytest_configure(config):
@@ -42,7 +41,7 @@ def pytest_collection_modifyitems(config, items):
     """
     # Check for torch availability
     try:
-        import torch
+        import torch  # noqa: F401
 
         torch_available = True
     except ImportError:
@@ -148,10 +147,9 @@ def random_genome(seed=42):
 
 def pytest_report_header(config):
     """Add custom information to pytest header."""
-    import bucket_brigade_core
 
     headers = []
-    headers.append(f"bucket-brigade-core available: Yes")
+    headers.append("bucket-brigade-core available: Yes")
 
     # Check optional dependencies
     try:
@@ -194,5 +192,7 @@ def pytest_runtest_setup(item):
         pytest.skip("need --run-slow option to run slow tests")
 
     # Skip integration tests unless --run-integration is passed
-    if "integration" in item.keywords and not item.config.getoption("--run-integration"):
+    if "integration" in item.keywords and not item.config.getoption(
+        "--run-integration"
+    ):
         pytest.skip("need --run-integration option to run integration tests")

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -89,9 +89,9 @@ class TestJSONDefinitions:
         for name, spec in data["archetypes"].items():
             assert "params" in spec, f"Archetype {name} missing params"
             assert isinstance(spec["params"], list), f"{name} params must be list"
-            assert (
-                len(spec["params"]) == EXPECTED_PARAM_COUNT
-            ), f"{name} should have {EXPECTED_PARAM_COUNT} params, got {len(spec['params'])}"
+            assert len(spec["params"]) == EXPECTED_PARAM_COUNT, (
+                f"{name} should have {EXPECTED_PARAM_COUNT} params, got {len(spec['params'])}"
+            )
 
     def test_all_archetypes_have_descriptions(self):
         """All archetypes have descriptions."""
@@ -100,7 +100,9 @@ class TestJSONDefinitions:
 
         for name, spec in data["archetypes"].items():
             assert "description" in spec, f"Archetype {name} missing description"
-            assert isinstance(spec["description"], str), f"{name} description must be string"
+            assert isinstance(spec["description"], str), (
+                f"{name} description must be string"
+            )
             assert len(spec["description"]) > 0, f"{name} description is empty"
 
     def test_all_scenarios_have_required_params(self):
@@ -111,9 +113,9 @@ class TestJSONDefinitions:
         for name, spec in data["scenarios"].items():
             for param in REQUIRED_SCENARIO_PARAMS:
                 assert param in spec, f"Scenario {name} missing {param}"
-                assert isinstance(
-                    spec[param], (int, float)
-                ), f"{name}.{param} must be numeric"
+                assert isinstance(spec[param], (int, float)), (
+                    f"{name}.{param} must be numeric"
+                )
 
     def test_all_scenarios_have_descriptions(self):
         """All scenarios have descriptions."""
@@ -122,7 +124,9 @@ class TestJSONDefinitions:
 
         for name, spec in data["scenarios"].items():
             assert "description" in spec, f"Scenario {name} missing description"
-            assert isinstance(spec["description"], str), f"{name} description must be string"
+            assert isinstance(spec["description"], str), (
+                f"{name} description must be string"
+            )
             assert len(spec["description"]) > 0, f"{name} description is empty"
 
 
@@ -136,9 +140,9 @@ class TestPythonGeneration:
 
         for name, spec in json_data["archetypes"].items():
             # Check archetype exists in Python
-            assert (
-                name in PY_ARCHETYPES
-            ), f"Archetype {name} not found in Python ARCHETYPES"
+            assert name in PY_ARCHETYPES, (
+                f"Archetype {name} not found in Python ARCHETYPES"
+            )
 
             # Check parameters match
             expected_params = np.array(spec["params"], dtype=np.float32)
@@ -166,7 +170,9 @@ class TestPythonGeneration:
         }
 
         for name, expected_params in archetype_constants.items():
-            json_params = np.array(json_data["archetypes"][name]["params"], dtype=np.float32)
+            json_params = np.array(
+                json_data["archetypes"][name]["params"], dtype=np.float32
+            )
             np.testing.assert_array_almost_equal(
                 expected_params,
                 json_params,
@@ -181,25 +187,27 @@ class TestPythonGeneration:
 
         # Test scenario registry
         for name, spec in json_data["scenarios"].items():
-            assert (
-                name in PY_SCENARIOS
-            ), f"Scenario {name} not found in Python SCENARIO_REGISTRY"
+            assert name in PY_SCENARIOS, (
+                f"Scenario {name} not found in Python SCENARIO_REGISTRY"
+            )
 
             # Get factory function
             factory = PY_SCENARIOS[name]
             scenario = factory(num_agents=10)
 
             # Verify it's a Scenario instance
-            assert isinstance(scenario, Scenario), f"{name} factory didn't return Scenario"
+            assert isinstance(scenario, Scenario), (
+                f"{name} factory didn't return Scenario"
+            )
 
             # Check each parameter matches JSON
             for param in REQUIRED_SCENARIO_PARAMS:
                 actual_value = getattr(scenario, param)
                 expected_value = spec[param]
 
-                assert (
-                    actual_value == expected_value
-                ), f"Scenario {name}.{param}: expected {expected_value}, got {actual_value}"
+                assert actual_value == expected_value, (
+                    f"Scenario {name}.{param}: expected {expected_value}, got {actual_value}"
+                )
 
     def test_python_scenario_factories(self):
         """Python scenario factories work correctly."""
@@ -252,9 +260,9 @@ class TestTypeScriptGeneration:
 
         # Check all archetypes are present
         for name in json_data["archetypes"].keys():
-            assert (
-                f"{name}:" in content
-            ), f"Archetype {name} not found in TypeScript file"
+            assert f"{name}:" in content, (
+                f"Archetype {name} not found in TypeScript file"
+            )
 
         # Check interfaces exist
         assert "export interface ArchetypeParams" in content
@@ -278,9 +286,9 @@ class TestTypeScriptGeneration:
         # Check all scenarios are present
         for name in json_data["scenarios"].keys():
             constant_name = name.upper()
-            assert (
-                f"{constant_name}:" in content
-            ), f"Scenario constant {constant_name} not found in TypeScript file"
+            assert f"{constant_name}:" in content, (
+                f"Scenario constant {constant_name} not found in TypeScript file"
+            )
 
         # Check types and constants exist
         assert "export const SCENARIO_TYPES" in content
@@ -294,7 +302,9 @@ class TestTypeScriptGeneration:
 
     def test_typescript_has_proper_escaping(self):
         """TypeScript strings are properly escaped."""
-        ts_archetype_file = ROOT_DIR / "web" / "src" / "data" / "archetypes.generated.ts"
+        ts_archetype_file = (
+            ROOT_DIR / "web" / "src" / "data" / "archetypes.generated.ts"
+        )
         content = ts_archetype_file.read_text()
 
         # Check that apostrophes in strings are escaped
@@ -365,9 +375,7 @@ class TestCodeGenerationWarnings:
 
     def test_python_archetypes_has_warning(self):
         """Generated Python archetypes file has DO NOT EDIT warning."""
-        py_file = (
-            ROOT_DIR / "bucket_brigade" / "agents" / "archetypes_generated.py"
-        )
+        py_file = ROOT_DIR / "bucket_brigade" / "agents" / "archetypes_generated.py"
         content = py_file.read_text()
 
         assert "GENERATED FILE" in content or "DO NOT EDIT" in content, (

--- a/tests/test_game_simulator.py
+++ b/tests/test_game_simulator.py
@@ -9,8 +9,7 @@ import pytest
 import numpy as np
 import torch
 import multiprocessing as mp
-from unittest.mock import Mock, MagicMock, patch
-from queue import Empty
+from unittest.mock import Mock
 
 from bucket_brigade.training.game_simulator import Matchmaker, GameSimulator
 from bucket_brigade.training import PolicyNetwork
@@ -107,7 +106,7 @@ class TestGameSimulatorInitialization:
 
     def test_basic_initialization(self):
         """Test basic simulator initialization."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -127,7 +126,7 @@ class TestGameSimulatorInitialization:
 
     def test_scenario_info_created(self):
         """Test that scenario info is cached."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(scenario=scenario, num_games=2)
 
@@ -137,7 +136,7 @@ class TestGameSimulatorInitialization:
 
     def test_matchmaker_initialized(self):
         """Test that matchmaker is initialized correctly."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -152,7 +151,7 @@ class TestGameSimulatorInitialization:
 
     def test_seed_determinism(self):
         """Test that seed produces deterministic results."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         # Create two simulators with same seed
         sim1 = GameSimulator(scenario=scenario, num_games=2, seed=42)
@@ -169,7 +168,7 @@ class TestGameSimulatorPolicyManagement:
 
     def test_register_policy(self):
         """Test registering a policy for an agent."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
         simulator = GameSimulator(scenario=scenario, num_games=2)
 
         # Create policy
@@ -183,7 +182,7 @@ class TestGameSimulatorPolicyManagement:
 
     def test_register_multiple_policies(self):
         """Test registering policies for multiple agents."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
         simulator = GameSimulator(scenario=scenario, num_games=2, population_size=4)
 
         for agent_id in range(4):
@@ -195,7 +194,7 @@ class TestGameSimulatorPolicyManagement:
 
     def test_update_policy(self):
         """Test updating an agent's policy weights."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
         simulator = GameSimulator(scenario=scenario, num_games=2)
 
         # Register initial policy
@@ -225,7 +224,7 @@ class TestGameSimulatorActionSelection:
 
     def test_select_action_shape(self):
         """Test that select_action returns correct shapes."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
         simulator = GameSimulator(scenario=scenario, num_games=2)
 
         # Register policy
@@ -236,7 +235,9 @@ class TestGameSimulatorActionSelection:
         observation = np.random.randn(36).astype(np.float32)
 
         # Select action
-        house, mode, logprob = simulator.select_action(agent_id=0, observation=observation)
+        house, mode, logprob = simulator.select_action(
+            agent_id=0, observation=observation
+        )
 
         # Verify types and ranges
         assert isinstance(house, int)
@@ -247,7 +248,7 @@ class TestGameSimulatorActionSelection:
 
     def test_select_action_determinism(self):
         """Test that same observation with same seed produces same action."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         # Create policy and observation
         policy = PolicyNetwork(obs_dim=36, action_dims=[10, 3], hidden_size=128)
@@ -260,7 +261,9 @@ class TestGameSimulatorActionSelection:
             simulator.register_policy(agent_id=0, policy=policy)
 
             torch.manual_seed(42)
-            house, mode, logprob = simulator.select_action(agent_id=0, observation=observation)
+            house, mode, logprob = simulator.select_action(
+                agent_id=0, observation=observation
+            )
             results.append((house, mode))
 
         # All results should be the same (with same seed)
@@ -272,7 +275,7 @@ class TestGameSimulatorExperienceDistribution:
 
     def test_distribute_experiences_basic(self):
         """Test distributing experiences to queues."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         # Create mock queues (easier to test than real mp.Queue)
         queues = [Mock() for _ in range(4)]
@@ -286,8 +289,8 @@ class TestGameSimulatorExperienceDistribution:
 
         # Create mock trajectories
         trajectories = {
-            0: [{'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0}],
-            1: [{'obs': np.zeros(36), 'action': [1, 1], 'reward': 2.0}],
+            0: [{"obs": np.zeros(36), "action": [0, 0], "reward": 1.0}],
+            1: [{"obs": np.zeros(36), "action": [1, 1], "reward": 2.0}],
         }
 
         # Distribute
@@ -305,7 +308,7 @@ class TestGameSimulatorExperienceDistribution:
 
     def test_distribute_experiences_multiple_per_agent(self):
         """Test distributing multiple experiences per agent."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         # Use mock queues
         queues = [Mock() for _ in range(2)]
@@ -320,9 +323,9 @@ class TestGameSimulatorExperienceDistribution:
         # Create trajectories with multiple experiences
         trajectories = {
             0: [
-                {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0},
-                {'obs': np.zeros(36), 'action': [1, 1], 'reward': 2.0},
-                {'obs': np.zeros(36), 'action': [2, 2], 'reward': 3.0},
+                {"obs": np.zeros(36), "action": [0, 0], "reward": 1.0},
+                {"obs": np.zeros(36), "action": [1, 1], "reward": 2.0},
+                {"obs": np.zeros(36), "action": [2, 2], "reward": 3.0},
             ],
         }
 
@@ -344,7 +347,7 @@ class TestGameSimulatorPolicyUpdates:
 
     def test_check_policy_updates_basic(self):
         """Test checking for and applying policy updates."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         # Create mock update queue
         update_queue = Mock()
@@ -387,7 +390,7 @@ class TestGameSimulatorPolicyUpdates:
 
     def test_check_policy_updates_multiple(self):
         """Test applying multiple policy updates."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         update_queue = mp.Queue()
 
@@ -405,7 +408,10 @@ class TestGameSimulatorPolicyUpdates:
 
         # Queue multiple updates
         for agent_id in range(4):
-            new_state = {k: torch.randn_like(v) for k, v in simulator.policies[agent_id].state_dict().items()}
+            new_state = {
+                k: torch.randn_like(v)
+                for k, v in simulator.policies[agent_id].state_dict().items()
+            }
             update_queue.put((agent_id, new_state))
 
         # Apply all updates
@@ -416,7 +422,7 @@ class TestGameSimulatorPolicyUpdates:
 
     def test_check_policy_updates_no_queue(self):
         """Test that check_policy_updates handles no queue gracefully."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -433,7 +439,7 @@ class TestGameSimulatorStatistics:
 
     def test_get_statistics_initial(self):
         """Test getting statistics from fresh simulator."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -443,16 +449,16 @@ class TestGameSimulatorStatistics:
 
         stats = simulator.get_statistics()
 
-        assert stats['total_steps'] == 0
-        assert stats['total_episodes'] == 0
-        assert len(stats['episode_rewards']) == 4
-        assert all(len(rewards) == 0 for rewards in stats['episode_rewards'].values())
-        assert len(stats['match_counts']) == 4
-        assert all(count == 0 for count in stats['match_counts'])
+        assert stats["total_steps"] == 0
+        assert stats["total_episodes"] == 0
+        assert len(stats["episode_rewards"]) == 4
+        assert all(len(rewards) == 0 for rewards in stats["episode_rewards"].values())
+        assert len(stats["match_counts"]) == 4
+        assert all(count == 0 for count in stats["match_counts"])
 
     def test_episode_rewards_tracking(self):
         """Test that episode rewards are tracked correctly."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -467,9 +473,9 @@ class TestGameSimulatorStatistics:
 
         stats = simulator.get_statistics()
 
-        assert len(stats['episode_rewards'][0]) == 2
-        assert len(stats['episode_rewards'][1]) == 1
-        assert stats['episode_rewards'][0][0] == pytest.approx(10.0)
+        assert len(stats["episode_rewards"][0]) == 2
+        assert len(stats["episode_rewards"][1]) == 1
+        assert stats["episode_rewards"][0][0] == pytest.approx(10.0)
 
 
 class TestGameSimulatorIntegration:
@@ -477,7 +483,7 @@ class TestGameSimulatorIntegration:
 
     def test_run_episode_basic(self):
         """Test running a full episode with real environment."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -500,16 +506,16 @@ class TestGameSimulatorIntegration:
         for agent_id, traj in trajectories.items():
             assert len(traj) > 0  # Should have at least some steps
             for exp in traj:
-                assert 'obs' in exp
-                assert 'action' in exp
-                assert 'reward' in exp
-                assert 'next_obs' in exp or exp['done']
-                assert 'done' in exp
-                assert 'logprob' in exp
+                assert "obs" in exp
+                assert "action" in exp
+                assert "reward" in exp
+                assert "next_obs" in exp or exp["done"]
+                assert "done" in exp
+                assert "logprob" in exp
 
     def test_run_episode_updates_statistics(self):
         """Test that running episode updates statistics."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,
@@ -536,7 +542,7 @@ class TestGameSimulatorIntegration:
 
     def test_multiple_episodes_consistent(self):
         """Test running multiple episodes produces consistent results."""
-        scenario = SCENARIOS['trivial_cooperation']
+        scenario = SCENARIOS["trivial_cooperation"]
 
         simulator = GameSimulator(
             scenario=scenario,

--- a/tests/test_info_theory.py
+++ b/tests/test_info_theory.py
@@ -185,7 +185,10 @@ class TestBootstrap:
         rng = np.random.default_rng(50)
         x = rng.integers(0, 4, size=2_000)
         est, lo, hi = bootstrap_ci(
-            entropy_discrete, (x,), n_boot=200, confidence=0.95,
+            entropy_discrete,
+            (x,),
+            n_boot=200,
+            confidence=0.95,
             rng=np.random.default_rng(51),
         )
         # Point estimate is the full-sample estimator.
@@ -198,7 +201,9 @@ class TestBootstrap:
         x = rng.integers(0, 4, size=2_000)
         y = x.copy()  # I(X; X) = log2 4 = 2 bits.
         est, lo, hi = bootstrap_ci(
-            mutual_information, (x, y), n_boot=200,
+            mutual_information,
+            (x, y),
+            n_boot=200,
             rng=np.random.default_rng(53),
         )
         assert lo <= 2.0 <= hi or abs(est - 2.0) < TOL_LARGE
@@ -301,9 +306,7 @@ class TestConditionerDiagnostics:
         degenerate_default, _ = is_degenerate_conditioner(z)
         assert degenerate_default is False
         # ...but should flag if we tighten max_modal_fraction below 0.6.
-        degenerate_strict, _ = is_degenerate_conditioner(
-            z, max_modal_fraction=0.55
-        )
+        degenerate_strict, _ = is_degenerate_conditioner(z, max_modal_fraction=0.55)
         assert degenerate_strict is True
 
     def test_diagnostics_match_helper(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,16 +65,18 @@ class TestEvolutionPipeline:
         assert result.best_individual.fitness is not None
         assert result.best_individual.fitness > 0  # Should achieve positive fitness
         assert len(result.fitness_history) == 5  # Should have 5 generations
-        assert result.converged_at is None or isinstance(result.converged_at, int)  # Should have convergence status
+        assert result.converged_at is None or isinstance(
+            result.converged_at, int
+        )  # Should have convergence status
 
         # Check that fitness improved or stayed reasonable
         first_gen_best = result.fitness_history[0]["max"]
         final_gen_best = result.fitness_history[-1]["max"]
 
         assert final_gen_best > 0, "Final generation should achieve positive fitness"
-        assert (
-            final_gen_best >= first_gen_best * 0.8
-        ), "Fitness should not degrade significantly"
+        assert final_gen_best >= first_gen_best * 0.8, (
+            "Fitness should not degrade significantly"
+        )
 
     def test_evolution_produces_valid_genome(self):
         """Test that evolution produces a valid genome."""
@@ -274,9 +276,9 @@ class TestResearchDataPipeline:
 
         # Should achieve reasonable fitness (within 50% of recorded fitness)
         recorded_fitness = data["fitness"]
-        assert (
-            fitness > recorded_fitness * 0.5
-        ), f"Genome fitness {fitness} too low compared to recorded {recorded_fitness}"
+        assert fitness > recorded_fitness * 0.5, (
+            f"Genome fitness {fitness} too low compared to recorded {recorded_fitness}"
+        )
 
     def test_scenario_evolution_roundtrip(self):
         """Test complete scenario → evolution → evaluation roundtrip."""
@@ -314,9 +316,9 @@ class TestResearchDataPipeline:
 
         # Fitness should be positive and reasonable
         assert fitness > 0, "Best evolved genome should have positive fitness"
-        assert (
-            fitness <= result.best_individual.fitness * 1.5
-        ), "Re-evaluation shouldn't differ by more than 50% (stochasticity)"
+        assert fitness <= result.best_individual.fitness * 1.5, (
+            "Re-evaluation shouldn't differ by more than 50% (stochasticity)"
+        )
 
 
 @pytest.mark.integration

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -27,7 +27,9 @@ def _env_fn():
     return BucketBrigadeEnv(num_agents=NUM_AGENTS)
 
 
-def _make_trainer(redundancy_coef: float = 0.0, hidden_size: int = 16) -> JointPPOTrainer:
+def _make_trainer(
+    redundancy_coef: float = 0.0, hidden_size: int = 16
+) -> JointPPOTrainer:
     env = _env_fn()
     obs = env.reset(seed=0)
     obs_dim = flatten_dict_obs(obs).shape[0]

--- a/tests/test_observation_utils.py
+++ b/tests/test_observation_utils.py
@@ -38,8 +38,12 @@ class TestFlattenObservation:
         assert np.allclose(flat_obs[:10], obs.houses)  # houses
         assert np.allclose(flat_obs[10:14], obs.signals)  # signals
         assert np.allclose(flat_obs[14:18], obs.locations)  # locations
-        assert np.allclose(flat_obs[18:26], [0, 1, 2, 0, 5, 2, 7, 1])  # last_actions flattened
-        assert np.allclose(flat_obs[26:], np.zeros(10))  # scenario_info (zeros when None)
+        assert np.allclose(
+            flat_obs[18:26], [0, 1, 2, 0, 5, 2, 7, 1]
+        )  # last_actions flattened
+        assert np.allclose(
+            flat_obs[26:], np.zeros(10)
+        )  # scenario_info (zeros when None)
 
     def test_flatten_observation_with_scenario_info(self):
         """Test flattening with provided scenario info."""
@@ -164,7 +168,9 @@ class TestCreateScenarioInfo:
 
         # Check values
         assert scenario_info[0] == pytest.approx(0.1)  # prob_fire_spreads_to_neighbor
-        assert scenario_info[1] == pytest.approx(0.2)  # prob_solo_agent_extinguishes_fire
+        assert scenario_info[1] == pytest.approx(
+            0.2
+        )  # prob_solo_agent_extinguishes_fire
         assert scenario_info[2] == pytest.approx(0.3)  # prob_house_catches_fire
         assert scenario_info[3] == pytest.approx(10.0)  # team_reward_house_survives
         assert scenario_info[4] == pytest.approx(-5.0)  # team_penalty_house_burns
@@ -283,7 +289,9 @@ class TestObservationUtilsIntegration:
             observations.append(obs)
 
         # Flatten all observations
-        flat_observations = [flatten_observation(obs, scenario_info) for obs in observations]
+        flat_observations = [
+            flatten_observation(obs, scenario_info) for obs in observations
+        ]
 
         # All should have same dimension
         for flat_obs in flat_observations:

--- a/tests/test_policy_learner.py
+++ b/tests/test_policy_learner.py
@@ -8,8 +8,7 @@ Focuses heavily on GAE computation where we found bugs during GPU testing.
 import pytest
 import numpy as np
 import torch
-import multiprocessing as mp
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock
 from collections import deque
 
 from bucket_brigade.training.policy_learner import PolicyLearner
@@ -216,12 +215,12 @@ class TestBatchPreparation:
         # Add experiences to buffer
         for i in range(4):
             exp = {
-                'obs': np.random.randn(36).astype(np.float32),
-                'action': [i % 10, i % 3],
-                'reward': float(i),
-                'next_obs': np.random.randn(36).astype(np.float32),
-                'done': False,
-                'logprob': -0.5,
+                "obs": np.random.randn(36).astype(np.float32),
+                "action": [i % 10, i % 3],
+                "reward": float(i),
+                "next_obs": np.random.randn(36).astype(np.float32),
+                "done": False,
+                "logprob": -0.5,
             }
             learner.experience_buffer.append(exp)
 
@@ -255,12 +254,12 @@ class TestBatchPreparation:
         # Add experiences with some done=True
         for i in range(3):
             exp = {
-                'obs': np.random.randn(36).astype(np.float32),
-                'action': [0, 0],
-                'reward': 1.0,
-                'next_obs': np.random.randn(36).astype(np.float32) if i < 2 else None,
-                'done': i == 2,
-                'logprob': -0.5,
+                "obs": np.random.randn(36).astype(np.float32),
+                "action": [0, 0],
+                "reward": 1.0,
+                "next_obs": np.random.randn(36).astype(np.float32) if i < 2 else None,
+                "done": i == 2,
+                "logprob": -0.5,
             }
             learner.experience_buffer.append(exp)
 
@@ -288,12 +287,12 @@ class TestBatchPreparation:
         # Add only 3 experiences
         for i in range(3):
             exp = {
-                'obs': np.zeros(36, dtype=np.float32),
-                'action': [0, 0],
-                'reward': 1.0,
-                'next_obs': np.zeros(36, dtype=np.float32),
-                'done': False,
-                'logprob': -0.5,
+                "obs": np.zeros(36, dtype=np.float32),
+                "action": [0, 0],
+                "reward": 1.0,
+                "next_obs": np.zeros(36, dtype=np.float32),
+                "done": False,
+                "logprob": -0.5,
             }
             learner.experience_buffer.append(exp)
 
@@ -391,12 +390,12 @@ class TestTrainBatch:
         # Add experiences
         for i in range(8):
             exp = {
-                'obs': np.random.randn(36).astype(np.float32),
-                'action': [i % 10, i % 3],
-                'reward': np.random.rand(),
-                'next_obs': np.random.randn(36).astype(np.float32),
-                'done': False,
-                'logprob': np.random.randn(),
+                "obs": np.random.randn(36).astype(np.float32),
+                "action": [i % 10, i % 3],
+                "reward": np.random.rand(),
+                "next_obs": np.random.randn(36).astype(np.float32),
+                "done": False,
+                "logprob": np.random.randn(),
             }
             learner.experience_buffer.append(exp)
 
@@ -404,11 +403,11 @@ class TestTrainBatch:
         stats = learner.train_batch()
 
         # Verify statistics returned
-        assert 'batch' in stats
-        assert 'policy_loss' in stats
-        assert 'value_loss' in stats
-        assert 'entropy' in stats
-        assert 'mean_reward' in stats
+        assert "batch" in stats
+        assert "policy_loss" in stats
+        assert "value_loss" in stats
+        assert "entropy" in stats
+        assert "mean_reward" in stats
 
         # Verify batch counter incremented
         assert learner.total_batches == 1
@@ -427,19 +426,18 @@ class TestTrainBatch:
 
         # Get initial weights
         initial_weights = {
-            name: param.clone()
-            for name, param in learner.policy.named_parameters()
+            name: param.clone() for name, param in learner.policy.named_parameters()
         }
 
         # Add experiences
         for i in range(4):
             exp = {
-                'obs': np.random.randn(36).astype(np.float32),
-                'action': [0, 0],
-                'reward': 1.0,
-                'next_obs': np.random.randn(36).astype(np.float32),
-                'done': False,
-                'logprob': -2.0,
+                "obs": np.random.randn(36).astype(np.float32),
+                "action": [0, 0],
+                "reward": 1.0,
+                "next_obs": np.random.randn(36).astype(np.float32),
+                "done": False,
+                "logprob": -2.0,
             }
             learner.experience_buffer.append(exp)
 
@@ -449,7 +447,7 @@ class TestTrainBatch:
         # Verify weights changed
         for name, param in learner.policy.named_parameters():
             # At least some parameters should have changed
-            if 'weight' in name or 'bias' in name:
+            if "weight" in name or "bias" in name:
                 # We expect at least one param to change (use any() to be lenient)
                 pass
 
@@ -484,12 +482,12 @@ class TestExperienceCollection:
         experiences = []
         for i in range(5):
             exp = {
-                'obs': np.zeros(36),
-                'action': [0, 0],
-                'reward': 1.0,
-                'next_obs': np.zeros(36),
-                'done': False,
-                'logprob': -1.0,
+                "obs": np.zeros(36),
+                "action": [0, 0],
+                "reward": 1.0,
+                "next_obs": np.zeros(36),
+                "done": False,
+                "logprob": -1.0,
             }
             experiences.append((0, exp))
 
@@ -519,11 +517,61 @@ class TestExperienceCollection:
 
         # Mix of experiences for different agents
         experiences = [
-            (0, {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0, 'next_obs': np.zeros(36), 'done': False, 'logprob': -1.0}),
-            (2, {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0, 'next_obs': np.zeros(36), 'done': False, 'logprob': -1.0}),
-            (1, {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0, 'next_obs': np.zeros(36), 'done': False, 'logprob': -1.0}),
-            (2, {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0, 'next_obs': np.zeros(36), 'done': False, 'logprob': -1.0}),
-            (2, {'obs': np.zeros(36), 'action': [0, 0], 'reward': 1.0, 'next_obs': np.zeros(36), 'done': False, 'logprob': -1.0}),
+            (
+                0,
+                {
+                    "obs": np.zeros(36),
+                    "action": [0, 0],
+                    "reward": 1.0,
+                    "next_obs": np.zeros(36),
+                    "done": False,
+                    "logprob": -1.0,
+                },
+            ),
+            (
+                2,
+                {
+                    "obs": np.zeros(36),
+                    "action": [0, 0],
+                    "reward": 1.0,
+                    "next_obs": np.zeros(36),
+                    "done": False,
+                    "logprob": -1.0,
+                },
+            ),
+            (
+                1,
+                {
+                    "obs": np.zeros(36),
+                    "action": [0, 0],
+                    "reward": 1.0,
+                    "next_obs": np.zeros(36),
+                    "done": False,
+                    "logprob": -1.0,
+                },
+            ),
+            (
+                2,
+                {
+                    "obs": np.zeros(36),
+                    "action": [0, 0],
+                    "reward": 1.0,
+                    "next_obs": np.zeros(36),
+                    "done": False,
+                    "logprob": -1.0,
+                },
+            ),
+            (
+                2,
+                {
+                    "obs": np.zeros(36),
+                    "action": [0, 0],
+                    "reward": 1.0,
+                    "next_obs": np.zeros(36),
+                    "done": False,
+                    "logprob": -1.0,
+                },
+            ),
         ]
 
         exp_queue.empty.side_effect = [False] * 5 + [True]
@@ -598,11 +646,11 @@ class TestStatistics:
 
         stats = learner.get_statistics()
 
-        assert stats['total_batches'] == 0
-        assert stats['total_updates'] == 0
-        assert len(stats['policy_loss_history']) == 0
-        assert len(stats['value_loss_history']) == 0
-        assert len(stats['entropy_history']) == 0
+        assert stats["total_batches"] == 0
+        assert stats["total_updates"] == 0
+        assert len(stats["policy_loss_history"]) == 0
+        assert len(stats["value_loss_history"]) == 0
+        assert len(stats["entropy_history"]) == 0
 
     def test_statistics_tracked_during_training(self):
         """Test that statistics are updated during training."""
@@ -618,12 +666,12 @@ class TestStatistics:
         # Add experiences and train
         for i in range(4):
             exp = {
-                'obs': np.random.randn(36).astype(np.float32),
-                'action': [0, 0],
-                'reward': 1.0,
-                'next_obs': np.random.randn(36).astype(np.float32),
-                'done': False,
-                'logprob': -1.0,
+                "obs": np.random.randn(36).astype(np.float32),
+                "action": [0, 0],
+                "reward": 1.0,
+                "next_obs": np.random.randn(36).astype(np.float32),
+                "done": False,
+                "logprob": -1.0,
             }
             learner.experience_buffer.append(exp)
 
@@ -631,10 +679,10 @@ class TestStatistics:
 
         stats = learner.get_statistics()
 
-        assert stats['total_batches'] == 1
-        assert len(stats['policy_loss_history']) == 1
-        assert len(stats['value_loss_history']) == 1
-        assert len(stats['entropy_history']) == 1
+        assert stats["total_batches"] == 1
+        assert len(stats["policy_loss_history"]) == 1
+        assert len(stats["value_loss_history"]) == 1
+        assert len(stats["entropy_history"]) == 1
 
 
 class TestGetPolicyState:
@@ -657,5 +705,5 @@ class TestGetPolicyState:
 
         # Should contain typical network parameters
         keys = list(state.keys())
-        assert any('weight' in key for key in keys)
-        assert any('bias' in key for key in keys)
+        assert any("weight" in key for key in keys)
+        assert any("bias" in key for key in keys)

--- a/tests/test_population_training_integration.py
+++ b/tests/test_population_training_integration.py
@@ -9,7 +9,6 @@ These tests are marked as 'slow' and can be skipped with: pytest -m "not slow"
 
 import pytest
 import tempfile
-import shutil
 from pathlib import Path
 import torch
 import time
@@ -38,17 +37,17 @@ class TestPopulationTrainingBasic:
 
             # Small configuration for fast test
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,  # Small population
-                num_games=4,        # Few parallel games
+                num_games=4,  # Few parallel games
                 num_agents_per_game=4,
-                hidden_size=64,     # Small network
+                hidden_size=64,  # Small network
                 learning_rate=3e-4,
-                device='cpu',       # Use CPU for test (works on CI)
-                matchmaking_strategy='round_robin',
+                device="cpu",  # Use CPU for test (works on CI)
+                matchmaking_strategy="round_robin",
                 seed=42,
-                batch_size=32,      # Small batch
-                num_epochs=2,       # Few epochs
+                batch_size=32,  # Small batch
+                num_epochs=2,  # Few epochs
                 update_interval=10,
                 checkpoint_dir=checkpoint_dir,
                 log_interval=5,
@@ -63,11 +62,11 @@ class TestPopulationTrainingBasic:
             # Verify simulator exists and has stats
             assert trainer.simulator is not None
             stats = trainer.simulator.get_statistics()
-            assert stats['total_episodes'] == 20
-            assert stats['total_steps'] > 0
+            assert stats["total_episodes"] == 20
+            assert stats["total_steps"] > 0
 
             # Verify all agents got to play (round-robin)
-            match_counts = stats['match_counts']
+            match_counts = stats["match_counts"]
             assert len(match_counts) == 4
             # Each agent should have played multiple times
             assert all(count > 0 for count in match_counts)
@@ -80,12 +79,12 @@ class TestPopulationTrainingBasic:
             checkpoint_dir = Path(tmpdir)
 
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=checkpoint_dir,
@@ -95,25 +94,25 @@ class TestPopulationTrainingBasic:
             trainer.train(num_episodes=10)
 
             # Save checkpoint
-            checkpoint_path = checkpoint_dir / 'test_checkpoint.pt'
+            checkpoint_path = checkpoint_dir / "test_checkpoint.pt"
             trainer.save_checkpoint(checkpoint_path)
 
             # Verify checkpoint exists and contains expected keys
             assert checkpoint_path.exists()
             checkpoint = torch.load(checkpoint_path)
 
-            assert 'scenario_name' in checkpoint
-            assert 'population_size' in checkpoint
-            assert 'total_episodes' in checkpoint
-            assert 'policies' in checkpoint
-            assert 'statistics' in checkpoint
+            assert "scenario_name" in checkpoint
+            assert "population_size" in checkpoint
+            assert "total_episodes" in checkpoint
+            assert "policies" in checkpoint
+            assert "statistics" in checkpoint
 
             # Verify policies saved
-            assert len(checkpoint['policies']) == 4
+            assert len(checkpoint["policies"]) == 4
             for agent_id in range(4):
-                assert agent_id in checkpoint['policies']
+                assert agent_id in checkpoint["policies"]
                 # Each policy should be a state dict
-                assert isinstance(checkpoint['policies'][agent_id], dict)
+                assert isinstance(checkpoint["policies"][agent_id], dict)
 
     def test_population_training_config_save(self):
         """Test that configuration saving works."""
@@ -121,20 +120,20 @@ class TestPopulationTrainingBasic:
             checkpoint_dir = Path(tmpdir)
 
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
                 learning_rate=1e-3,
-                device='cpu',
+                device="cpu",
                 seed=123,
                 batch_size=16,
                 checkpoint_dir=checkpoint_dir,
             )
 
             # Save config
-            config_path = checkpoint_dir / 'config.json'
+            config_path = checkpoint_dir / "config.json"
             trainer.save_config(config_path)
 
             # Verify config file exists
@@ -142,26 +141,30 @@ class TestPopulationTrainingBasic:
 
             # Load and verify contents
             import json
+
             with open(config_path) as f:
                 config = json.load(f)
 
-            assert config['scenario_name'] == 'trivial_cooperation'
-            assert config['population_size'] == 4
-            assert config['num_games'] == 2
-            assert config['hidden_size'] == 32
-            assert config['learning_rate'] == pytest.approx(1e-3)
-            assert config['seed'] == 123
+            assert config["scenario_name"] == "trivial_cooperation"
+            assert config["population_size"] == 4
+            assert config["num_games"] == 2
+            assert config["hidden_size"] == 32
+            assert config["learning_rate"] == pytest.approx(1e-3)
+            assert config["seed"] == 123
 
 
 @pytest.mark.slow
 class TestPopulationTrainingMultiScenario:
     """Test population training across multiple scenarios."""
 
-    @pytest.mark.parametrize('scenario_name', [
-        'trivial_cooperation',
-        'easy',
-        'greedy_neighbor',
-    ])
+    @pytest.mark.parametrize(
+        "scenario_name",
+        [
+            "trivial_cooperation",
+            "easy",
+            "greedy_neighbor",
+        ],
+    )
     def test_training_different_scenarios(self, scenario_name):
         """Test that training works with different scenarios.
 
@@ -180,7 +183,7 @@ class TestPopulationTrainingMultiScenario:
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=checkpoint_dir,
@@ -192,8 +195,8 @@ class TestPopulationTrainingMultiScenario:
             # Verify completion
             assert trainer.total_episodes == 5
             stats = trainer.simulator.get_statistics()
-            assert stats['total_episodes'] == 5
-            assert stats['total_steps'] > 0
+            assert stats["total_episodes"] == 5
+            assert stats["total_steps"] > 0
 
 
 @pytest.mark.slow
@@ -204,12 +207,12 @@ class TestPopulationTrainingScaling:
         """Test with larger population (8 agents)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=8,  # Larger population
                 num_games=4,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -219,19 +222,19 @@ class TestPopulationTrainingScaling:
 
             # Verify all 8 agents trained
             stats = trainer.simulator.get_statistics()
-            assert len(stats['match_counts']) == 8
-            assert all(count > 0 for count in stats['match_counts'])
+            assert len(stats["match_counts"]) == 8
+            assert all(count > 0 for count in stats["match_counts"])
 
     def test_more_parallel_games(self):
         """Test with more parallel game environments."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=8,  # More parallel games
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -249,12 +252,14 @@ class TestPopulationTrainingRobustness:
 
     def test_mismatched_population_size_validation(self):
         """Test that invalid population size is caught."""
-        with pytest.raises(ValueError, match="Population size.*must be >= num_agents_per_game"):
+        with pytest.raises(
+            ValueError, match="Population size.*must be >= num_agents_per_game"
+        ):
             PopulationTrainer(
-                scenario_name='trivial_cooperation',
-                population_size=2,       # Too small!
-                num_agents_per_game=4,   # Needs 4 agents per game
-                device='cpu',
+                scenario_name="trivial_cooperation",
+                population_size=2,  # Too small!
+                num_agents_per_game=4,  # Needs 4 agents per game
+                device="cpu",
             )
 
     def test_training_completes_without_hanging(self):
@@ -264,12 +269,12 @@ class TestPopulationTrainingRobustness:
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -281,7 +286,9 @@ class TestPopulationTrainingRobustness:
             elapsed = time.time() - start_time
 
             # Should complete quickly (definitely under 60 seconds)
-            assert elapsed < 60, f"Training took {elapsed:.1f}s - possible deadlock or performance issue"
+            assert elapsed < 60, (
+                f"Training took {elapsed:.1f}s - possible deadlock or performance issue"
+            )
 
     def test_cleanup_processes_on_completion(self):
         """Test that all processes are cleaned up after training."""
@@ -292,12 +299,12 @@ class TestPopulationTrainingRobustness:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -311,8 +318,9 @@ class TestPopulationTrainingRobustness:
 
         # All spawned processes should be cleaned up
         final_processes = len(mp.active_children())
-        assert final_processes == initial_processes, \
+        assert final_processes == initial_processes, (
             f"Process leak detected: started with {initial_processes}, ended with {final_processes}"
+        )
 
 
 @pytest.mark.slow
@@ -323,12 +331,12 @@ class TestPopulationTrainingStatistics:
         """Test that episode rewards are tracked for all agents."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -337,7 +345,7 @@ class TestPopulationTrainingStatistics:
             trainer.train(num_episodes=10)
 
             stats = trainer.simulator.get_statistics()
-            episode_rewards = stats['episode_rewards']
+            episode_rewards = stats["episode_rewards"]
 
             # Should have rewards for all 4 agents
             assert len(episode_rewards) == 4
@@ -350,12 +358,12 @@ class TestPopulationTrainingStatistics:
         """Test that total steps are counted correctly."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
+                device="cpu",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
@@ -366,35 +374,38 @@ class TestPopulationTrainingStatistics:
             stats = trainer.simulator.get_statistics()
 
             # Should have taken some steps
-            assert stats['total_steps'] > 0
+            assert stats["total_steps"] > 0
 
             # Should have taken at least 1 step per episode
-            assert stats['total_steps'] >= stats['total_episodes']
+            assert stats["total_steps"] >= stats["total_episodes"]
 
     def test_match_count_tracking(self):
         """Test that match counts are tracked correctly."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=2,
                 num_agents_per_game=4,
                 hidden_size=32,
-                device='cpu',
-                matchmaking_strategy='round_robin',
+                device="cpu",
+                matchmaking_strategy="round_robin",
                 seed=42,
                 batch_size=16,
                 checkpoint_dir=Path(tmpdir),
             )
 
-            trainer.train(num_episodes=12)  # 12 episodes, 4 agents per game = 3 games each
+            trainer.train(
+                num_episodes=12
+            )  # 12 episodes, 4 agents per game = 3 games each
 
             stats = trainer.simulator.get_statistics()
-            match_counts = stats['match_counts']
+            match_counts = stats["match_counts"]
 
             # All agents should have played 3 times (round-robin, 12 episodes ÷ 4 agents)
-            assert all(count == 3 for count in match_counts), \
+            assert all(count == 3 for count in match_counts), (
                 f"Round-robin failed: {match_counts}"
+            )
 
 
 @pytest.mark.slow
@@ -417,14 +428,14 @@ class TestPopulationTrainingEndToEnd:
 
             # Configuration similar to actual training (but scaled down)
             trainer = PopulationTrainer(
-                scenario_name='trivial_cooperation',
+                scenario_name="trivial_cooperation",
                 population_size=4,
                 num_games=4,
                 num_agents_per_game=4,
                 hidden_size=64,
                 learning_rate=3e-4,
-                device='cpu',
-                matchmaking_strategy='round_robin',
+                device="cpu",
+                matchmaking_strategy="round_robin",
                 seed=42,
                 batch_size=32,
                 num_epochs=2,
@@ -439,34 +450,35 @@ class TestPopulationTrainingEndToEnd:
             # Verify training metrics
             assert trainer.total_episodes == 25
             stats = trainer.simulator.get_statistics()
-            assert stats['total_episodes'] == 25
-            assert stats['total_steps'] > 25  # Should have multiple steps per episode
+            assert stats["total_episodes"] == 25
+            assert stats["total_steps"] > 25  # Should have multiple steps per episode
 
             # Save final checkpoint
-            final_checkpoint = checkpoint_dir / 'final.pt'
+            final_checkpoint = checkpoint_dir / "final.pt"
             trainer.save_checkpoint(final_checkpoint)
             assert final_checkpoint.exists()
 
             # Verify checkpoint contents
             checkpoint = torch.load(final_checkpoint)
-            assert checkpoint['total_episodes'] == 25
-            assert len(checkpoint['policies']) == 4
+            assert checkpoint["total_episodes"] == 25
+            assert len(checkpoint["policies"]) == 4
 
             # Verify all policies have reasonable state
-            for agent_id, state_dict in checkpoint['policies'].items():
+            for agent_id, state_dict in checkpoint["policies"].items():
                 assert len(state_dict) > 0
                 # Check that weights are finite (not NaN or Inf)
                 for param_name, param in state_dict.items():
-                    assert torch.isfinite(param).all(), \
+                    assert torch.isfinite(param).all(), (
                         f"Agent {agent_id} has non-finite weights in {param_name}"
+                    )
 
             # Save config
-            config_path = checkpoint_dir / 'config.json'
+            config_path = checkpoint_dir / "config.json"
             trainer.save_config(config_path)
             assert config_path.exists()
 
             # Verify match distribution is balanced
-            match_counts = stats['match_counts']
+            match_counts = stats["match_counts"]
             max_diff = max(match_counts) - min(match_counts)
             # With round-robin and 25 episodes, difference should be at most 1
             assert max_diff <= 1, f"Unbalanced matchmaking: {match_counts}"

--- a/tests/test_research_findings.py
+++ b/tests/test_research_findings.py
@@ -22,7 +22,7 @@ These tests use the evolved_v4 genomes and validate that:
 import json
 import itertools
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict
 
 import pytest
 import numpy as np
@@ -39,13 +39,8 @@ from bucket_brigade.envs.scenarios import (
     mixed_motivation_scenario,
     # Boundary scenarios
     glacial_spread_scenario,
-    explosive_spread_scenario,
     wildfire_scenario,
     # Mechanism design scenarios
-    free_work_scenario,
-    cheap_work_scenario,
-    expensive_work_scenario,
-    prohibitive_work_scenario,
     Scenario,
 )
 from bucket_brigade.evolution.fitness_rust import RustFitnessEvaluator
@@ -103,7 +98,7 @@ def load_all_evolved_v4_genomes() -> Dict[str, np.ndarray]:
     for scenario_name in BASE_SCENARIOS:
         try:
             genomes[scenario_name] = load_evolved_genome(scenario_name, "v4")
-        except:
+        except Exception:
             pass  # Skip if missing
     return genomes
 
@@ -401,7 +396,7 @@ class TestPopulationSizeInvariance:
 
             # Should have <10% degradation
             assert degradation < 0.10, (
-                f"Population size N={N} shows {degradation*100:.1f}% degradation "
+                f"Population size N={N} shows {degradation * 100:.1f}% degradation "
                 f"from baseline (N=4: {baseline_payoff:.1f}, N={N}: {payoff_n:.1f})"
             )
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -11,7 +11,7 @@ torch = pytest.importorskip(
     "torch", reason="torch not installed (install with: uv sync --extra rl)"
 )
 
-from bucket_brigade.training import PolicyNetwork
+from bucket_brigade.training import PolicyNetwork  # noqa: E402
 
 
 class TestPolicyNetwork:


### PR DESCRIPTION
## Summary

Fixes all ruff `check` and `format` failures in pre-existing Python files, unblocking the `lint-python` and `pre-commit` CI jobs that were revealed as failing in PR #147 evaluation.

## Changes

- **76 errors auto-fixed** by `uv run ruff check --fix .`
  - 46x F541 (f-string without placeholders): dropped `f` prefix
  - ~30x F401 (unused imports): removed
- **37 files reformatted** by `uv run ruff format .`
- **12 errors fixed manually** (see breakdown below)

### Manual Fixes

| Rule | File | Fix |
|------|------|-----|
| F821 (x2) | `bucket_brigade/envs/puffer_env.py:241,245` | **Real bug** — `spaces.Box(...)` and `spaces.MultiDiscrete(...)` -> `gym_spaces.Box(...)` and `gym_spaces.MultiDiscrete(...)` (the file imports `from gymnasium import spaces as gym_spaces`). See note below. |
| F841 (x2) | `experiments/marl/train_gpu_vectorized.py:270`, `experiments/marl/train_puffer_hybrid.py:238` | `mb_values` not consumed in PPO update — prefixed with `_` to preserve parallel structure with sibling minibatch slices |
| F841 | `experiments/marl/train_pufferlib.py:183` | Dropped unused `data = ` from `pufferlib.frameworks.cleanrl.train(...)` |
| F841 (x3) | `experiments/marl/train_rust_vectorized.py:53,167,202` | Prefixed `num_envs`, `episode_rewards`, `b_values` with `_` |
| F841 | `experiments/p3_specialization/analyze_plateau.py:328` | Prefixed `xs` with `_` (computed but plot path that uses it diverges) |
| F401 | `tests/conftest.py:44` | `import torch` is intentional availability probe — added `# noqa: F401` |
| E722 | `tests/test_research_findings.py:101` | `except:` -> `except Exception:` |
| E402 | `tests/test_training.py:14` | Import is intentionally placed after `pytest.importorskip("torch")` — added `# noqa: E402` |

### F821 Investigation (Real Bugs)

The two F821 errors in `bucket_brigade/envs/puffer_env.py` were **genuine NameErrors** that would crash at runtime in `PufferBucketBrigadeVectorized.__init__`. The file imports `gymnasium.spaces as gym_spaces` and uses `gym_spaces` correctly in the parent class, but lines 241 and 245 referenced bare `spaces`. Fixed by changing `spaces` to `gym_spaces`. The vectorized class is likely not yet exercised in tests (otherwise this would have surfaced earlier), but the fix is mechanical and obvious.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `uv run ruff check .` returns 0 errors | yes | `All checks passed!` |
| `uv run ruff format --check .` reports no changes | yes | `98 files already formatted` |
| Top affected modules still import | yes | `from bucket_brigade.envs import BucketBrigadeEnv` succeeds |
| Test collection unchanged | yes | `pytest tests/test_environment.py --collect-only` collects 25 tests |
| Pure lint/format cleanup, no refactors | yes | All changes are ruff-driven mechanical fixes |

## Test Plan

- [x] `uv run ruff check .` (with CI exclude flags) -> 0 errors (was 88)
- [x] `uv run ruff format --check .` -> 0 reformat (was 37)
- [x] `python -c "from bucket_brigade.envs import BucketBrigadeEnv"` -> ok
- [x] `pytest tests/test_environment.py --collect-only` -> 25 tests collected
- [x] `python -c "import ast; ast.parse(open('bucket_brigade/envs/puffer_env.py').read())"` -> ok
- [ ] CI `lint-python` job (runs on PR) — expected to pass
- [ ] CI `pre-commit` job (runs on PR) — expected to pass for ruff/ruff-format hooks; bandit remains out of scope per the issue

No heavy compute (training/evolution/Nash) was run, per CLAUDE.md guidance.

Closes #148