### PR TITLE
feat: mask degenerate per-pair Option-3 CMIs from aggregate

### DIFF
--- a/experiments/p3_specialization/analyze.py
+++ b/experiments/p3_specialization/analyze.py
@@ -74,8 +74,16 @@ def _load_cell(cell_dir: Path) -> Dict[str, object] | None:
     # Option 3 sensitivity-check CMI (architect decision 2026-05-15, #172).
     # Older runs predate this metric; treat as optional so the analysis stays
     # tolerant of mixed-vintage sweep trees.
+    #
+    # Per the post-PR-#180 amendment to the architect notebook, the aggregate
+    # ``cmi_action/mean_pair`` is masked over non-degenerate per-pair CMIs and
+    # can be NaN (written as JSON ``null``) when every conditioning agent is
+    # degenerate. Carry through ``cmi_action_n_valid_pairs`` so the
+    # aggregator can report the explicit denominator alongside the mean.
     if "cmi_action/mean_pair" in final:
         out["cmi_action_mean"] = final["cmi_action/mean_pair"]
+    if "cmi_action/n_valid_pairs" in final:
+        out["cmi_action_n_valid_pairs"] = final["cmi_action/n_valid_pairs"]
 
     # Optional dropout robustness if it has been evaluated.
     dropout_path = cell_dir / "dropout_results.json"
@@ -116,11 +124,43 @@ def aggregate(sweep_root: Path) -> Dict[Tuple[str, float], Dict[str, dict]]:
     for key, group in by_key.items():
         agg: Dict[str, dict] = {"n_seeds": len(group)}
         for metric in metrics_to_aggregate:
-            vals = [c[metric] for c in group if metric in c]
+            # Skip null/NaN cells. ``cmi_action_mean`` is masked to NaN (JSON
+            # ``null``) when every conditioning agent is degenerate (notebook
+            # Amendment, post-PR #180); other metrics shouldn't contain
+            # ``None``/``NaN`` in practice, but filter defensively. We honour
+            # NaN-skip semantics so a single fully-collapsed cell doesn't
+            # poison the cross-seed mean.
+            vals = []
+            for c in group:
+                if metric not in c:
+                    continue
+                v = c[metric]
+                if v is None:
+                    continue
+                fv = float(v)
+                if np.isnan(fv):
+                    continue
+                vals.append(fv)
             if not vals:
                 continue
             point, lo, hi = _bootstrap_mean_ci(np.asarray(vals, dtype=float))
             agg[metric] = {"mean": point, "ci_lo": lo, "ci_hi": hi, "n": len(vals)}
+        # Surface the n_valid_pairs denominator for the Option 3 aggregate so
+        # consumers can interpret the masked mean correctly. We report the
+        # min across seeds (worst case — "this many pairs were valid in at
+        # least one seed of this cell"). Skipped if no seed in the cell
+        # logged the field (mixed-vintage trees).
+        n_valid = [
+            int(c["cmi_action_n_valid_pairs"])
+            for c in group
+            if "cmi_action_n_valid_pairs" in c
+        ]
+        if n_valid:
+            agg["cmi_action_n_valid_pairs"] = {
+                "min": min(n_valid),
+                "max": max(n_valid),
+                "n": len(n_valid),
+            }
         out[key] = agg
     return out
 

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -202,6 +202,52 @@ def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray
     return codes
 
 
