### PR TITLE
test: cover A/L split reward fields and xfail-document four unused ones

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -559,9 +559,7 @@ class TestScenarioRewardFields:
         env = BucketBrigadeEnv(scenario=scenario)
         env.reset(seed=0)
         # Deterministic ownership: agent 0 owns house 0.
-        env.house_owners = np.array(
-            [0, 1, 2, 3, 0, 1, 2, 3, 0, 1], dtype=np.int8
-        )
+        env.house_owners = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1], dtype=np.int8)
         # Stage a SAFE-transition for agent 0's owned house 0 only.
         env._prev_houses_state = np.array(
             [env.BURNING, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8
@@ -590,13 +588,9 @@ class TestScenarioRewardFields:
         env = BucketBrigadeEnv(scenario=scenario)
         env.reset(seed=0)
         # Agent 0 owns house 0 only (others split among 1-3).
-        env.house_owners = np.array(
-            [0, 1, 2, 3, 1, 2, 3, 1, 2, 3], dtype=np.int8
-        )
+        env.house_owners = np.array([0, 1, 2, 3, 1, 2, 3, 1, 2, 3], dtype=np.int8)
         # House 0 is RUINED, owned by agent 0; everything else SAFE.
-        env.houses = np.array(
-            [env.RUINED, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8
-        )
+        env.houses = np.array([env.RUINED, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8)
         env._prev_houses_state = env.houses.copy()
         actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
         rewards = env._compute_rewards(actions)
@@ -624,9 +618,7 @@ class TestScenarioRewardFields:
             env = BucketBrigadeEnv(scenario=scenario)
             env.reset(seed=0)
             # Agent 0 owns *no* houses; houses 0-9 owned by agents 1-3.
-            env.house_owners = np.array(
-                [1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8
-            )
+            env.house_owners = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8)
             # All houses SAFE, all transitioned from BURNING this turn (so each
             # is a save event for its owner).
             env.houses = np.zeros(10, dtype=np.int8)
@@ -660,9 +652,7 @@ class TestScenarioRewardFields:
             env = BucketBrigadeEnv(scenario=scenario)
             env.reset(seed=0)
             # Agent 0 owns *no* houses.
-            env.house_owners = np.array(
-                [1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8
-            )
+            env.house_owners = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8)
             # All houses RUINED, owned by others. Agent 0 has zero owned
             # ruined houses, so the hardcoded -2.0*owned_ruined is 0 for agent 0
             # and any difference must come from penalty_other_house_burns.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,7 +1,12 @@
 """Tests for the Bucket Brigade environment."""
 
+import dataclasses
+
 import numpy as np
+import pytest
+
 from bucket_brigade.envs import BucketBrigadeEnv, default_scenario, random_scenario
+from bucket_brigade.envs.scenarios_generated import Scenario
 
 
 class TestBucketBrigadeEnv:
@@ -366,4 +371,309 @@ class TestScenarioFunctions:
 
         pytest.skip(
             "sample_deception_scenario removed in commit 27c76e74 (scenarios.py -> scenarios_generated.py refactor)"
+        )
+
+
+# Helper: indices of the six reward fields inside Scenario.to_feature_vector()
+# Mirrors scenarios_generated.py:51-67 (see issue #157).
+REWARD_FIELD_INDICES = {
+    "team_reward_house_survives": 3,
+    "team_penalty_house_burns": 4,
+    "reward_own_house_survives": 5,
+    "reward_other_house_survives": 6,
+    "penalty_own_house_burns": 7,
+    "penalty_other_house_burns": 8,
+}
+
+
+def _make_minimal_scenario(**overrides) -> Scenario:
+    """Build a Scenario with all reward/cost fields zeroed except those overridden.
+
+    Used to isolate the contribution of a single reward field to ``_compute_rewards``.
+    """
+    base = dict(
+        prob_fire_spreads_to_neighbor=0.0,
+        prob_solo_agent_extinguishes_fire=0.0,
+        prob_house_catches_fire=0.0,
+        team_reward_house_survives=0.0,
+        team_penalty_house_burns=0.0,
+        reward_own_house_survives=0.0,
+        reward_other_house_survives=0.0,
+        penalty_own_house_burns=0.0,
+        penalty_other_house_burns=0.0,
+        cost_to_work_one_night=0.0,
+        min_nights=12,
+        num_agents=4,
+    )
+    base.update(overrides)
+    return Scenario(**base)
+
+
+class TestScenarioRewardFields:
+    """Regression and behavior coverage for the six Scenario reward fields.
+
+    Context (issue #157): After the A/L split in PR #150, ``Scenario`` exposes six
+    reward fields, but only two (``team_reward_house_survives`` and
+    ``team_penalty_house_burns``) are actually consumed by
+    ``BucketBrigadeEnv._compute_rewards`` and the Rust ``rewards.rs`` engine. The
+    four ownership-variant fields are currently shadowed by hardcoded constants
+    (``+1.0`` / ``-2.0``) for ``own`` houses and are entirely unreferenced for
+    ``other`` houses.
+
+    This class:
+      * Guards the field names and feature-vector layout against accidental
+        rename/reorder (AC1, AC2).
+      * Verifies behavior of the two reward fields that ARE wired up (AC3).
+      * Uses ``xfail(strict=False)`` to *document* that the four remaining fields
+        are not yet honored by reward computation (AC4). These xfails will turn
+        into XPASS once a future PR wires the fields up; that is intentional and
+        signals the fix.
+    """
+
+    # --- AC1: field-name regression ----------------------------------------
+
+    def test_scenario_has_all_six_reward_fields(self):
+        """All six post-A/L-split reward fields must exist on ``Scenario``."""
+        field_names = {f.name for f in dataclasses.fields(Scenario)}
+        for name in REWARD_FIELD_INDICES:
+            assert name in field_names, (
+                f"Scenario dataclass is missing reward field {name!r}. "
+                "If this field was renamed, update REWARD_FIELD_INDICES and "
+                "every reward-computation site that references it."
+            )
+
+    def test_scenario_reward_fields_are_readable(self):
+        """Each reward field accepts and round-trips a distinct non-default value."""
+        scenario = _make_minimal_scenario(
+            team_reward_house_survives=11.0,
+            team_penalty_house_burns=12.0,
+            reward_own_house_survives=13.0,
+            reward_other_house_survives=14.0,
+            penalty_own_house_burns=15.0,
+            penalty_other_house_burns=16.0,
+        )
+        assert scenario.team_reward_house_survives == 11.0
+        assert scenario.team_penalty_house_burns == 12.0
+        assert scenario.reward_own_house_survives == 13.0
+        assert scenario.reward_other_house_survives == 14.0
+        assert scenario.penalty_own_house_burns == 15.0
+        assert scenario.penalty_other_house_burns == 16.0
+
+    # --- AC2: feature-vector layout -----------------------------------------
+
+    def test_feature_vector_length_is_twelve(self):
+        """``to_feature_vector`` returns the expected 12-element layout."""
+        features = default_scenario(num_agents=4).to_feature_vector()
+        assert features.shape == (12,)
+
+    def test_reward_fields_at_expected_feature_indices(self):
+        """Each reward field surfaces at the index documented in issue #157."""
+        scenario = _make_minimal_scenario(
+            team_reward_house_survives=11.0,
+            team_penalty_house_burns=12.0,
+            reward_own_house_survives=13.0,
+            reward_other_house_survives=14.0,
+            penalty_own_house_burns=15.0,
+            penalty_other_house_burns=16.0,
+        )
+        features = scenario.to_feature_vector()
+        for name, idx in REWARD_FIELD_INDICES.items():
+            assert features[idx] == pytest.approx(getattr(scenario, name)), (
+                f"Feature index {idx} should expose {name}. "
+                "If indices have shifted, update REWARD_FIELD_INDICES and any "
+                "consumer (e.g. observation.rs, payoff_evaluator_rust.py)."
+            )
+
+    # --- AC3: behavior tests for the two reward fields actually in use ------
+
+    def test_team_reward_house_survives_scales_per_agent_reward(self):
+        """Doubling ``team_reward_house_survives`` doubles the team component."""
+        # Two scenarios that differ ONLY in team_reward_house_survives.
+        scenario_low = _make_minimal_scenario(team_reward_house_survives=10.0)
+        scenario_high = _make_minimal_scenario(team_reward_house_survives=20.0)
+
+        def reward_with(scenario: Scenario) -> np.ndarray:
+            env = BucketBrigadeEnv(scenario=scenario)
+            env.reset(seed=0)
+            # All houses safe; no transitions => only team component fires.
+            env.houses = np.zeros(10, dtype=np.int8)
+            env._prev_houses_state = env.houses.copy()
+            # All agents REST so cost_to_work_one_night is irrelevant (=0 anyway).
+            actions = np.zeros((env.num_agents, 2), dtype=np.int8)
+            return env._compute_rewards(actions)
+
+        low_rewards = reward_with(scenario_low)
+        high_rewards = reward_with(scenario_high)
+
+        # Each agent has a 0.5 rest bonus; the team component is the only other
+        # contribution because all_safe + no transitions + zero costs.
+        # team_component = team_reward_house_survives * 1.0 (saved fraction)
+        # so the *difference* per agent must equal 20.0 - 10.0 == 10.0.
+        diff = high_rewards - low_rewards
+        assert np.allclose(diff, 10.0), (
+            "Per-agent reward delta should equal the team_reward_house_survives "
+            f"delta when all houses are safe. Got {diff!r}."
+        )
+
+    def test_team_penalty_house_burns_scales_per_agent_reward(self):
+        """Doubling ``team_penalty_house_burns`` doubles the team penalty."""
+        scenario_low = _make_minimal_scenario(team_penalty_house_burns=10.0)
+        scenario_high = _make_minimal_scenario(team_penalty_house_burns=20.0)
+
+        def reward_with(scenario: Scenario) -> np.ndarray:
+            env = BucketBrigadeEnv(scenario=scenario)
+            env.reset(seed=0)
+            # All houses ruined; no SAFE-transitions => only team penalty fires
+            # (plus the per-agent owned-ruined hardcoded -2.0, but that is
+            # *identical* between the two scenarios so it cancels in the delta).
+            env.houses = np.full(10, env.RUINED, dtype=np.int8)
+            env._prev_houses_state = env.houses.copy()
+            actions = np.zeros((env.num_agents, 2), dtype=np.int8)
+            return env._compute_rewards(actions)
+
+        low_rewards = reward_with(scenario_low)
+        high_rewards = reward_with(scenario_high)
+
+        # Burned fraction is 1.0 for all 10 houses, so the per-agent delta is
+        # -(20.0 - 10.0) == -10.0 (penalty grew more negative).
+        diff = high_rewards - low_rewards
+        assert np.allclose(diff, -10.0), (
+            "Per-agent reward delta should equal -(team_penalty_house_burns) "
+            f"delta when all houses are ruined. Got {diff!r}."
+        )
+
+    # --- AC4: xfail-documented bugs for the four unused reward fields -------
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Issue #157: reward_own_house_survives is shadowed by a hardcoded "
+            "+1.0 in BucketBrigadeEnv._compute_rewards (bucket_brigade_env.py:273) "
+            "and in Rust rewards.rs:36. Scenario value is ignored. Test will "
+            "XPASS once the wire-up lands."
+        ),
+    )
+    def test_reward_own_house_survives_is_honored(self):
+        """Per-agent saved-own-house bonus should equal ``reward_own_house_survives``."""
+        scenario = _make_minimal_scenario(reward_own_house_survives=10.0)
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # Deterministic ownership: agent 0 owns house 0.
+        env.house_owners = np.array(
+            [0, 1, 2, 3, 0, 1, 2, 3, 0, 1], dtype=np.int8
+        )
+        # Stage a SAFE-transition for agent 0's owned house 0 only.
+        env._prev_houses_state = np.array(
+            [env.BURNING, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8
+        )
+        env.houses = np.zeros(10, dtype=np.int8)  # all SAFE now
+        actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
+        rewards = env._compute_rewards(actions)
+
+        # team_reward_house_survives is 0; rest bonus is +0.5; expected own-save
+        # bonus is +10.0 (from scenario), so agent 0 should be 10.5. Currently
+        # gets 1.5 because of the hardcoded +1.0.
+        assert rewards[0] == pytest.approx(10.5)
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Issue #157: penalty_own_house_burns is shadowed by a hardcoded "
+            "-2.0 in BucketBrigadeEnv._compute_rewards (bucket_brigade_env.py:277) "
+            "and in Rust rewards.rs:41. Scenario value is ignored. Test will "
+            "XPASS once the wire-up lands."
+        ),
+    )
+    def test_penalty_own_house_burns_is_honored(self):
+        """Per-agent owned-ruined penalty should equal ``-penalty_own_house_burns``."""
+        scenario = _make_minimal_scenario(penalty_own_house_burns=10.0)
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # Agent 0 owns house 0 only (others split among 1-3).
+        env.house_owners = np.array(
+            [0, 1, 2, 3, 1, 2, 3, 1, 2, 3], dtype=np.int8
+        )
+        # House 0 is RUINED, owned by agent 0; everything else SAFE.
+        env.houses = np.array(
+            [env.RUINED, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8
+        )
+        env._prev_houses_state = env.houses.copy()
+        actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
+        rewards = env._compute_rewards(actions)
+
+        # rest bonus +0.5; owned-ruined penalty should be -10.0 (from scenario).
+        # Currently agent 0 gets 0.5 - 2.0 = -1.5 because of the hardcoded -2.0.
+        assert rewards[0] == pytest.approx(-9.5)
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Issue #157: reward_other_house_survives is never referenced in "
+            "BucketBrigadeEnv._compute_rewards or Rust rewards.rs. Changing it "
+            "has no effect on rewards. Test will XPASS once the field is wired "
+            "up."
+        ),
+    )
+    def test_reward_other_house_survives_affects_rewards(self):
+        """Two scenarios differing only in ``reward_other_house_survives`` must yield
+        different per-agent rewards when other-owned houses survive."""
+        scenario_low = _make_minimal_scenario(reward_other_house_survives=0.0)
+        scenario_high = _make_minimal_scenario(reward_other_house_survives=10.0)
+
+        def reward_for_agent_zero(scenario: Scenario) -> float:
+            env = BucketBrigadeEnv(scenario=scenario)
+            env.reset(seed=0)
+            # Agent 0 owns *no* houses; houses 0-9 owned by agents 1-3.
+            env.house_owners = np.array(
+                [1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8
+            )
+            # All houses SAFE, all transitioned from BURNING this turn (so each
+            # is a save event for its owner).
+            env.houses = np.zeros(10, dtype=np.int8)
+            env._prev_houses_state = np.full(10, env.BURNING, dtype=np.int8)
+            actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
+            return float(env._compute_rewards(actions)[0])
+
+        low = reward_for_agent_zero(scenario_low)
+        high = reward_for_agent_zero(scenario_high)
+        assert high != low, (
+            "reward_other_house_survives currently has no effect; both scenarios "
+            f"produced reward={low} for agent 0."
+        )
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Issue #157: penalty_other_house_burns is never referenced in "
+            "BucketBrigadeEnv._compute_rewards or Rust rewards.rs. Changing it "
+            "has no effect on rewards. Test will XPASS once the field is wired "
+            "up."
+        ),
+    )
+    def test_penalty_other_house_burns_affects_rewards(self):
+        """Two scenarios differing only in ``penalty_other_house_burns`` must yield
+        different per-agent rewards when other-owned houses are ruined."""
+        scenario_low = _make_minimal_scenario(penalty_other_house_burns=0.0)
+        scenario_high = _make_minimal_scenario(penalty_other_house_burns=10.0)
+
+        def reward_for_agent_zero(scenario: Scenario) -> float:
+            env = BucketBrigadeEnv(scenario=scenario)
+            env.reset(seed=0)
+            # Agent 0 owns *no* houses.
+            env.house_owners = np.array(
+                [1, 2, 3, 1, 2, 3, 1, 2, 3, 1], dtype=np.int8
+            )
+            # All houses RUINED, owned by others. Agent 0 has zero owned
+            # ruined houses, so the hardcoded -2.0*owned_ruined is 0 for agent 0
+            # and any difference must come from penalty_other_house_burns.
+            env.houses = np.full(10, env.RUINED, dtype=np.int8)
+            env._prev_houses_state = env.houses.copy()
+            actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
+            return float(env._compute_rewards(actions)[0])
+
+        low = reward_for_agent_zero(scenario_low)
+        high = reward_for_agent_zero(scenario_high)
+        assert high != low, (
+            "penalty_other_house_burns currently has no effect; both scenarios "
+            f"produced reward={low} for agent 0."
         )


