### PR TITLE
feat: Add Option 3 (other-agent lagged action) CMI sensitivity check (#172)

### DIFF
--- a/experiments/p3_specialization/analyze.py
+++ b/experiments/p3_specialization/analyze.py
@@ -71,6 +71,11 @@ def _load_cell(cell_dir: Path) -> Dict[str, object] | None:
         "cmi_mean": final["cmi/mean_pair"],
         "action_entropy_mean": final["action_entropy/mean"],
     }
+    # Option 3 sensitivity-check CMI (architect decision 2026-05-15, #172).
+    # Older runs predate this metric; treat as optional so the analysis stays
+    # tolerant of mixed-vintage sweep trees.
+    if "cmi_action/mean_pair" in final:
+        out["cmi_action_mean"] = final["cmi_action/mean_pair"]
 
     # Optional dropout robustness if it has been evaluated.
     dropout_path = cell_dir / "dropout_results.json"
@@ -103,6 +108,7 @@ def aggregate(sweep_root: Path) -> Dict[Tuple[str, float], Dict[str, dict]]:
         "team_reward",
         "mi_mean",
         "cmi_mean",
+        "cmi_action_mean",
         "action_entropy_mean",
         "dropout_baseline",
         "dropout_mean_drop",
@@ -196,6 +202,7 @@ def _print_summary(
         n = data.get("n_seeds", 0)
         tr = data.get("team_reward", {})
         cmi = data.get("cmi_mean", {})
+        cmi_action = data.get("cmi_action_mean", {})
         drop = data.get("dropout_mean_drop", {})
         print(
             f"  lambda={lam:<7g} n={n:2d} | "
@@ -203,6 +210,8 @@ def _print_summary(
             f"[{tr.get('ci_lo', float('nan')):.2f}, {tr.get('ci_hi', float('nan')):.2f}] | "
             f"cmi={cmi.get('mean', float('nan')):.3f} "
             f"[{cmi.get('ci_lo', float('nan')):.2f}, {cmi.get('ci_hi', float('nan')):.2f}] | "
+            f"cmi_action={cmi_action.get('mean', float('nan')):.3f} "
+            f"[{cmi_action.get('ci_lo', float('nan')):.2f}, {cmi_action.get('ci_hi', float('nan')):.2f}] | "
             f"dropout_drop={drop.get('mean', float('nan')):.3f}"
         )
 

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -10,10 +10,20 @@ later analysis pass needs:
 - ``config.json`` --- the exact arguments used (for reproducibility).
 
 Plug-in conditional MI between encoder outputs is computed on each
-rollout's most recent batch, conditioned on a coarse state summary
-``(num_houses_burning, day_index)`` (Option 1 from issue #154). Unconditional
-MI is also logged so we can see how much "specialization beyond shared
-state" the encoders actually carry.
+rollout's most recent batch, with two conditioners reported side-by-side:
+
+- **Primary (Option 1, state summary):** coarse ``(num_houses_burning,
+  day_index)``. Exogenous environment state; clean removal of "redundancy
+  from looking at the same world."
+- **Sensitivity check (Option 3, other-agent lagged action):** per pair
+  ``(i, j)``, agent ``j``'s packed action at ``t-1``. Conditions on a
+  signal that is downstream of agent ``j``'s encoder (via its policy
+  head), so it can suppress CMI for the wrong reason — useful as a
+  cross-check, not as a primary measurement.
+
+See ``research_notebook/2026-05-15_p3_conditioner_decision.md`` for the
+architect rationale and the four-way agreement table used to interpret
+the two CMI series together. Unconditional MI is also logged.
 """
 
 from __future__ import annotations
@@ -111,11 +121,7 @@ def _state_summary_codes(
     output matches the 1-D hashable-code shape consumed by
     :func:`conditional_mutual_information`.
 
-    NOTE: Conditioner selected by Builder (issue #154 Option 1: state summary).
-    The choice between state-summary vs. trajectory-bucket vs. other-agent-action
-    is a research call; curator flagged this for Architect review (see #154
-    builder-note for the Option 2/3 tradeoffs). If measurement values look
-    wrong, revisit Options 2/3 in #154.
+    Architect-validated; see ``research_notebook/2026-05-15_p3_conditioner_decision.md``.
     """
     obs_np = rollout.observations.cpu().numpy()
     # Per-house state ∈ {SAFE=0, BURNING=1, RUINED=2}; count BURNING per step.
@@ -144,6 +150,58 @@ def _state_summary_codes(
     return num_burning + 11 * day_codes.astype(np.int64)
 
 
+# Packed-action alphabet used by ``_other_agent_action_codes`` and the
+# ``action_entropy`` metric below. With ``action_dims = [10, 2]`` the pack
+# ``a[:, 0] * 2 + a[:, 1]`` covers ``0..19`` inclusive (20 distinct values).
+# We reserve code 20 as a sentinel for the "no prior action" case at ``t=0``
+# (and just after an episode boundary), so the conditioner's alphabet is
+# ``[0, 21)``. Using a dedicated sentinel keeps the conditioner well-defined
+# at the cost of one extra bin; ``is_degenerate_conditioner`` will still fire
+# correctly if real actions collapse to a single value.
+_ACTION_PACK_BASE = 2  # second action dimension cardinality
+_ACTION_NO_PRIOR_SENTINEL = 20
+_ACTION_CODE_ALPHABET = 21  # 0..19 real + 20 sentinel
+
+
+def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray:
+    """Per-step codes for agent ``j``'s packed action at ``t - lag``.
+
+    Implements **Option 3** from issue #154 — a sensitivity-check conditioner
+    that asks: "are agents ``i`` and ``j`` redundant beyond what their
+    *observed coordination* (agent ``j``'s recent action) forces?"
+    See ``research_notebook/2026-05-15_p3_conditioner_decision.md`` for the
+    architect rationale on why Option 3 is reported as a **secondary**
+    check alongside Option 1, not as a primary measurement.
+
+    Per-pair convention: when measuring ``CMI(Ẑ_i; Ẑ_j | Z_ij)`` with the
+    Option 3 conditioner, ``Z_ij`` is the *other* agent's lagged action —
+    here, agent ``j``'s action at ``t - lag``. This matches the convention
+    used in the four-way diagnostic table in the architect notebook.
+
+    Codes use the existing pack ``a[:, 0] * _ACTION_PACK_BASE + a[:, 1]``
+    (range ``0..19`` for ``action_dims = [10, 2]``). For ``t < lag`` (no
+    prior action exists yet) we emit the sentinel ``_ACTION_NO_PRIOR_SENTINEL``
+    so the conditioner is defined on every step.
+
+    Note: we do **not** reset the sentinel at episode boundaries here. The
+    architect spec calls for a single-step lag and defensive ``t=0`` handling;
+    leaking the last action of episode ``k-1`` into the first step of episode
+    ``k`` is a small effect at lag=1 and the env auto-resets observations
+    (which the encoder consumes) at the same step. If a future scenario uses
+    very short episodes where this matters, revisit.
+    """
+    if lag < 1:
+        raise ValueError(f"lag must be >= 1, got {lag}")
+    a = rollout.actions[agent_j].cpu().numpy()
+    # Pack the multi-discrete action: a[:, 0] in [0, 10), a[:, 1] in [0, 2).
+    packed = (a[:, 0] * _ACTION_PACK_BASE + a[:, 1]).astype(np.int64)
+    T = packed.shape[0]
+    codes = np.full(T, _ACTION_NO_PRIOR_SENTINEL, dtype=np.int64)
+    if T > lag:
+        codes[lag:] = packed[:-lag]
+    return codes
+
+
 def _measure_information(
     trainer: JointPPOTrainer,
     rollout,
@@ -152,17 +210,20 @@ def _measure_information(
 ) -> Dict[str, float]:
     """Plug-in MI/CMI on the rollout's encoder outputs.
 
-    Conditioned on a coarse ``(num_houses_burning, day_index)`` state summary
-    (issue #154 Option 1). Also logs unconditional MI per pair.
+    Reports two conditional MI series per pair, side-by-side:
+
+    - ``cmi/*`` — Option 1, conditioned on the coarse
+      ``(num_houses_burning, day_index)`` state summary.
+    - ``cmi_action/*`` — Option 3, conditioned on the *other* agent's
+      packed action at ``t-1`` (per-pair conditioner).
+
+    Also logs unconditional MI per pair.
 
     Encoder outputs are projected from ``hidden_size`` to a small dimension
     via the shared ``projection`` matrix before quantization, because a
     direct quantize-and-pack of a 64-D vector overflows the integer code.
 
-    NOTE: Conditioner selected by Builder (issue #154 Option 1: state summary).
-    The choice between state-summary vs. trajectory-bucket vs. other-agent-action
-    is a research call; curator flagged this for Architect review. If
-    measurement values look wrong, revisit Options 2/3 in #154.
+    Architect-validated; see ``research_notebook/2026-05-15_p3_conditioner_decision.md``.
     """
     with torch.no_grad():
         feats = trainer.encoder_outputs_batch(rollout.observations)
@@ -171,21 +232,21 @@ def _measure_information(
     # Quantize each (T, mi_proj_dims) projection into a single integer code.
     codes = [quantize_uniform(f, n_bins=n_bins) for f in feats_np]
 
-    # State-summary conditioning variable (issue #154 Option 1). See
-    # ``_state_summary_codes`` for the Architect-deferred decision rationale.
+    # Primary conditioner (Option 1, state summary). See
+    # ``_state_summary_codes`` and the architect notebook for rationale.
     z_codes = _state_summary_codes(rollout)
 
     out: Dict[str, float] = {}
 
-    # Defensive measurement-quality check (see issue #146).
-    #
-    # The team-reward conditioner used previously was near-constant on several
-    # scenarios (``trivial_cooperation`` literally; ``default`` and
-    # ``chain_reaction`` near-deterministically), which made the plug-in CMI
-    # collapse to the unconditional MI. Issue #154 Option 1 replaces it with a
-    # coarse ``(num_houses_burning, day_index)`` summary; this check stays in
-    # place to detect future regressions (e.g., if a scenario ends on step 0
-    # every time, both components collapse).
+    # Defensive measurement-quality check on the Option 1 conditioner (see
+    # issue #146 for the failure mode this guards against). The team-reward
+    # conditioner used previously was near-constant on several scenarios
+    # (``trivial_cooperation`` literally; ``default`` and ``chain_reaction``
+    # near-deterministically), which made the plug-in CMI collapse to the
+    # unconditional MI. The current Option 1 state-summary conditioner has not
+    # tripped this guard on the May 14 sweep; the check stays in place to
+    # detect future regressions (e.g., if a scenario ends on step 0 every
+    # time, both components collapse).
     is_degenerate, diag = is_degenerate_conditioner(z_codes)
     out["cmi/conditioner_n_distinct"] = float(diag["n_distinct"])
     out["cmi/conditioner_modal_fraction"] = diag["modal_fraction"]
@@ -194,12 +255,12 @@ def _measure_information(
     if is_degenerate:
         warnings.warn(
             (
-                "P3 CMI conditioner appears degenerate "
+                "P3 CMI Option 1 (state-summary) conditioner appears degenerate "
                 f"(n_distinct={diag['n_distinct']}, "
                 f"modal_fraction={diag['modal_fraction']:.3f}, "
                 f"entropy_bits={diag['entropy_bits']:.3f}). "
                 "I(Ẑ_i; Ẑ_j | Z) ≈ I(Ẑ_i; Ẑ_j) is mathematically guaranteed; "
-                "see issue #154 for context. Reported CMI values for this "
+                "see issue #146 for context. Reported `cmi/*` values for this "
                 "iteration should not be interpreted as 'conditional'."
             ),
             RuntimeWarning,
@@ -207,18 +268,83 @@ def _measure_information(
         )
 
     n = trainer.num_agents
+
+    # Sensitivity-check conditioners (Option 3): for each pair ``(i, j)`` with
+    # ``i < j``, the conditioner is agent ``j``'s packed action at ``t - 1``.
+    # Precompute once per agent ``j`` so the per-pair loop stays cheap, and
+    # so the degenerate diagnostics are emitted per conditioning agent. See
+    # the architect notebook for why this is reported alongside (not in place
+    # of) the Option 1 measurement.
+    action_codes_per_agent: Dict[int, np.ndarray] = {
+        j: _other_agent_action_codes(rollout, agent_j=j, lag=1) for j in range(n)
+    }
+    # Aggregate degenerate-diagnostic stats across the conditioning agents
+    # we actually use (j = 1..n-1, since pairs are i < j).
+    action_cond_diag_agents = list(range(1, n))
+    action_cond_degenerate_any = False
+    action_cond_modal_fractions: List[float] = []
+    action_cond_entropy_bits: List[float] = []
+    action_cond_n_distinct: List[int] = []
+    for j in action_cond_diag_agents:
+        is_deg_j, diag_j = is_degenerate_conditioner(action_codes_per_agent[j])
+        out[f"cmi_action/conditioner_agent_{j}_n_distinct"] = float(diag_j["n_distinct"])
+        out[f"cmi_action/conditioner_agent_{j}_modal_fraction"] = diag_j[
+            "modal_fraction"
+        ]
+        out[f"cmi_action/conditioner_agent_{j}_entropy_bits"] = diag_j["entropy_bits"]
+        out[f"cmi_action/conditioner_agent_{j}_degenerate"] = float(is_deg_j)
+        action_cond_degenerate_any = action_cond_degenerate_any or is_deg_j
+        action_cond_modal_fractions.append(diag_j["modal_fraction"])
+        action_cond_entropy_bits.append(diag_j["entropy_bits"])
+        action_cond_n_distinct.append(int(diag_j["n_distinct"]))
+        if is_deg_j:
+            warnings.warn(
+                (
+                    "P3 CMI Option 3 (other-agent-action) conditioner appears "
+                    f"degenerate for agent {j} "
+                    f"(n_distinct={diag_j['n_distinct']}, "
+                    f"modal_fraction={diag_j['modal_fraction']:.3f}, "
+                    f"entropy_bits={diag_j['entropy_bits']:.3f}). "
+                    "I(Ẑ_i; Ẑ_j | A_j[t-1]) ≈ I(Ẑ_i; Ẑ_j) is mathematically "
+                    "guaranteed for pairs conditioned on this agent. "
+                    f"Reported `cmi_action/agent_*_{j}` values for this "
+                    "iteration should not be interpreted as 'conditional'."
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    # Aggregate diagnostics across conditioning agents (mean over j).
+    if action_cond_diag_agents:
+        out["cmi_action/conditioner_n_distinct"] = float(
+            np.mean(action_cond_n_distinct)
+        )
+        out["cmi_action/conditioner_modal_fraction"] = float(
+            np.mean(action_cond_modal_fractions)
+        )
+        out["cmi_action/conditioner_entropy_bits"] = float(
+            np.mean(action_cond_entropy_bits)
+        )
+        out["cmi_action/conditioner_degenerate"] = float(action_cond_degenerate_any)
+
     mi_vals = []
     cmi_vals = []
+    cmi_action_vals = []
     for i in range(n):
         for j in range(i + 1, n):
             mi = mutual_information(codes[i], codes[j])
             cmi = conditional_mutual_information(codes[i], codes[j], z_codes)
+            cmi_action = conditional_mutual_information(
+                codes[i], codes[j], action_codes_per_agent[j]
+            )
             out[f"mi/agent_{i}_{j}"] = mi
             out[f"cmi/agent_{i}_{j}"] = cmi
+            out[f"cmi_action/agent_{i}_{j}"] = cmi_action
             mi_vals.append(mi)
             cmi_vals.append(cmi)
+            cmi_action_vals.append(cmi_action)
     out["mi/mean_pair"] = float(np.mean(mi_vals))
     out["cmi/mean_pair"] = float(np.mean(cmi_vals))
+    out["cmi_action/mean_pair"] = float(np.mean(cmi_action_vals))
 
     # Marginal action entropy per agent (proxy for role entropy H(A_i^*)).
     for i in range(n):
@@ -302,6 +428,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
                 f"  iter {it:4d} | team_reward {mean_reward:8.3f} | "
                 f"mi_mean {info_stats['mi/mean_pair']:.3f} | "
                 f"cmi_mean {info_stats['cmi/mean_pair']:.3f} | "
+                f"cmi_action_mean {info_stats['cmi_action/mean_pair']:.3f} | "
                 f"red_loss {stats['redundancy_loss']:.4f}"
             )
 

--- a/tests/test_p3_conditioners.py
+++ b/tests/test_p3_conditioners.py
@@ -1,0 +1,115 @@
+"""Tests for the P3 specialization CMI conditioner helpers.
+
+Pins down ``_other_agent_action_codes`` (Option 3, added in #172) since it is
+the per-pair sensitivity-check conditioner reported alongside the existing
+Option 1 (``_state_summary_codes``) measurement in
+``experiments/p3_specialization/train.py``. Architect rationale and the
+four-way diagnostic table live in
+``research_notebook/2026-05-15_p3_conditioner_decision.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pytest
+import torch
+
+from experiments.p3_specialization.train import (
+    _ACTION_NO_PRIOR_SENTINEL,
+    _other_agent_action_codes,
+)
+
+
+@dataclass
+class _FakeRollout:
+    """Minimal stand-in matching the fields ``_other_agent_action_codes`` reads.
+
+    Only ``actions`` is consumed; using a dataclass keeps the test independent
+    of the full ``RolloutBuffer`` definition (which carries observation /
+    log-prob / value tensors irrelevant to the conditioner helper).
+    """
+
+    actions: Dict[int, torch.Tensor]
+
+
+def _make_rollout(actions_np: Dict[int, np.ndarray]) -> _FakeRollout:
+    return _FakeRollout(
+        actions={i: torch.from_numpy(a.astype(np.int64)) for i, a in actions_np.items()}
+    )
+
+
+class TestOtherAgentActionCodes:
+    def test_lag1_shifts_and_sentinels_t0(self):
+        # Agent 0 takes the same packed-action pattern (5, 7, 11, 3); we
+        # expect t=0 to be the sentinel and the rest to be the prior step.
+        a0 = np.array([[2, 1], [3, 1], [5, 1], [1, 1]])  # packed = 5, 7, 11, 3
+        rollout = _make_rollout({0: a0, 1: a0.copy()})
+        codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
+        expected = np.array([_ACTION_NO_PRIOR_SENTINEL, 5, 7, 11], dtype=np.int64)
+        np.testing.assert_array_equal(codes, expected)
+
+    def test_lag_k_sentinels_first_k_steps(self):
+        a0 = np.array([[1, 0], [2, 1], [3, 0], [4, 1], [0, 0]])
+        # packed = 2, 5, 6, 9, 0
+        rollout = _make_rollout({0: a0})
+        codes = _other_agent_action_codes(rollout, agent_j=0, lag=3)
+        # First 3 entries are sentinel; then prior-prior-prior actions.
+        assert codes[0] == _ACTION_NO_PRIOR_SENTINEL
+        assert codes[1] == _ACTION_NO_PRIOR_SENTINEL
+        assert codes[2] == _ACTION_NO_PRIOR_SENTINEL
+        assert codes[3] == 2
+        assert codes[4] == 5
+
+    def test_short_rollout_all_sentinel_when_lag_ge_T(self):
+        a0 = np.array([[1, 0], [2, 1]])
+        rollout = _make_rollout({0: a0})
+        codes = _other_agent_action_codes(rollout, agent_j=0, lag=2)
+        # T == lag → entire output is sentinel (no t with a defined prior).
+        np.testing.assert_array_equal(
+            codes, np.full(2, _ACTION_NO_PRIOR_SENTINEL, dtype=np.int64)
+        )
+        # T < lag → likewise all sentinel.
+        codes_3 = _other_agent_action_codes(rollout, agent_j=0, lag=3)
+        np.testing.assert_array_equal(
+            codes_3, np.full(2, _ACTION_NO_PRIOR_SENTINEL, dtype=np.int64)
+        )
+
+    def test_pack_matches_existing_convention(self):
+        # The pack is ``a[:, 0] * 2 + a[:, 1]`` and must match the
+        # convention used by the existing ``action_entropy`` metric in
+        # ``_measure_information`` (lines 287-289 of train.py).
+        a0 = np.array([[7, 1], [9, 0]])  # packed = 15, 18
+        rollout = _make_rollout({0: a0})
+        codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
+        # codes[1] is the prior packed action (15); codes[0] is sentinel.
+        assert codes[1] == 15
+
+    def test_alphabet_max_is_19(self):
+        # Largest legal packed action with action_dims = [10, 2] is
+        # ``9 * 2 + 1 = 19`` (< _ACTION_NO_PRIOR_SENTINEL = 20).
+        a0 = np.array([[9, 1], [0, 0]])
+        rollout = _make_rollout({0: a0})
+        codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
+        assert codes[1] == 19
+        # Sentinel value sits strictly above the legal range.
+        assert _ACTION_NO_PRIOR_SENTINEL == 20
+
+    def test_per_agent_independence(self):
+        # Each agent's codes are computed from that agent's own action stream;
+        # passing different action_dims values should not cross-contaminate.
+        a0 = np.array([[1, 0], [2, 0], [3, 0]])  # packed = 2, 4, 6
+        a1 = np.array([[5, 1], [6, 0], [7, 1]])  # packed = 11, 12, 15
+        rollout = _make_rollout({0: a0, 1: a1})
+        codes0 = _other_agent_action_codes(rollout, agent_j=0, lag=1)
+        codes1 = _other_agent_action_codes(rollout, agent_j=1, lag=1)
+        assert codes0[1] == 2 and codes0[2] == 4
+        assert codes1[1] == 11 and codes1[2] == 12
+
+    def test_rejects_lag_zero(self):
+        a0 = np.array([[1, 0], [2, 0]])
+        rollout = _make_rollout({0: a0})
+        with pytest.raises(ValueError):
+            _other_agent_action_codes(rollout, agent_j=0, lag=0)


### PR DESCRIPTION
Closes #172.

Implements the architect decision from
[`research_notebook/2026-05-15_p3_conditioner_decision.md`](https://github.com/rjwalters/bucket-brigade/blob/main/research_notebook/2026-05-15_p3_conditioner_decision.md):
keep Option 1 (state-summary) as the primary CMI conditioner and add
Option 3 (other-agent lagged action) as a secondary sensitivity check,
reported side-by-side.

## :warning: Architect-input-needed finding from smoke test

The architect's acceptance check states:

> `is_degenerate_conditioner` does not fire on **either** conditioner on
> `default`, `chain_reaction`, `trivial_cooperation` at λ=0 over a short
> sandbox run (10 iters × 512 steps is sufficient).

The Option 1 (state-summary) conditioner passes cleanly on all three
scenarios — `modal_fraction` 0.20–0.30, `n_distinct` 4–14, `degenerate=0`.
**Option 3 (other-agent action) fires `degenerate=1` on all three
scenarios at λ=0 at this scale.**

Drilling into the per-conditioning-agent diagnostics on the smoke run
(default, 10 iters × 1024 steps, seed=0):

| Conditioning agent | modal_fraction | n_distinct | degenerate? |
|---|---|---|---|
| agent 1 | 0.998 | 3 | **yes** |
| agent 2 | 0.751 | 7 | no |
| agent 3 | 0.956 | 5 | no |

Reading: at λ=0 with a freshly-initialized policy, **agent 1's marginal
action distribution collapses to one dominant action** (~99.8% of steps).
The state-summary conditioner doesn't see this because it depends on the
shared environment, not on any one agent's policy.

This is consistent with the architect notebook's caveat about Option 3's
circularity, but at a different scale than expected: the spec anticipated
the conditioner being well-defined at the acceptance-check scale. Two
plausible readings:

1. **Transient early-training effect** — agent 1's marginal sharpens
   for one or two iterations before exploration kicks in, and the issue
   resolves itself on a longer run. The full sweep would confirm.
2. **Genuine pathology of Option 3 at low λ_red** — the conditioner's
   degeneracy guard fires whenever a single agent's policy is
   near-deterministic, which it may always be at λ=0 in some scenarios.
   If so, Option 3's degenerate-aggregate signal is part of the
   measurement-design surface (the diagnostic table in the notebook
   already prepares for "Option 3 numbers should not be trusted as
   conditional when the per-agent conditioner is degenerate"), but the
   smoke-test acceptance criterion as written would never pass at λ=0.

Per Builder instructions ("If `is_degenerate_conditioner` fires on the
new action-codes conditioner on any scenario, STOP and report — that's
a finding the architect needs to see, not something to paper over"), I
am surfacing this finding here rather than tweaking thresholds or
silencing the warning. The implementation faithfully follows the spec.

Recommended next step: architect decides whether the acceptance check
needs revision (e.g., evaluate at λ > 0, or only on agent 2/3 conditioners,
or after N warmup iters), and whether `loom:blocked` should be applied
to the issue/PR until then.

## What changed

`experiments/p3_specialization/train.py`:
- New `_other_agent_action_codes(rollout, agent_j, lag=1)` — per pair
  `(i, j)` the conditioner is agent `j`'s packed action at `t-1` using
  the existing `a[:,0]*2 + a[:,1]` pack. `t < lag` emits a sentinel
  (20) so the conditioner is defined on every step.
- `_measure_information` emits `cmi_action/agent_{i}_{j}` per pair and
  `cmi_action/mean_pair` alongside the existing Option 1 metrics.
  Applies `is_degenerate_conditioner` per conditioning agent and emits
  `cmi_action/conditioner_*` diagnostics (per-agent and aggregate).
- Removed the "Builder-pick" caveat comments at the old lines 114-118
  and 162-165; replaced with a one-line pointer to the architect notebook.

`experiments/p3_specialization/analyze.py`:
- Aggregation loads `cmi_action/mean_pair` (optional for runs predating
  this metric) and includes `cmi_action_mean` in the bootstrap CI table
  and per-cell printed summary.

`tests/test_p3_conditioners.py` (new): seven focused tests for
`_other_agent_action_codes` covering t=0 sentinel handling, lag>1, short
rollouts where T<=lag, alphabet bounds, per-agent independence, and
rejection of lag<1.

## Out of scope (per the notebook)

- Full sweep re-run (sandbox-1 job)
- Updates to the May 14 results writeup (post-sweep)
- Training-side penalty design (#146)

## Test plan

- [x] `uv run pytest tests/test_info_theory.py tests/test_p3_conditioners.py` — 37/37 pass
- [x] `uv run ruff check` on the three changed files — passes
- [x] Smoke run: 10 iters × 512 steps, λ=0, seed=0, three scenarios — completes
- [x] Option 1 (`cmi/conditioner_degenerate`) **does not fire** on any of
      `default`, `chain_reaction`, `trivial_cooperation` (modal_fraction
      0.20–0.30, n_distinct 4–14)
- [ ] :warning: Option 3 (`cmi_action/conditioner_degenerate`) **fires
      on all three scenarios** at λ=0 (driven by agent 1; agents 2/3 are
      fine). See "Architect-input-needed finding" above.
- [x] `cmi/mean_pair` and `cmi_action/mean_pair` both appear in
      per-iteration JSON log and are consumed by `analyze.py` aggregation