+def _masked_mean_cmi_action(
+    cmi_values: List[float],
+    conditioning_agents: List[int],
+    per_agent_degenerate: Dict[int, bool],
+) -> tuple[float, int]:
+    """Mean of per-pair Option-3 CMIs, masking pairs with a degenerate conditioner.
+
+    Aggregate-only masking for the Option 3 (other-agent lagged action)
+    sensitivity check. Per the post-PR-#180 amendment to
+    ``research_notebook/2026-05-15_p3_conditioner_decision.md``, when any
+    conditioning agent's action distribution collapses to (near-)deterministic
+    — which is a structural outcome of PPO at λ=0 with no specialization
+    pressure — that agent's contribution to the aggregate is mathematically
+    vacuous (``I(X; Y | Z) ≈ I(X; Y)``). We exclude only the affected pairs
+    from the aggregate; per-pair raw CMIs continue to be emitted unmasked for
+    drilldown.
+
+    Args:
+        cmi_values: Per-pair Option-3 CMI values, in the order produced by
+            the ``i < j`` pair loop.
+        conditioning_agents: For each entry in ``cmi_values``, the index of
+            the conditioning agent (the larger of ``i, j`` per the pair
+            convention). Same length as ``cmi_values``.
+        per_agent_degenerate: Map ``{agent_j: bool}`` marking which
+            conditioning agents have a degenerate marginal action
+            distribution at this iteration.
+
+    Returns:
+        ``(mean_pair, n_valid_pairs)`` where ``mean_pair`` is the mean over
+        non-degenerate pairs, or ``float('nan')`` if every pair is degenerate
+        (``n_valid_pairs == 0``).
+    """
+    assert len(cmi_values) == len(conditioning_agents), (
+        "cmi_values and conditioning_agents must align"
+    )
+    kept = [
+        v
+        for v, j in zip(cmi_values, conditioning_agents)
+        if not per_agent_degenerate.get(j, False)
+    ]
+    n_valid = len(kept)
+    if n_valid == 0:
+        return float("nan"), 0
+    return float(np.mean(kept)), n_valid
+
+
 def _measure_information(
     trainer: JointPPOTrainer,
     rollout,
@@ -222,6 +268,20 @@ def _measure_information(
     Encoder outputs are projected from ``hidden_size`` to a small dimension
     via the shared ``projection`` matrix before quantization, because a
     direct quantize-and-pack of a 64-D vector overflows the integer code.
+
+    Aggregate masking (Option 3 only): per the post-PR-#180 amendment to the
+    architect notebook, ``cmi_action/mean_pair`` is the mean over **non-
+    degenerate** per-pair CMIs only (where "degenerate" is judged on the
+    *conditioning* agent ``j``'s marginal action distribution via
+    :func:`is_degenerate_conditioner`). ``cmi_action/n_valid_pairs`` is
+    emitted as the explicit denominator; if every conditioning agent is
+    degenerate the aggregate is ``NaN`` (JSON ``null``). Per-pair raw
+    ``cmi_action/agent_{i}_{j}`` values are emitted unconditionally so
+    drilldown into a degenerate pair is still possible. The aggregate
+    ``cmi_action/conditioner_degenerate`` flag retains its "any-degenerate"
+    semantics — diagnostic, not a gate. See
+    ``research_notebook/2026-05-15_p3_conditioner_decision.md`` Amendment
+    section.
 
     Architect-validated; see ``research_notebook/2026-05-15_p3_conditioner_decision.md``.
     """
@@ -282,18 +342,22 @@ def _measure_information(
     # we actually use (j = 1..n-1, since pairs are i < j).
     action_cond_diag_agents = list(range(1, n))
     action_cond_degenerate_any = False
+    action_cond_degenerate_per_agent: Dict[int, bool] = {}
     action_cond_modal_fractions: List[float] = []
     action_cond_entropy_bits: List[float] = []
     action_cond_n_distinct: List[int] = []
     for j in action_cond_diag_agents:
         is_deg_j, diag_j = is_degenerate_conditioner(action_codes_per_agent[j])
-        out[f"cmi_action/conditioner_agent_{j}_n_distinct"] = float(diag_j["n_distinct"])
+        out[f"cmi_action/conditioner_agent_{j}_n_distinct"] = float(
+            diag_j["n_distinct"]
+        )
         out[f"cmi_action/conditioner_agent_{j}_modal_fraction"] = diag_j[
             "modal_fraction"
         ]
         out[f"cmi_action/conditioner_agent_{j}_entropy_bits"] = diag_j["entropy_bits"]
         out[f"cmi_action/conditioner_agent_{j}_degenerate"] = float(is_deg_j)
         action_cond_degenerate_any = action_cond_degenerate_any or is_deg_j
+        action_cond_degenerate_per_agent[j] = bool(is_deg_j)
         action_cond_modal_fractions.append(diag_j["modal_fraction"])
         action_cond_entropy_bits.append(diag_j["entropy_bits"])
         action_cond_n_distinct.append(int(diag_j["n_distinct"]))
@@ -328,7 +392,8 @@ def _measure_information(
 
     mi_vals = []
     cmi_vals = []
-    cmi_action_vals = []
+    cmi_action_vals: List[float] = []
+    cmi_action_conditioning_agents: List[int] = []
     for i in range(n):
         for j in range(i + 1, n):
             mi = mutual_information(codes[i], codes[j])
@@ -338,13 +403,22 @@ def _measure_information(
             )
             out[f"mi/agent_{i}_{j}"] = mi
             out[f"cmi/agent_{i}_{j}"] = cmi
+            # Per-pair raw CMI is emitted unconditionally; masking applies only
+            # to the aggregate below. See docstring + notebook Amendment.
             out[f"cmi_action/agent_{i}_{j}"] = cmi_action
             mi_vals.append(mi)
             cmi_vals.append(cmi)
             cmi_action_vals.append(cmi_action)
+            cmi_action_conditioning_agents.append(j)
     out["mi/mean_pair"] = float(np.mean(mi_vals))
     out["cmi/mean_pair"] = float(np.mean(cmi_vals))
-    out["cmi_action/mean_pair"] = float(np.mean(cmi_action_vals))
+    cmi_action_mean, n_valid_pairs = _masked_mean_cmi_action(
+        cmi_action_vals,
+        cmi_action_conditioning_agents,
+        action_cond_degenerate_per_agent,
+    )
+    out["cmi_action/mean_pair"] = cmi_action_mean
+    out["cmi_action/n_valid_pairs"] = n_valid_pairs
 
     # Marginal action entropy per agent (proxy for role entropy H(A_i^*)).
     for i in range(n):
@@ -428,7 +502,8 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
                 f"  iter {it:4d} | team_reward {mean_reward:8.3f} | "
                 f"mi_mean {info_stats['mi/mean_pair']:.3f} | "
                 f"cmi_mean {info_stats['cmi/mean_pair']:.3f} | "
-                f"cmi_action_mean {info_stats['cmi_action/mean_pair']:.3f} | "
+                f"cmi_action_mean {info_stats['cmi_action/mean_pair']:.3f} "
+                f"(n_valid={info_stats['cmi_action/n_valid_pairs']}) | "
                 f"red_loss {stats['redundancy_loss']:.4f}"
             )
 

--- a/tests/test_p3_conditioners.py
+++ b/tests/test_p3_conditioners.py
@@ -17,8 +17,10 @@ import numpy as np
 import pytest
 import torch
 
+from bucket_brigade.analysis.info_theory import is_degenerate_conditioner
 from experiments.p3_specialization.train import (
     _ACTION_NO_PRIOR_SENTINEL,
+    _masked_mean_cmi_action,
     _other_agent_action_codes,
 )
 
@@ -113,3 +115,78 @@ class TestOtherAgentActionCodes:
         rollout = _make_rollout({0: a0})
         with pytest.raises(ValueError):
             _other_agent_action_codes(rollout, agent_j=0, lag=0)
+
+
+class TestMaskedMeanCMIAction:
+    """Aggregate-only masking of degenerate per-pair Option-3 CMIs.
+
+    See the Amendment section of
+    ``research_notebook/2026-05-15_p3_conditioner_decision.md`` for the
+    motivating finding: at λ=0, agent 1's policy converges to fully
+    deterministic on `default`, which mathematically zeros the pair (0, 1)
+    Option-3 CMI even though the other 5 of 6 pairs remain valid. The
+    aggregate masks the bad pair; per-pair raw CMIs are still emitted by
+    ``_measure_information`` for drilldown (tested implicitly via the
+    train.py code path).
+
+    Tests construct synthetic per-pair CMI dicts that mirror what the live
+    ``_measure_information`` loop produces for a 4-agent setup. Pair
+    convention: ``i < j``; conditioning agent is ``j`` (the larger index).
+    Six pairs total: (0,1) (0,2) (0,3) (1,2) (1,3) (2,3) → conditioning
+    agents [1, 2, 3, 2, 3, 3].
+    """
+
+    # Conditioning-agent indices in the canonical pair-iteration order for
+    # a 4-agent rollout. Same order the per-pair loop in
+    # ``_measure_information`` emits.
+    CONDITIONING_AGENTS_4 = [1, 2, 3, 2, 3, 3]
+
+    def test_one_degenerate_conditioner_excluded(self):
+        # Exactly one conditioning agent (agent 1) is degenerate. Pair (0, 1)
+        # is the only pair conditioned on agent 1 — it must be excluded from
+        # the aggregate. The other five pairs survive.
+        cmi_values = [0.5, 0.4, 0.3, 0.6, 0.7, 0.2]  # six pairs
+        per_agent_degenerate = {1: True, 2: False, 3: False}
+        mean_pair, n_valid = _masked_mean_cmi_action(
+            cmi_values, self.CONDITIONING_AGENTS_4, per_agent_degenerate
+        )
+        # Excluded value is cmi_values[0] (pair (0,1) → conditioning agent 1).
+        expected = float(np.mean([0.4, 0.3, 0.6, 0.7, 0.2]))
+        assert n_valid == 5
+        assert mean_pair == pytest.approx(expected)
+
+    def test_all_degenerate_returns_nan_and_zero_pairs(self):
+        # Every conditioning agent collapsed (e.g., end-of-training run where
+        # all three agent policies are deterministic). Aggregate must be NaN
+        # and ``n_valid_pairs`` must be 0 so downstream analyzers can skip
+        # the cell rather than averaging a meaningless zero.
+        cmi_values = [0.5, 0.4, 0.3, 0.6, 0.7, 0.2]
+        per_agent_degenerate = {1: True, 2: True, 3: True}
+        mean_pair, n_valid = _masked_mean_cmi_action(
+            cmi_values, self.CONDITIONING_AGENTS_4, per_agent_degenerate
+        )
+        assert n_valid == 0
+        assert np.isnan(mean_pair)
+
+    def test_no_degenerate_returns_unmasked_mean(self):
+        # Sanity baseline: when no conditioning agent is degenerate the
+        # aggregate matches the plain mean over all six pairs.
+        cmi_values = [0.5, 0.4, 0.3, 0.6, 0.7, 0.2]
+        per_agent_degenerate = {1: False, 2: False, 3: False}
+        mean_pair, n_valid = _masked_mean_cmi_action(
+            cmi_values, self.CONDITIONING_AGENTS_4, per_agent_degenerate
+        )
+        assert n_valid == 6
+        assert mean_pair == pytest.approx(float(np.mean(cmi_values)))
+
+    def test_is_degenerate_conditioner_agrees_on_modal_fraction_1(self):
+        # End-to-end sanity check that the degeneracy flag the masker
+        # consumes is the same one ``is_degenerate_conditioner`` produces
+        # from a fully-collapsed action stream (modal_fraction = 1.0).
+        T = 1024
+        # All actions identical → packed code constant; n_distinct = 1.
+        codes = np.zeros(T, dtype=np.int64)
+        is_deg, diag = is_degenerate_conditioner(codes)
+        assert is_deg is True
+        assert diag["modal_fraction"] == 1.0
+        assert diag["n_distinct"] == 1


### PR DESCRIPTION
## Summary

Implements the masking refinement from the post-PR-#180 amendment to `research_notebook/2026-05-15_p3_conditioner_decision.md`. The Option 3 (other-agent lagged action) sensitivity-check aggregate is now masked to exclude per-pair CMIs whose conditioning agent has a degenerate marginal action distribution — addressing the structural finding (not a bug) that PPO at λ=0 routinely collapses individual agent policies to deterministic, mathematically zeroing pairs that condition on that agent while leaving the rest valid.

## Changes

- `experiments/p3_specialization/train.py`
  - New `_masked_mean_cmi_action(cmi_values, conditioning_agents, per_agent_degenerate)` helper. Returns `(mean_pair, n_valid_pairs)`; `mean_pair = float('nan')` (JSON `null`) when no pair is valid.
  - `_measure_information` collects per-agent degeneracy flags during the Option 3 diagnostic loop and uses them to mask the aggregate. Emits `cmi_action/mean_pair` (now possibly NaN) and `cmi_action/n_valid_pairs: int in [0, 6]`. Per-pair raw `cmi_action/agent_{i}_{j}` values are still emitted unconditionally.
  - The aggregate `cmi_action/conditioner_degenerate` flag retains its "any-degenerate" semantics (diagnostic, not a gate) per the notebook spec.
  - Docstring updated to point at the notebook Amendment section.
  - Iteration print line shows `n_valid_pairs` alongside the masked mean.
- `experiments/p3_specialization/analyze.py`
  - `_load_cell` carries through `cmi_action_n_valid_pairs` when present (older runs that predate the field are tolerated).
  - `aggregate` skips `None` / `NaN` values for all bootstrap metrics (defensive; `cmi_action_mean` is the only one that can be NaN in practice).
  - Surfaces a `cmi_action_n_valid_pairs` `{min, max, n}` summary across seeds so consumers can interpret the masked denominator. Reporting per-cell min/max (not a per-seed array) is the small-surgery tradeoff for keeping the aggregator's column shape stable.
- `tests/test_p3_conditioners.py`
  - New `TestMaskedMeanCMIAction` class with the two cases the notebook asks for (one degenerate -> mean over 5, `n_valid_pairs=5`; all degenerate -> NaN, `n_valid_pairs=0`), plus a no-degenerate baseline and a sanity check that `is_degenerate_conditioner` agrees on a fully-collapsed action stream.

## Acceptance Criteria Verification

| Criterion (from notebook Amendment) | Status | Verification |
|---|---|---|
| `cmi_action/mean_pair` masks degenerate per-pair CMIs | done | `_masked_mean_cmi_action` filters by `per_agent_degenerate.get(j, False)`; covered by `test_one_degenerate_conditioner_excluded` |
| Emit `cmi_action/n_valid_pairs: int` | done | Set in `_measure_information` after the helper call; non-negative int up to 6 for 4 agents |
| NaN (JSON `null`) when `n_valid_pairs == 0` | done | Helper returns `float('nan')`; `json.dump` writes as `null`; covered by `test_all_degenerate_returns_nan_and_zero_pairs` |
| Per-pair raw `cmi_action/agent_{i}_{j}` emitted unconditionally | done | Per-pair `out[...]` write is inside the loop, outside any degeneracy check; comment in code clarifies intent |
| Aggregate `conditioner_degenerate` keeps "any-degenerate" semantics | done | `action_cond_degenerate_any` logic untouched |
| `analyze.py` skips null/NaN aggregates | done | `aggregate()` filters `None` and `np.isnan(fv)` per metric |
| `_measure_information` docstring notes masking semantics | done | New paragraph points at the notebook Amendment section |
| Focused unit tests | done | 4 new tests in `TestMaskedMeanCMIAction` |

## Test Plan

`uv run --extra rl --extra dev python -m pytest tests/test_p3_conditioners.py tests/test_info_theory.py -v` -> 41 passed.

Per task spec, no training/sweep was run; this is an additive measurement-side change that the sandbox-1 re-run will exercise.

## Tradeoffs

- `cmi_action_n_valid_pairs` in `analyze.py` aggregated output: surfaced as `{min, max, n}` rather than per-seed array to keep the aggregator's fixed column shape. Per-seed denominators are still available in each cell's `metrics.json` for any drilldown the published `analysis.json` would not satisfy.
- NaN is propagated through JSON as `null` via Python's default `json.dump` handling of `float('nan')` -> Python emits literal `NaN` in JSON (not strict-RFC). The downstream `_load_cell` reads it back as `float('nan')` via `json.load`. This was acceptable to the notebook spec, which explicitly calls for the NaN/null pattern.

Closes #172