### PR TITLE
feat: Add optional return normalization to JointPPOTrainer for #159 ablation

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -44,6 +44,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 from bucket_brigade.training.networks import PolicyNetwork, compute_gae
+from bucket_brigade.training.normalizers import RunningMeanStd
 
 
 __all__ = ["JointPPOTrainer", "RolloutBuffer", "flatten_dict_obs"]
@@ -114,6 +115,11 @@ class JointPPOTrainer:
             split into multiple chunks in a future revision if needed).
         device: ``"cpu"`` or ``"cuda"``.
         seed: Optional torch + env seed for reproducibility.
+        normalize_returns: If True, maintain a running mean/std of returns
+            (Welford / Chan) shared across all agents and divide returns by
+            ``sqrt(var + 1e-8)`` before the value-loss MSE. Default ``False``
+            preserves prior behavior. See issue #159 for the motivating
+            value-loss-magnitude diagnostics.
     """
 
     def __init__(
@@ -135,6 +141,7 @@ class JointPPOTrainer:
         minibatch_size: int = 256,
         device: str = "cpu",
         seed: Optional[int] = None,
+        normalize_returns: bool = False,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
@@ -152,6 +159,14 @@ class JointPPOTrainer:
         self.redundancy_coef = redundancy_coef
         self.ppo_epochs = ppo_epochs
         self.minibatch_size = minibatch_size
+
+        # Issue #159: optional running mean/std of returns to shrink the
+        # value-loss MSE target to O(1) (Phase 1 diagnostics showed
+        # value_term/policy_term ~ 10^6-10^7).
+        self.normalize_returns = normalize_returns
+        self._return_rms: Optional[RunningMeanStd] = (
+            RunningMeanStd(shape=()) if normalize_returns else None
+        )
 
         self.device = torch.device(device)
 
@@ -352,6 +367,25 @@ class JointPPOTrainer:
             )
             advantages[i] = (adv - adv.mean()) / (adv.std() + 1e-8)
             returns[i] = ret
+
+        # Issue #159: optional return normalization. Update the shared running
+        # mean/std from the concatenation of all agents' returns (commensurate
+        # since rewards live on the same scale), then scale each agent's
+        # returns by 1/sqrt(var + eps). This shrinks the MSE target to O(1)
+        # so that vf_coef=0.5 isn't dwarfing the policy gradient. Advantages
+        # are already standardized above and are NOT rescaled here (they enter
+        # the policy loss, not the value loss).
+        if self._return_rms is not None:
+            all_returns = (
+                torch.cat([returns[i] for i in range(self.num_agents)])
+                .detach()
+                .cpu()
+                .numpy()
+            )
+            self._return_rms.update(all_returns)
+            scale = float(np.sqrt(self._return_rms.var + 1e-8))
+            for i in range(self.num_agents):
+                returns[i] = returns[i] / scale
 
         stats: Dict[str, float] = {
             f"policy_loss/agent_{i}": 0.0 for i in range(self.num_agents)

--- a/bucket_brigade/training/normalizers.py
+++ b/bucket_brigade/training/normalizers.py
@@ -1,0 +1,77 @@
+"""Running statistics helpers for RL training.
+
+Currently exposes :class:`RunningMeanStd`, an online (Welford / Chan)
+mean+variance estimator used by :class:`JointPPOTrainer` to optionally
+normalize returns before the value-loss MSE. See issue #159 for the
+motivating Phase 1 diagnostics (value loss six to seven orders of
+magnitude larger than the policy term).
+
+The implementation follows the parallel/Chan update used in OpenAI
+baselines / Stable-Baselines3 ``VecNormalize`` so that a whole batch can
+be folded in with one update rather than one sample at a time.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+__all__ = ["RunningMeanStd"]
+
+
+class RunningMeanStd:
+    """Online mean / variance over a stream of batches.
+
+    Tracks ``mean``, ``var``, and ``count`` using Chan's parallel
+    variance update (numerically stable, ``O(1)`` memory). Intended for
+    scalar streams (e.g., flattened PPO returns) but works for any
+    fixed-shape ``ndarray`` per sample.
+
+    Args:
+        epsilon: Initial pseudo-count to avoid division by zero on the
+            first ``update``. The reported ``var`` is biased toward
+            ``1.0`` until enough real samples have arrived.
+        shape: Shape of a single sample. ``()`` for a scalar stream.
+    """
+
+    def __init__(self, epsilon: float = 1e-4, shape: tuple = ()) -> None:
+        self.mean = np.zeros(shape, dtype=np.float64)
+        self.var = np.ones(shape, dtype=np.float64)
+        self.count = float(epsilon)
+
+    def update(self, x: np.ndarray) -> None:
+        """Fold a batch of samples into the running statistics.
+
+        ``x`` is treated as ``(batch, *shape)``; the leading axis is
+        reduced.
+        """
+        x = np.asarray(x, dtype=np.float64)
+        batch_mean = x.mean(axis=0)
+        batch_var = x.var(axis=0)
+        batch_count = x.shape[0]
+        self._update_from_moments(batch_mean, batch_var, batch_count)
+
+    def _update_from_moments(
+        self,
+        batch_mean: np.ndarray,
+        batch_var: np.ndarray,
+        batch_count: int,
+    ) -> None:
+        # Chan / parallel-algorithm combine of two (mean, M2, count) blocks.
+        delta = batch_mean - self.mean
+        tot_count = self.count + batch_count
+
+        new_mean = self.mean + delta * batch_count / tot_count
+        m_a = self.var * self.count
+        m_b = batch_var * batch_count
+        m2 = m_a + m_b + np.square(delta) * self.count * batch_count / tot_count
+        new_var = m2 / tot_count
+
+        self.mean = new_mean
+        self.var = new_var
+        self.count = tot_count
+
+    @property
+    def std(self) -> np.ndarray:
+        """Standard deviation, computed lazily from ``var``."""
+        return np.sqrt(self.var)