### PR DESCRIPTION
## Summary

Adds dedicated coverage for the six `Scenario` reward fields introduced by PR #150's A/L split. Two of them (`team_reward_house_survives`, `team_penalty_house_burns`) get real behavior tests; the four ownership-variant fields get `xfail(strict=False)` tests that document the bug Curator surfaced in issue #157: `_compute_rewards` (Python and Rust) ignores those fields and uses hardcoded `+1.0`/`-2.0` constants instead.

This PR adds tests only. The reward wire-up itself is deliberately deferred and should be a follow-up issue.

## Changes

- `tests/test_environment.py`: new `TestScenarioRewardFields` class plus a `_make_minimal_scenario` helper that zeroes everything except the field under test.
- Top-of-file imports updated for `dataclasses`, `pytest`, and `Scenario`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: field-name regression for all 6 fields | Pass | `test_scenario_has_all_six_reward_fields` introspects `dataclasses.fields(Scenario)`; `test_scenario_reward_fields_are_readable` round-trips distinct values for each |
| AC2: `to_feature_vector` length 12 and reward fields at indices 3-8 | Pass | `test_feature_vector_length_is_twelve` + `test_reward_fields_at_expected_feature_indices` (parameterized via `REWARD_FIELD_INDICES`) |
| AC3: behavior tests for the two consumed fields | Pass | `test_team_reward_house_survives_scales_per_agent_reward` (all-SAFE, delta == +10) and `test_team_penalty_house_burns_scales_per_agent_reward` (all-RUINED, delta == -10) |
| AC4: xfail documentation for 4 unused fields | Pass | Four `xfail(strict=False)` tests, each with a `reason=` string naming the file/line of the hardcoded constant |
| AC5: `uv run pytest tests/test_environment.py -v` passes | Pass | 27 passed, 4 xfailed, 4 skipped (skips pre-existing, unrelated) |

## Test Plan

```
uv run pytest tests/test_environment.py -v
# 27 passed, 4 skipped, 4 xfailed in ~2s
```

- All new tests pass.
- The four xfail tests are reported as XFAIL (expected failure) rather than failed — when a future PR wires up the four unused fields, they will turn into XPASS, which is the intended signal.
- No existing tests were modified.

## Out of Scope (Follow-ups)

- Wiring `reward_own_house_survives`, `penalty_own_house_burns`, `reward_other_house_survives`, `penalty_other_house_burns` into `BucketBrigadeEnv._compute_rewards` and Rust `rewards.rs`. The xfail reasons in this PR point at the exact lines.
- Fixing the Rust↔Python feature-vector ordering mismatch noted in the Curator investigation (`engine/observation.rs:23-36` vs `scenarios_generated.py:51-67`).

Closes #157