### PR TITLE
fix: Update 37 consumers of removed bucket_brigade.envs.scenarios module

### DIFF
--- a/experiments/scripts/analyze_heuristics.py
+++ b/experiments/scripts/analyze_heuristics.py
@@ -17,7 +17,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from bucket_brigade.envs import BucketBrigadeEnv
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.agents import create_archetype_agent
 from bucket_brigade.agents.archetypes import (
     FIREFIGHTER_PARAMS,
@@ -64,9 +64,9 @@ def analyze_heuristics(
     scenario = get_scenario_by_name(scenario_name, num_agents=4)
 
     print("Scenario Parameters:")
-    print(f"  beta (spread):       {scenario.beta:.2f}")
-    print(f"  kappa (extinguish):  {scenario.kappa:.2f}")
-    print(f"  c (work cost):       {scenario.c:.2f}")
+    print(f"  beta (spread):       {scenario.prob_fire_spreads_to_neighbor:.2f}")
+    print(f"  kappa (extinguish):  {scenario.prob_solo_agent_extinguishes_fire:.2f}")
+    print(f"  c (work cost):       {scenario.cost_to_work_one_night:.2f}")
     print(f"  num_agents:          {scenario.num_agents}")
     print()
 
@@ -179,12 +179,11 @@ def analyze_heuristics(
     results = {
         "scenario": scenario_name,
         "parameters": {
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "A": scenario.A,
-            "L": scenario.L,
-            "rho_ignite": scenario.rho_ignite,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "A": scenario.team_reward_house_survives,
+            "L": scenario.team_penalty_house_burns,
             "num_agents": scenario.num_agents,
         },
         "agents": [

--- a/experiments/scripts/compute_nash.py
+++ b/experiments/scripts/compute_nash.py
@@ -18,7 +18,7 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import DoubleOracle
 from bucket_brigade.agents.archetypes import (
     FIREFIGHTER_PARAMS,
@@ -88,9 +88,9 @@ def compute_nash_equilibrium(
     scenario = get_scenario_by_name(scenario_name, num_agents=4)
 
     print("Scenario Parameters:")
-    print(f"  beta (spread):       {scenario.beta:.2f}")
-    print(f"  kappa (extinguish):  {scenario.kappa:.2f}")
-    print(f"  c (work cost):       {scenario.c:.2f}")
+    print(f"  beta (spread):       {scenario.prob_fire_spreads_to_neighbor:.2f}")
+    print(f"  kappa (extinguish):  {scenario.prob_solo_agent_extinguishes_fire:.2f}")
+    print(f"  c (work cost):       {scenario.cost_to_work_one_night:.2f}")
     print(f"  num_agents:          {scenario.num_agents}")
     print()
 
@@ -236,12 +236,11 @@ def compute_nash_equilibrium(
     results = {
         "scenario": scenario_name,
         "parameters": {
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "A": scenario.A,
-            "L": scenario.L,
-            "rho_ignite": scenario.rho_ignite,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "A": scenario.team_reward_house_survives,
+            "L": scenario.team_penalty_house_burns,
             "num_agents": scenario.num_agents,
         },
         "algorithm": {

--- a/experiments/scripts/compute_nash_v2.py
+++ b/experiments/scripts/compute_nash_v2.py
@@ -22,7 +22,7 @@ from typing import Optional, List
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import (
     DoubleOracle,
     load_all_evolved_agents,
@@ -80,9 +80,9 @@ def compute_nash_v2(
     scenario = get_scenario_by_name(scenario_name, num_agents=4)
 
     print("Scenario Parameters:")
-    print(f"  beta (spread):       {scenario.beta:.2f}")
-    print(f"  kappa (extinguish):  {scenario.kappa:.2f}")
-    print(f"  c (work cost):       {scenario.c:.2f}")
+    print(f"  beta (spread):       {scenario.prob_fire_spreads_to_neighbor:.2f}")
+    print(f"  kappa (extinguish):  {scenario.prob_solo_agent_extinguishes_fire:.2f}")
+    print(f"  c (work cost):       {scenario.cost_to_work_one_night:.2f}")
     print(f"  num_agents:          {scenario.num_agents}")
     print()
 
@@ -302,12 +302,11 @@ def compute_nash_v2(
         "scenario": scenario_name,
         "version": "v2",
         "parameters": {
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "A": scenario.A,
-            "L": scenario.L,
-            "rho_ignite": scenario.rho_ignite,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "A": scenario.team_reward_house_survives,
+            "L": scenario.team_penalty_house_burns,
             "num_agents": scenario.num_agents,
         },
         "algorithm": {

--- a/experiments/scripts/diagnose_v4_failure.py
+++ b/experiments/scripts/diagnose_v4_failure.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.evolution import FitnessEvaluator, Individual
 from bucket_brigade.evolution.fitness_rust import (
     _heuristic_action,

--- a/experiments/scripts/evaluate_cross_scenario.py
+++ b/experiments/scripts/evaluate_cross_scenario.py
@@ -105,8 +105,12 @@ def evaluate_cross_scenario(
 
     if verbose:
         print("Test Scenario Parameters:")
-        print(f"  beta (spread):       {test_scenario_obj.prob_fire_spreads_to_neighbor:.2f}")
-        print(f"  kappa (extinguish):  {test_scenario_obj.prob_solo_agent_extinguishes_fire:.2f}")
+        print(
+            f"  beta (spread):       {test_scenario_obj.prob_fire_spreads_to_neighbor:.2f}"
+        )
+        print(
+            f"  kappa (extinguish):  {test_scenario_obj.prob_solo_agent_extinguishes_fire:.2f}"
+        )
         print(f"  c (work cost):       {test_scenario_obj.cost_to_work_one_night:.2f}")
         print()
 

--- a/experiments/scripts/evaluate_cross_scenario.py
+++ b/experiments/scripts/evaluate_cross_scenario.py
@@ -25,7 +25,7 @@ from typing import Optional
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import (
     load_evolved_agent,
     load_evolved_agent_metadata,
@@ -105,9 +105,9 @@ def evaluate_cross_scenario(
 
     if verbose:
         print("Test Scenario Parameters:")
-        print(f"  beta (spread):       {test_scenario_obj.beta:.2f}")
-        print(f"  kappa (extinguish):  {test_scenario_obj.kappa:.2f}")
-        print(f"  c (work cost):       {test_scenario_obj.c:.2f}")
+        print(f"  beta (spread):       {test_scenario_obj.prob_fire_spreads_to_neighbor:.2f}")
+        print(f"  kappa (extinguish):  {test_scenario_obj.prob_solo_agent_extinguishes_fire:.2f}")
+        print(f"  c (work cost):       {test_scenario_obj.cost_to_work_one_night:.2f}")
         print()
 
     # Create Rust evaluator for test scenario
@@ -147,11 +147,11 @@ def evaluate_cross_scenario(
         "elapsed_time": elapsed_time,
         "agent_metadata": agent_metadata,
         "test_scenario_params": {
-            "beta": test_scenario_obj.beta,
-            "kappa": test_scenario_obj.kappa,
-            "c": test_scenario_obj.c,
-            "A": test_scenario_obj.A,
-            "L": test_scenario_obj.L,
+            "beta": test_scenario_obj.prob_fire_spreads_to_neighbor,
+            "kappa": test_scenario_obj.prob_solo_agent_extinguishes_fire,
+            "c": test_scenario_obj.cost_to_work_one_night,
+            "A": test_scenario_obj.team_reward_house_survives,
+            "L": test_scenario_obj.team_penalty_house_burns,
             "num_agents": test_scenario_obj.num_agents,
         },
     }

--- a/experiments/scripts/generate_insights.py
+++ b/experiments/scripts/generate_insights.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Any
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import list_scenarios
+from bucket_brigade.envs import list_scenarios
 
 
 class InsightGenerator:

--- a/experiments/scripts/run_comparison.py
+++ b/experiments/scripts/run_comparison.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.evolution.fitness_rust import (
     _heuristic_action,
     _convert_scenario_to_rust,

--- a/experiments/scripts/run_evolution.py
+++ b/experiments/scripts/run_evolution.py
@@ -17,7 +17,7 @@ from typing import Optional
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.evolution import EvolutionConfig, GeneticAlgorithm
 
 
@@ -40,9 +40,9 @@ def run_evolution(
     scenario = get_scenario_by_name(scenario_name, num_agents=4)
 
     print("Scenario Parameters:")
-    print(f"  beta (spread):       {scenario.beta:.2f}")
-    print(f"  kappa (extinguish):  {scenario.kappa:.2f}")
-    print(f"  c (work cost):       {scenario.c:.2f}")
+    print(f"  beta (spread):       {scenario.prob_fire_spreads_to_neighbor:.2f}")
+    print(f"  kappa (extinguish):  {scenario.prob_solo_agent_extinguishes_fire:.2f}")
+    print(f"  c (work cost):       {scenario.cost_to_work_one_night:.2f}")
     print(f"  num_agents:          {scenario.num_agents}")
     print()
 

--- a/experiments/scripts/run_generalist_evolution.py
+++ b/experiments/scripts/run_generalist_evolution.py
@@ -17,7 +17,7 @@ from multiprocessing import Pool, cpu_count
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.evolution import EvolutionConfig, GeneticAlgorithm
 from bucket_brigade.evolution.fitness_rust import RustFitnessEvaluator
 from bucket_brigade.evolution.population import Individual

--- a/experiments/scripts/run_scenario_research.py
+++ b/experiments/scripts/run_scenario_research.py
@@ -16,7 +16,7 @@ from pathlib import Path
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import list_scenarios
+from bucket_brigade.envs import list_scenarios
 
 
 def run_command(cmd: list, description: str) -> bool:

--- a/experiments/scripts/test_boundary_scenarios.py
+++ b/experiments/scripts/test_boundary_scenarios.py
@@ -81,7 +81,9 @@ def main():
             "kappa": scenario.prob_solo_agent_extinguishes_fire,
         }
 
-        print(f"β={scenario.prob_fire_spreads_to_neighbor:.2f}, c={scenario.cost_to_work_one_night:.2f} → {payoff:.2f}")
+        print(
+            f"β={scenario.prob_fire_spreads_to_neighbor:.2f}, c={scenario.cost_to_work_one_night:.2f} → {payoff:.2f}"
+        )
 
     print()
     print("=" * 80)

--- a/experiments/scripts/test_boundary_scenarios.py
+++ b/experiments/scripts/test_boundary_scenarios.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import load_evolved_agent, PayoffEvaluator
 
 # Extreme scenarios to test
@@ -76,12 +76,12 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "c": scenario.c,
-            "kappa": scenario.kappa,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "c": scenario.cost_to_work_one_night,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
         }
 
-        print(f"β={scenario.beta:.2f}, c={scenario.c:.2f} → {payoff:.2f}")
+        print(f"β={scenario.prob_fire_spreads_to_neighbor:.2f}, c={scenario.cost_to_work_one_night:.2f} → {payoff:.2f}")
 
     print()
     print("=" * 80)

--- a/experiments/scripts/test_full_game.py
+++ b/experiments/scripts/test_full_game.py
@@ -10,14 +10,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import numpy as np
 from bucket_brigade.envs import BucketBrigadeEnv
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.agents import create_archetype_agent
 
 print("Starting full game test...")
 
 # Load scenario
 scenario = get_scenario_by_name("greedy_neighbor", num_agents=4)
-print(f"Scenario: beta={scenario.beta}, kappa={scenario.kappa}, c={scenario.c}")
+print(f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}, c={scenario.cost_to_work_one_night}")
 
 # Create environment
 env = BucketBrigadeEnv(scenario)

--- a/experiments/scripts/test_full_game.py
+++ b/experiments/scripts/test_full_game.py
@@ -17,7 +17,9 @@ print("Starting full game test...")
 
 # Load scenario
 scenario = get_scenario_by_name("greedy_neighbor", num_agents=4)
-print(f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}, c={scenario.cost_to_work_one_night}")
+print(
+    f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}, c={scenario.cost_to_work_one_night}"
+)
 
 # Create environment
 env = BucketBrigadeEnv(scenario)

--- a/experiments/scripts/test_mechanism_scenarios.py
+++ b/experiments/scripts/test_mechanism_scenarios.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import load_evolved_agent, PayoffEvaluator
 
 # Phase 2D mechanism scenarios
@@ -85,18 +85,17 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "p_spark": scenario.p_spark,
-            "rho_ignite": scenario.rho_ignite,
-            "A": scenario.A,
-            "L": scenario.L,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "p_spark": scenario.prob_house_catches_fire,
+            "A": scenario.team_reward_house_survives,
+            "L": scenario.team_penalty_house_burns,
             "type": "mechanism",
         }
 
         print(
-            f"β={scenario.beta:.2f}, c={scenario.c:.2f}, p_spark={scenario.p_spark:.2f} → {payoff:.2f}"
+            f"β={scenario.prob_fire_spreads_to_neighbor:.2f}, c={scenario.cost_to_work_one_night:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}"
         )
 
     print()
@@ -123,18 +122,17 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "p_spark": scenario.p_spark,
-            "rho_ignite": scenario.rho_ignite,
-            "A": scenario.A,
-            "L": scenario.L,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "p_spark": scenario.prob_house_catches_fire,
+            "A": scenario.team_reward_house_survives,
+            "L": scenario.team_penalty_house_burns,
             "type": "reference",
         }
 
         print(
-            f"β={scenario.beta:.2f}, c={scenario.c:.2f}, p_spark={scenario.p_spark:.2f} → {payoff:.2f}"
+            f"β={scenario.prob_fire_spreads_to_neighbor:.2f}, c={scenario.cost_to_work_one_night:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}"
         )
 
     print()

--- a/experiments/scripts/test_minimal.py
+++ b/experiments/scripts/test_minimal.py
@@ -10,14 +10,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import numpy as np
 from bucket_brigade.envs import BucketBrigadeEnv
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.agents import create_archetype_agent
 
 print("1. Importing modules... ✓")
 
 # Load scenario
 scenario = get_scenario_by_name("greedy_neighbor", num_agents=4)
-print(f"2. Loaded scenario: {scenario.beta=}, {scenario.kappa=}, {scenario.c=} ✓")
+print(f"2. Loaded scenario: {scenario.prob_fire_spreads_to_neighbor=}, {scenario.prob_solo_agent_extinguishes_fire=}, {scenario.cost_to_work_one_night=} ✓")
 
 # Create environment
 env = BucketBrigadeEnv(scenario)

--- a/experiments/scripts/test_minimal.py
+++ b/experiments/scripts/test_minimal.py
@@ -17,7 +17,9 @@ print("1. Importing modules... ✓")
 
 # Load scenario
 scenario = get_scenario_by_name("greedy_neighbor", num_agents=4)
-print(f"2. Loaded scenario: {scenario.prob_fire_spreads_to_neighbor=}, {scenario.prob_solo_agent_extinguishes_fire=}, {scenario.cost_to_work_one_night=} ✓")
+print(
+    f"2. Loaded scenario: {scenario.prob_fire_spreads_to_neighbor=}, {scenario.prob_solo_agent_extinguishes_fire=}, {scenario.cost_to_work_one_night=} ✓"
+)
 
 # Create environment
 env = BucketBrigadeEnv(scenario)

--- a/experiments/scripts/test_rust_python_parity.py
+++ b/experiments/scripts/test_rust_python_parity.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.evolution.fitness_rust import (
     _heuristic_action,
     _convert_scenario_to_rust,

--- a/experiments/scripts/test_scale_quick.py
+++ b/experiments/scripts/test_scale_quick.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json
 import numpy as np
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import load_evolved_agent, PayoffEvaluator
 
 # Population sizes to test

--- a/experiments/scripts/test_trivial_cooperation_anomaly.py
+++ b/experiments/scripts/test_trivial_cooperation_anomaly.py
@@ -82,7 +82,9 @@ def main():
             "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
+        print(
+            f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}"
+        )
 
     print()
     print("Testing p_spark (ongoing fires) sweep (κ=0.90)...")
@@ -118,7 +120,9 @@ def main():
             "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
+        print(
+            f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}"
+        )
 
     print()
     print("Testing reference scenarios...")
@@ -150,7 +154,9 @@ def main():
             "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
+        print(
+            f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}"
+        )
 
     print()
     print("=" * 80)

--- a/experiments/scripts/test_trivial_cooperation_anomaly.py
+++ b/experiments/scripts/test_trivial_cooperation_anomaly.py
@@ -12,7 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import load_evolved_agent, PayoffEvaluator
 
 # κ sweep scenarios (varying extinguish rate, p_spark=0)
@@ -76,13 +76,13 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "p_spark": scenario.p_spark,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.kappa:.2f}, p_spark={scenario.p_spark:.2f} → {payoff:.2f}")
+        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
 
     print()
     print("Testing p_spark (ongoing fires) sweep (κ=0.90)...")
@@ -112,13 +112,13 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "p_spark": scenario.p_spark,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.kappa:.2f}, p_spark={scenario.p_spark:.2f} → {payoff:.2f}")
+        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
 
     print()
     print("Testing reference scenarios...")
@@ -144,13 +144,13 @@ def main():
 
         results[scenario_name] = {
             "payoff": float(payoff),
-            "beta": scenario.beta,
-            "kappa": scenario.kappa,
-            "c": scenario.c,
-            "p_spark": scenario.p_spark,
+            "beta": scenario.prob_fire_spreads_to_neighbor,
+            "kappa": scenario.prob_solo_agent_extinguishes_fire,
+            "c": scenario.cost_to_work_one_night,
+            "p_spark": scenario.prob_house_catches_fire,
         }
 
-        print(f"κ={scenario.kappa:.2f}, p_spark={scenario.p_spark:.2f} → {payoff:.2f}")
+        print(f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f}, p_spark={scenario.prob_house_catches_fire:.2f} → {payoff:.2f}")
 
     print()
     print("=" * 80)

--- a/scripts/analyze_nash_equilibrium.py
+++ b/scripts/analyze_nash_equilibrium.py
@@ -12,7 +12,7 @@ Usage:
 import argparse
 import numpy as np
 from multiprocessing import cpu_count
-from bucket_brigade.envs.scenarios import get_scenario_by_name, list_scenarios
+from bucket_brigade.envs import get_scenario_by_name, list_scenarios
 from bucket_brigade.equilibrium import DoubleOracle
 from bucket_brigade.agents.archetypes import (
     FIREFIGHTER_PARAMS,
@@ -34,16 +34,15 @@ def print_scenario_info(scenario):
     """Print detailed scenario information."""
     print("Scenario Parameters:")
     print(f"  Fire Dynamics:")
-    print(f"    beta (spread probability):     {scenario.beta:.2f}")
-    print(f"    kappa (extinguish efficiency): {scenario.kappa:.2f}")
+    print(f"    beta (spread probability):     {scenario.prob_fire_spreads_to_neighbor:.2f}")
+    print(f"    kappa (extinguish efficiency): {scenario.prob_solo_agent_extinguishes_fire:.2f}")
     print(f"  Reward Structure:")
-    print(f"    A (reward per saved house):    {scenario.A:.2f}")
-    print(f"    L (penalty per ruined house):  {scenario.L:.2f}")
-    print(f"    c (cost per worker per night): {scenario.c:.2f}")
+    print(f"    A (reward per saved house):    {scenario.team_reward_house_survives:.2f}")
+    print(f"    L (penalty per ruined house):  {scenario.team_penalty_house_burns:.2f}")
+    print(f"    c (cost per worker per night): {scenario.cost_to_work_one_night:.2f}")
     print(f"  Initial Conditions:")
-    print(f"    rho_ignite (initial burn rate): {scenario.rho_ignite:.2f}")
-    print(f"    p_spark (spontaneous ignition): {scenario.p_spark:.2f}")
-    print(f"    N_min (minimum nights):         {scenario.N_min}")
+    print(f"    p_spark (spontaneous ignition): {scenario.prob_house_catches_fire:.2f}")
+    print(f"    N_min (minimum nights):         {scenario.min_nights}")
     print(f"    num_agents:                     {scenario.num_agents}")
 
 

--- a/scripts/evolve_agents.py
+++ b/scripts/evolve_agents.py
@@ -24,7 +24,7 @@ from bucket_brigade.evolution import (
     Individual,
     Population,
 )
-from bucket_brigade.envs.scenarios import default_scenario, greedy_neighbor_scenario
+from bucket_brigade.envs import default_scenario, greedy_neighbor_scenario
 
 
 def progress_callback(generation: int, population: Population) -> None:

--- a/scripts/evolve_remote.py
+++ b/scripts/evolve_remote.py
@@ -45,7 +45,7 @@ except (ImportError, ModuleNotFoundError) as e:
 
     RUST_AVAILABLE = False
 
-from bucket_brigade.envs.scenarios import default_scenario
+from bucket_brigade.envs import default_scenario
 
 
 class RemoteEvolutionRunner:

--- a/scripts/evolve_scenario_expert.py
+++ b/scripts/evolve_scenario_expert.py
@@ -23,7 +23,7 @@ from bucket_brigade.evolution import (
     Individual,
     Population,
 )
-from bucket_brigade.envs.scenarios import get_scenario_by_name, list_scenarios
+from bucket_brigade.envs import get_scenario_by_name, list_scenarios
 from bucket_brigade.agents.heuristic_agent import HeuristicAgent
 from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
 

--- a/scripts/evolve_v6.py
+++ b/scripts/evolve_v6.py
@@ -29,7 +29,7 @@ from bucket_brigade.evolution import (
     Individual,
     Population,
 )
-from bucket_brigade.envs.scenarios import get_scenario_by_name
+from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.agents.heuristic_agent import HeuristicAgent
 from bucket_brigade.agents.archetypes import ARCHETYPES
 from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv

--- a/scripts/evolve_v6_simple.py
+++ b/scripts/evolve_v6_simple.py
@@ -29,7 +29,7 @@ from bucket_brigade.evolution import (
     GeneticAlgorithm,
     Population,
 )
-from bucket_brigade.envs.scenarios import list_scenarios
+from bucket_brigade.envs import list_scenarios
 
 
 def progress_callback(generation: int, population: Population, output_dir: Path) -> None:

--- a/scripts/evolve_v7.py
+++ b/scripts/evolve_v7.py
@@ -34,7 +34,7 @@ from bucket_brigade.evolution.heterogeneous_evaluator import (
     HeterogeneousEvaluator,
     create_heterogeneous_evaluator,
 )
-from bucket_brigade.envs.scenarios import list_scenarios
+from bucket_brigade.envs import list_scenarios
 
 
 def progress_callback(generation: int, population: Population, output_dir: Path) -> None:

--- a/scripts/export_definitions.py
+++ b/scripts/export_definitions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from bucket_brigade.agents.archetypes import ARCHETYPES
-from bucket_brigade.envs.scenarios import SCENARIO_REGISTRY
+from bucket_brigade.envs import SCENARIO_REGISTRY
 
 
 def export_archetypes(output_path: Path):
@@ -45,14 +45,13 @@ def export_scenarios(output_path: Path):
         scenario = factory(num_agents=4)
 
         scenarios[name] = {
-            "beta": float(scenario.beta),
-            "kappa": float(scenario.kappa),
-            "A": float(scenario.A),
-            "L": float(scenario.L),
-            "c": float(scenario.c),
-            "rho_ignite": float(scenario.rho_ignite),
-            "N_min": int(scenario.N_min),
-            "p_spark": float(scenario.p_spark),
+            "beta": float(scenario.prob_fire_spreads_to_neighbor),
+            "kappa": float(scenario.prob_solo_agent_extinguishes_fire),
+            "A": float(scenario.team_reward_house_survives),
+            "L": float(scenario.team_penalty_house_burns),
+            "c": float(scenario.cost_to_work_one_night),
+            "N_min": int(scenario.min_nights),
+            "p_spark": float(scenario.prob_house_catches_fire),
             "N_spark": int(scenario.N_spark),
             "description": _get_scenario_description(name)
         }

--- a/scripts/test_nash_minimal.py
+++ b/scripts/test_nash_minimal.py
@@ -6,7 +6,7 @@ Tests basic functionality with absolute minimum parameters.
 """
 
 import numpy as np
-from bucket_brigade.envs.scenarios import trivial_cooperation_scenario
+from bucket_brigade.envs import trivial_cooperation_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 from bucket_brigade.equilibrium.payoff_evaluator import PayoffEvaluator
 
@@ -18,9 +18,9 @@ print("=" * 80)
 scenario = trivial_cooperation_scenario(num_agents=4)
 
 print("\nScenario: Trivial Cooperation")
-print(f"  beta (spread):    {scenario.beta}")
-print(f"  kappa (extinguish): {scenario.kappa}")
-print(f"  c (work cost):    {scenario.c}")
+print(f"  beta (spread):    {scenario.prob_fire_spreads_to_neighbor}")
+print(f"  kappa (extinguish): {scenario.prob_solo_agent_extinguishes_fire}")
+print(f"  c (work cost):    {scenario.cost_to_work_one_night}")
 print(f"  num_agents:       {scenario.num_agents}")
 
 # Create evaluator with VERY few simulations

--- a/scripts/test_nash_ultra_minimal.py
+++ b/scripts/test_nash_ultra_minimal.py
@@ -8,7 +8,7 @@ import numpy as np
 
 print("Starting ultra-minimal Nash equilibrium test...")
 
-from bucket_brigade.envs.scenarios import trivial_cooperation_scenario
+from bucket_brigade.envs import trivial_cooperation_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 from bucket_brigade.equilibrium.payoff_evaluator import PayoffEvaluator
 
@@ -16,7 +16,7 @@ print("Imports successful!")
 
 # Trivial scenario
 scenario = trivial_cooperation_scenario(num_agents=4)
-print(f"Scenario: beta={scenario.beta}, kappa={scenario.kappa}")
+print(f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}")
 
 # Just 2 simulations, sequential
 evaluator = PayoffEvaluator(

--- a/scripts/test_rust_fitness.py
+++ b/scripts/test_rust_fitness.py
@@ -6,7 +6,7 @@ Test Rust-backed fitness evaluator for evolution module.
 import time
 import numpy as np
 from bucket_brigade.evolution import FitnessEvaluator, Individual
-from bucket_brigade.envs.scenarios import default_scenario
+from bucket_brigade.envs import default_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 
 print("=" * 80)
@@ -16,9 +16,9 @@ print("=" * 80)
 # Create scenario
 scenario = default_scenario(num_agents=1)
 print(f"\nScenario: Default (num_agents=1)")
-print(f"  beta:  {scenario.beta}")
-print(f"  kappa: {scenario.kappa}")
-print(f"  c (work cost): {scenario.c}")
+print(f"  beta:  {scenario.prob_fire_spreads_to_neighbor}")
+print(f"  kappa: {scenario.prob_solo_agent_extinguishes_fire}")
+print(f"  c (work cost): {scenario.cost_to_work_one_night}")
 
 # Create Rust evaluator
 print("\n" + "-" * 80)

--- a/scripts/test_rust_payoff.py
+++ b/scripts/test_rust_payoff.py
@@ -5,7 +5,7 @@ Test Rust-backed payoff evaluator - should be FAST!
 
 import time
 import numpy as np
-from bucket_brigade.envs.scenarios import greedy_neighbor_scenario
+from bucket_brigade.envs import greedy_neighbor_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 from bucket_brigade.equilibrium.payoff_evaluator_rust import RustPayoffEvaluator
 
@@ -16,9 +16,9 @@ print("=" * 80)
 # Greedy neighbor scenario
 scenario = greedy_neighbor_scenario(num_agents=4)
 print(f"\nScenario: Greedy Neighbor (high work cost)")
-print(f"  beta:  {scenario.beta}")
-print(f"  kappa: {scenario.kappa}")
-print(f"  c (work cost): {scenario.c}  ← High cost creates free-riding incentive")
+print(f"  beta:  {scenario.prob_fire_spreads_to_neighbor}")
+print(f"  kappa: {scenario.prob_solo_agent_extinguishes_fire}")
+print(f"  c (work cost): {scenario.cost_to_work_one_night}  ← High cost creates free-riding incentive")
 
 # Create Rust evaluator
 print("\n" + "-" * 80)

--- a/test_rust_heuristic.py
+++ b/test_rust_heuristic.py
@@ -4,7 +4,7 @@ Quick test to verify Rust heuristic implementation works.
 
 import numpy as np
 from bucket_brigade.equilibrium.payoff_evaluator_rust import RustPayoffEvaluator
-from bucket_brigade.envs.scenarios import Scenario
+from bucket_brigade.envs import Scenario
 
 
 def test_rust_vs_python_heuristic():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture
 def trivial_scenario():
     """Create a trivial cooperation scenario for testing."""
-    from bucket_brigade.envs.scenarios import trivial_cooperation_scenario
+    from bucket_brigade.envs import trivial_cooperation_scenario
 
     return trivial_cooperation_scenario(num_agents=4)
 
@@ -84,7 +84,7 @@ def trivial_scenario():
 @pytest.fixture
 def easy_scenario():
     """Create an easy scenario for testing."""
-    from bucket_brigade.envs.scenarios import easy_scenario
+    from bucket_brigade.envs import easy_scenario
 
     return easy_scenario(num_agents=4)
 

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -6,7 +6,7 @@ Tests basic functionality with minimal simulations to verify correctness.
 
 import pytest
 import numpy as np
-from bucket_brigade.envs.scenarios import trivial_cooperation_scenario
+from bucket_brigade.envs import trivial_cooperation_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 from bucket_brigade.equilibrium.payoff_evaluator import PayoffEvaluator
 from bucket_brigade.equilibrium.best_response import compute_best_response

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -574,7 +574,7 @@ class TestParallelEvaluation:
 
     def test_parallel_with_scenario(self):
         """Test parallel evaluation with custom scenario."""
-        from bucket_brigade.envs.scenarios import default_scenario
+        from bucket_brigade.envs import default_scenario
         from bucket_brigade.evolution.fitness_rust import (
             RustFitnessEvaluator as FitnessEvaluator,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ import numpy as np
 from pathlib import Path
 import json
 
-from bucket_brigade.envs.scenarios import (
+from bucket_brigade.envs import (
     easy_scenario,
     trivial_cooperation_scenario,
 )

--- a/tests/test_research_findings.py
+++ b/tests/test_research_findings.py
@@ -27,7 +27,7 @@ from typing import Dict
 import pytest
 import numpy as np
 
-from bucket_brigade.envs.scenarios import (
+from bucket_brigade.envs import (
     trivial_cooperation_scenario,
     early_containment_scenario,
     greedy_neighbor_scenario,
@@ -37,12 +37,11 @@ from bucket_brigade.envs.scenarios import (
     deceptive_calm_scenario,
     overcrowding_scenario,
     mixed_motivation_scenario,
-    # Boundary scenarios
-    glacial_spread_scenario,
-    wildfire_scenario,
-    # Mechanism design scenarios
     Scenario,
 )
+# Boundary/mechanism scenarios (glacial_spread, explosive_spread, wildfire,
+# free_work, cheap_work, expensive_work, prohibitive_work) were removed in
+# commit 33cc6585; tests that depended on them are skipped below.
 from bucket_brigade.evolution.fitness_rust import RustFitnessEvaluator
 
 
@@ -252,6 +251,11 @@ class TestBoundaryRobustness:
     @pytest.mark.slow
     def test_extreme_beta_robustness(self):
         """Phase 2A: Universal strategy works on extreme β (fire spread) (slow: ~1 min)."""
+        pytest.skip(
+            "glacial_spread_scenario and wildfire_scenario were removed in "
+            "commit 33cc6585 (scenario pruning). Re-introducing boundary "
+            "scenarios is out of scope for this fix."
+        )
         universal = get_universal_genome()
 
         # Test extreme fire spread rates
@@ -285,13 +289,13 @@ class TestBoundaryRobustness:
             # Create custom scenario with specific p_spark
             scenario = Scenario(
                 num_agents=4,
-                beta=0.3,
-                kappa=0.2,
-                p_spark=p_spark,
-                A=100.0,
-                L=100.0,
-                c=5.0,
-                N_min=20,
+                prob_fire_spreads_to_neighbor=0.3,
+                prob_solo_agent_extinguishes_fire=0.2,
+                prob_house_catches_fire=p_spark,
+                team_reward_house_survives=100.0,
+                team_penalty_house_burns=100.0,
+                cost_to_work_one_night=5.0,
+                min_nights=20,
             )
 
             payoffs[p_spark] = evaluate_genome_on_scenario(

--- a/tests/test_research_findings.py
+++ b/tests/test_research_findings.py
@@ -39,6 +39,7 @@ from bucket_brigade.envs import (
     mixed_motivation_scenario,
     Scenario,
 )
+
 # Boundary/mechanism scenarios (glacial_spread, explosive_spread, wildfire,
 # free_work, cheap_work, expensive_work, prohibitive_work) were removed in
 # commit 33cc6585; tests that depended on them are skipped below.
@@ -256,25 +257,24 @@ class TestBoundaryRobustness:
             "commit 33cc6585 (scenario pruning). Re-introducing boundary "
             "scenarios is out of scope for this fix."
         )
-        universal = get_universal_genome()
-
-        # Test extreme fire spread rates
-        extreme_betas = [
-            (0.02, "glacial_spread", glacial_spread_scenario),
-            (0.75, "wildfire", wildfire_scenario),
-        ]
-
-        for beta, name, scenario_fn in extreme_betas:
-            scenario = scenario_fn(num_agents=4)
-            payoff = evaluate_genome_on_scenario(
-                universal, scenario, num_simulations=50, seed=42
-            )
-
-            # Should still achieve reasonable performance
-            assert payoff > 30, (
-                f"Universal genome failed on extreme β={beta} ({name}): "
-                f"payoff = {payoff:.1f} < 30"
-            )
+        # NOTE: body below is unreachable (pytest.skip raises) but retained
+        # for reference. The boundary scenario functions referenced here were
+        # removed; restore them or delete this test if the scenarios stay
+        # gone permanently.
+        # universal = get_universal_genome()
+        # extreme_betas = [
+        #     (0.02, "glacial_spread", glacial_spread_scenario),
+        #     (0.75, "wildfire", wildfire_scenario),
+        # ]
+        # for beta, name, scenario_fn in extreme_betas:
+        #     scenario = scenario_fn(num_agents=4)
+        #     payoff = evaluate_genome_on_scenario(
+        #         universal, scenario, num_simulations=50, seed=42
+        #     )
+        #     assert payoff > 30, (
+        #         f"Universal genome failed on extreme β={beta} ({name}): "
+        #         f"payoff = {payoff:.1f} < 30"
+        #     )
 
     @pytest.mark.slow
     def test_pspark_goldilocks_zone(self):

--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -178,7 +178,10 @@ class TestRustCoreIntegration:
 
             # Check key parameters match (use approximate comparison for floats)
             assert (
-                abs(rust_scenario.prob_fire_spreads_to_neighbor - python_scenario.prob_fire_spreads_to_neighbor)
+                abs(
+                    rust_scenario.prob_fire_spreads_to_neighbor
+                    - python_scenario.prob_fire_spreads_to_neighbor
+                )
                 < 1e-6
             )
             assert (
@@ -189,9 +192,17 @@ class TestRustCoreIntegration:
                 < 1e-6
             )
             assert (
-                abs(rust_scenario.team_reward_house_survives - python_scenario.team_reward_house_survives) < 1e-6
+                abs(
+                    rust_scenario.team_reward_house_survives
+                    - python_scenario.team_reward_house_survives
+                )
+                < 1e-6
             )
             assert (
-                abs(rust_scenario.team_penalty_house_burns - python_scenario.team_penalty_house_burns) < 1e-6
+                abs(
+                    rust_scenario.team_penalty_house_burns
+                    - python_scenario.team_penalty_house_burns
+                )
+                < 1e-6
             )
             # Note: num_agents is now a team composition parameter, not part of Scenario

--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -158,7 +158,7 @@ class TestRustCoreIntegration:
         except ImportError:
             pytest.skip("Rust core not available")
 
-        from bucket_brigade.envs.scenarios import (
+        from bucket_brigade.envs import (
             trivial_cooperation_scenario,
             early_containment_scenario,
             greedy_neighbor_scenario,
@@ -178,20 +178,20 @@ class TestRustCoreIntegration:
 
             # Check key parameters match (use approximate comparison for floats)
             assert (
-                abs(rust_scenario.prob_fire_spreads_to_neighbor - python_scenario.beta)
+                abs(rust_scenario.prob_fire_spreads_to_neighbor - python_scenario.prob_fire_spreads_to_neighbor)
                 < 1e-6
             )
             assert (
                 abs(
                     rust_scenario.prob_solo_agent_extinguishes_fire
-                    - python_scenario.kappa
+                    - python_scenario.prob_solo_agent_extinguishes_fire
                 )
                 < 1e-6
             )
             assert (
-                abs(rust_scenario.team_reward_house_survives - python_scenario.A) < 1e-6
+                abs(rust_scenario.team_reward_house_survives - python_scenario.team_reward_house_survives) < 1e-6
             )
             assert (
-                abs(rust_scenario.team_penalty_house_burns - python_scenario.L) < 1e-6
+                abs(rust_scenario.team_penalty_house_burns - python_scenario.team_penalty_house_burns) < 1e-6
             )
             # Note: num_agents is now a team composition parameter, not part of Scenario

--- a/tests/test_strategy_validation.py
+++ b/tests/test_strategy_validation.py
@@ -13,7 +13,7 @@ from scipy import stats
 
 from bucket_brigade.envs import BucketBrigadeEnv
 from bucket_brigade.agents import HeuristicAgent
-from bucket_brigade.envs.scenarios import (
+from bucket_brigade.envs import (
     early_containment_scenario,
     greedy_neighbor_scenario,
     rest_trap_scenario,


### PR DESCRIPTION
## Summary

Completes the migration started by PR #150. The `bucket_brigade.envs.scenarios` module was deleted in commit `27c76e74` (replaced by `scenarios_generated.py` with renamed fields), but 37 consumer files still imported from it. PR #150 only fixed `tests/test_environment.py`. This PR fixes the remaining 37, including the CI-blocking `tests/test_integration.py`.

## Changes

Mechanical rewrites driven by curator's 3-bucket matrix:

- **Bucket A (6 files, import rename only)**: `tests/conftest.py`, `tests/test_equilibrium.py`, `tests/test_evolution.py`, `tests/test_integration.py`, `tests/test_research_findings.py`, `tests/test_strategy_validation.py`
- **Bucket B (18 files, import + field renames + drop `.rho_ignite`)**: `tests/test_rust_integration.py`, `test_rust_heuristic.py`, 11 `experiments/scripts/*.py`, 6 `scripts/*.py`
- **Bucket C (13 files, import rename only)**: 7 `experiments/scripts/*.py` and 6 `scripts/evolve_*.py`

Field rename table applied to Bucket B (from PR #150):
| Old | New |
|---|---|
| `.beta` | `.prob_fire_spreads_to_neighbor` |
| `.kappa` | `.prob_solo_agent_extinguishes_fire` |
| `.c` | `.cost_to_work_one_night` |
| `.A` | `.team_reward_house_survives` |
| `.L` | `.team_penalty_house_burns` |
| `.p_spark` | `.prob_house_catches_fire` |
| `.N_min` | `.min_nights` |
| `.rho_ignite` | (removed — drop the line) |

### Skipped/Deleted Symbols

`tests/test_research_findings.py` imported seven scenario functions that were pruned in commit `33cc6585` (before the `scenarios.py` deletion): `glacial_spread_scenario`, `explosive_spread_scenario`, `wildfire_scenario`, `free_work_scenario`, `cheap_work_scenario`, `expensive_work_scenario`, `prohibitive_work_scenario`. Following PR #150's pattern for `sample_*_scenario`:

- Removed all seven dead imports.
- Added `pytest.skip(...)` to `test_extreme_beta_robustness` (only test that actually called the removed symbols at runtime — `glacial_spread`/`wildfire`).
- Updated `test_pspark_goldilocks_zone` to use the new `Scenario(...)` field names instead of old ones (its inline scenario construction would have raised `TypeError` otherwise).
- `test_free_work_*` / `test_cheap_work_*` test bodies did not actually call the removed scenario functions, so they remain runnable.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `grep -rlE "from bucket_brigade\.envs\.scenarios import" --include='*.py' .` returns nothing | Yes | Verified post-edit; 0 matches |
| All 37 files parse cleanly (AST) | Yes | `python -c "import ast; [ast.parse(open(p).read()) for p in <37 files>]"` succeeds |
| `tests/test_integration.py` collection passes | Yes | `pytest tests/test_rust_integration.py tests/test_integration.py --collect-only` -> 15 tests collected (was: 5 + 1 error on main) |
| `tests/` collection passes (minus pre-existing breakage in `test_code_generation.py`) | Yes | 251 tests collected, 0 errors (was: 213 tests, 4 errors on main) |
| Field-rename sanity in scope | Yes | `grep -E "scenario\.(beta\|kappa\|rho_ignite\|p_spark\|N_min\|A\|L\|c)\b"` on all 37 files returns no matches |
| `tests/test_environment.py` baseline unchanged | Yes | Still collects 25 tests as before |

## Test Plan

Targeted collection checks (full pytest not run — would launch training jobs per CLAUDE.md compute guideline):

```
$ pytest tests/test_rust_integration.py tests/test_integration.py --collect-only
15 tests collected in 1.95s    # vs 5 tests + collection error on main

$ pytest tests/ --collect-only --ignore=tests/test_code_generation.py
251 tests collected in 2.99s   # vs 213 tests + 4 errors on main

$ pytest tests/test_environment.py --collect-only
25 tests collected             # unchanged
```

`tests/test_code_generation.py` has a pre-existing `archetypes_generated` import failure unrelated to this issue (different module, different generator); out of scope.

Closes #155