--- a/experiments/p3_specialization/run_sweep.py
+++ b/experiments/p3_specialization/run_sweep.py
@@ -42,6 +42,7 @@ def run_sweep(
     skip_existing: bool,
     value_coef: float = CellConfig.__dataclass_fields__["value_coef"].default,
     entropy_coef: float = CellConfig.__dataclass_fields__["entropy_coef"].default,
+    normalize_returns: bool = CellConfig.__dataclass_fields__["normalize_returns"].default,
 ) -> None:
     n_cells = len(scenarios) * len(lambdas) * len(seeds)
     print(
@@ -49,7 +50,10 @@ def run_sweep(
         f"({len(scenarios)} scenarios x {len(lambdas)} lambdas x {len(seeds)} seeds)"
     )
     print(f"Output root: {output_root}")
-    print(f"PPO coefs: value_coef={value_coef}, entropy_coef={entropy_coef}")
+    print(
+        f"PPO coefs: value_coef={value_coef}, entropy_coef={entropy_coef}, "
+        f"normalize_returns={normalize_returns}"
+    )
 
     t0 = time.time()
     done = 0
@@ -76,6 +80,7 @@ def run_sweep(
                     num_agents=num_agents,
                     value_coef=value_coef,
                     entropy_coef=entropy_coef,
+                    normalize_returns=normalize_returns,
                     device=device,
                 )
 
@@ -129,6 +134,15 @@ def main() -> None:
             "prevent entropy collapse (issue #153)."
         ),
     )
+    p.add_argument(
+        "--normalize-returns",
+        action="store_true",
+        help=(
+            "Issue #159: normalize PPO returns by running std before the "
+            "value-loss MSE on every cell in the sweep. Default off preserves "
+            "existing behavior; flip on for the 4-cell ablation."
+        ),
+    )
     args = p.parse_args()
 
     run_sweep(
@@ -143,6 +157,7 @@ def main() -> None:
         skip_existing=args.skip_existing,
         value_coef=args.value_coef,
         entropy_coef=args.entropy_coef,
+        normalize_returns=args.normalize_returns,
     )
 
 

--- a/experiments/p3_specialization/run_sweep.py
+++ b/experiments/p3_specialization/run_sweep.py
@@ -42,7 +42,9 @@ def run_sweep(
     skip_existing: bool,
     value_coef: float = CellConfig.__dataclass_fields__["value_coef"].default,
     entropy_coef: float = CellConfig.__dataclass_fields__["entropy_coef"].default,
-    normalize_returns: bool = CellConfig.__dataclass_fields__["normalize_returns"].default,
+    normalize_returns: bool = CellConfig.__dataclass_fields__[
+        "normalize_returns"
+    ].default,
 ) -> None:
     n_cells = len(scenarios) * len(lambdas) * len(seeds)
     print(

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -60,6 +60,9 @@ class CellConfig:
     # (see ``experiments/p3_specialization/diagnostics/summary.md``).
     value_coef: float = 0.5
     entropy_coef: float = 0.01
+    # Issue #159: optional return normalization. Default False preserves
+    # existing behavior; flip on for the ablation cells.
+    normalize_returns: bool = False
     # Encoder outputs are quantized for plug-in MI. We first project from
     # ``hidden_size`` down to ``mi_proj_dims`` via a fixed random matrix
     # (seeded from ``seed``); then ``quantize_uniform`` packs each row into
@@ -190,6 +193,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         value_coef=cfg.value_coef,
         entropy_coef=cfg.entropy_coef,
         redundancy_coef=cfg.lambda_red,
+        normalize_returns=cfg.normalize_returns,
         device=cfg.device,
         seed=cfg.seed,
     )
@@ -276,6 +280,15 @@ def main() -> None:
             "Raised in Phase 2 sweeps to prevent entropy collapse (issue #153)."
         ),
     )
+    p.add_argument(
+        "--normalize-returns",
+        action="store_true",
+        help=(
+            "Issue #159: normalize PPO returns by running std before the "
+            "value-loss MSE. Default off preserves existing behavior; flip on "
+            "for the 4-cell ablation."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -288,6 +301,7 @@ def main() -> None:
         num_agents=args.num_agents,
         value_coef=args.value_coef,
         entropy_coef=args.entropy_coef,
+        normalize_returns=args.normalize_returns,
         device=args.device,
     )
     print(


### PR DESCRIPTION
Closes #159 (implementation + plumbing; 4-cell ablation sweep on sandbox-1 still required for validation).

## Summary

Adds optional return normalization to `JointPPOTrainer` per #159 hypothesis (value loss ~10^6-10^7 larger than policy loss per Phase 1 diagnostics).

- New `bucket_brigade/training/normalizers.py`: Welford/Chan `RunningMeanStd` (online mean+var, scalar or vector)
- `JointPPOTrainer.__init__`: new `normalize_returns: bool = False` flag (default OFF = behavior unchanged)
- When enabled: maintains shared running mean/std across all agents' returns; divides each agent's returns by `sqrt(var + 1e-8)` before the value-loss MSE
- Plumbed through `CellConfig` and `--normalize-returns` CLI flag in both `experiments/p3_specialization/train.py` and `run_sweep.py`

## Test plan

Smoke tests confirmed:
- `RunningMeanStd` produces correct mean/std on synthetic input
- `CellConfig().normalize_returns == False` (default preserved)
- Both `train.py --help` and `run_sweep.py --help` show the new flag

Actual 4-cell ablation (baseline / coefs-only / norm-only / all-three) requires sandbox-1 per CLAUDE.md.