### PR TITLE
fix: pass num_agents to BucketBrigade in two Rust integration tests

### DIFF
--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -99,7 +99,8 @@ class TestRustCoreIntegration:
         import time
 
         scenario = SCENARIOS["trivial_cooperation"]
-        env = BucketBrigade(scenario, seed=42)
+        num_agents = 4
+        env = BucketBrigade(scenario, num_agents, seed=42)
 
         # Benchmark: run many steps
         num_steps = 1000
@@ -113,7 +114,7 @@ class TestRustCoreIntegration:
 
             # Reset if game finishes
             if done:
-                env = BucketBrigade(scenario, seed=42 + step)
+                env = BucketBrigade(scenario, num_agents, seed=42 + step)
 
         end_time = time.time()
         total_time = end_time - start_time
@@ -135,13 +136,14 @@ class TestRustCoreIntegration:
             pytest.skip("Rust core not available")
 
         scenario = SCENARIOS["trivial_cooperation"]
+        num_agents = 4
 
         # Run same scenario twice with same seed
         results1 = []
         results2 = []
 
         for run in [1, 2]:
-            env = BucketBrigade(scenario, seed=12345)
+            env = BucketBrigade(scenario, num_agents, seed=12345)
             run_results = []
 
             for _ in range(10):


### PR DESCRIPTION
## Summary
Add `num_agents=4` to the three `BucketBrigade(...)` construction sites in `test_rust_core_performance` and `test_rust_core_reproducibility`. The Rust constructor requires `num_agents` as a positional second argument (`bucket-brigade-core/src/python.rs:14-21`); without it, both tests raised `TypeError` at construction. Mirrors the post-PR-#184 invocation pattern used by `test_rust_vs_python_consistency`.

## Changes
- `tests/test_rust_integration.py:102` — `BucketBrigade(scenario, seed=42)` → `BucketBrigade(scenario, num_agents, seed=42)`
- `tests/test_rust_integration.py:116` — `BucketBrigade(scenario, seed=42 + step)` → `BucketBrigade(scenario, num_agents, seed=42 + step)`
- `tests/test_rust_integration.py:144` — `BucketBrigade(scenario, seed=12345)` → `BucketBrigade(scenario, num_agents, seed=12345)`
- Introduced local `num_agents = 4` binding in each test so the three call sites read cleanly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `test_rust_core_performance` passes | Yes | Ran via `.venv/bin/python -m pytest tests/test_rust_integration.py -v` |
| `test_rust_core_reproducibility` passes | Yes | Same run |
| Performance assertion `total_time < 1.0` not softened | Yes | Assertion unchanged at line 122 |
| Reproducibility scenario unchanged | Yes | Still `trivial_cooperation` with seed `12345`; only `num_agents` added |
| No new tests added | Yes | Diff is +5 / -3 lines in one file |
| Diff confined to `tests/test_rust_integration.py` | Yes | `git diff --stat` shows only that file |
| `test_rust_vs_python_consistency` (PR #184) untouched | Yes | Not in diff |

## Test Plan
- `.venv/bin/python -m pytest tests/test_rust_integration.py -v` → 4 passed, 1 skipped (the explicit `@pytest.mark.skip` on `test_rust_scenario_coverage` remains, per scope).
- Per-test durations: `test_rust_vs_python_consistency` 0.03s, `test_rust_core_performance` 0.01s, others <0.005s. Total wall time 0.20s.
- No Rust-side issues surfaced once construction was fixed.

Closes #185