### PR TITLE
diagnostic: H1 per-step rollout-reward inspector (#190)

### DIFF
--- a/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+++ b/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
@@ -1,0 +1,337 @@
+"""H1 diagnostic: inspect per-step ``rollout.rewards`` distribution (#190).
+
+Loads trained policies from a P3 cell, runs one rollout via
+``trainer.collect_rollout(2048)``, and dumps per-agent reward statistics
+to confirm/rule out reward-signal degeneracy (hypothesis H1 from #190 /
+#183).
+
+Cell source
+-----------
+Default cell: ``/tmp/h1_cell`` — rsynced from ``$COMPUTE_HOST_PRIMARY``
+(``robbs-mac-studio``) at:
+
+    ~/GitHub/bucket-brigade/experiments/p3_specialization/runs/
+        p3_183_phase3/L1_norm/default/lambda_0e0/seed_42/
+
+That cell ran 500 iterations (scenario=default, lambda_red=0.0, seed=42,
+normalize_returns=true). It is the canonical Phase-3-stuck cell cited in
+the #190 issue body.
+
+If ``/tmp/h1_cell`` is missing, fall back to a freshly trained 50-iter
+cell with the same hyperparameters; the H1 question is about signal
+degeneracy, which is visible at any training stage. Override the cell
+path with ``--cell <path>``.
+
+Methodology (per curator enhancement on #190)
+---------------------------------------------
+``rollout.rewards`` is ``Dict[int, torch.Tensor]`` — one ``[T]`` tensor
+per agent — and must be stacked into an ``ndarray[N, T]`` before
+distributional analysis. For each agent we report:
+
+- mean, std, CV (= std / |mean|)
+- p10 / p50 / p90 of per-step reward
+- aggregate text histogram across all (N, T) samples
+- analytic decomposition of the action-controllable work/rest term
+  (constants from the ``default`` scenario: ``cost_to_work_one_night=0.5``,
+  rest_reward=+0.5) and the residual (team + ownership + sparking)
+- action–reward R² via a 20-class regressor on the packed action
+  ``a[:, 0] * 2 + a[:, 1]`` (10 houses × {rest, work})
+- a side-channel R² on the binary work/rest dim alone, for sanity
+
+Interpretive rubric (from issue #190 ACs):
+
+- CV < 0.05 AND R² < 0.01  → H1 confirmed (degenerate signal).
+- CV low but R² >= 0.05    → H1 ruled out; PPO is failing to extract
+  the signal (points at H2/H3/H4).
+- CV high AND R² >= 0.05   → H1 ruled out; reward is informative.
+
+Usage
+-----
+    uv run python experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+    uv run python ... --cell /tmp/h1_cell --no-baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.training.joint_trainer import (
+    JointPPOTrainer,
+    flatten_dict_obs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Statistics helpers
+# ---------------------------------------------------------------------------
+
+
+def per_agent_stats(r: np.ndarray) -> dict:
+    """Distributional stats for a single agent's per-step reward series."""
+    mean = float(r.mean())
+    std = float(r.std())
+    cv = std / (abs(mean) + 1e-9)
+    p10, p50, p90 = (float(x) for x in np.percentile(r, [10, 50, 90]))
+    return {"mean": mean, "std": std, "cv": cv, "p10": p10, "p50": p50, "p90": p90}
+
+
+def conditional_mean_r2(r: np.ndarray, labels: np.ndarray) -> float:
+    """R² of the optimal class-mean regressor of ``r`` on ``labels``.
+
+    Equivalent to 1 − SS_within / SS_total — i.e. the fraction of
+    per-step reward variance explained by the action label.
+    Returns NaN if ``r`` has zero variance.
+    """
+    ss_total = float(((r - r.mean()) ** 2).sum())
+    if ss_total <= 1e-12:
+        return float("nan")
+    pred = np.zeros_like(r, dtype=np.float64)
+    for lab in np.unique(labels):
+        mask = labels == lab
+        pred[mask] = r[mask].mean()
+    ss_res = float(((r - pred) ** 2).sum())
+    return 1.0 - ss_res / ss_total
+
+
+def text_histogram(values: np.ndarray, n_bins: int = 15, width: int = 60) -> str:
+    """ASCII histogram of a 1-D array."""
+    hist, edges = np.histogram(values, bins=n_bins)
+    peak = max(hist.max(), 1)
+    lines = []
+    for h, lo, hi in zip(hist, edges[:-1], edges[1:]):
+        bar = "#" * int(width * h / peak)
+        lines.append(f"  [{lo:8.3f}, {hi:8.3f}) {h:6d} {bar}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Rollout driver
+# ---------------------------------------------------------------------------
+
+
+def run_one_rollout(
+    cell_dir: Path,
+    *,
+    load_policies: bool,
+    rollout_steps: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, dict, "BucketBrigadeEnv"]:
+    """Load (or randomly init) policies from ``cell_dir`` and run one rollout.
+
+    Returns ``(R, A, cfg, scenario)`` where:
+
+    - ``R``: ndarray ``[N, T]`` of per-step rewards (stacked from the dict).
+    - ``A``: ndarray ``[N, T, 2]`` of per-step actions.
+    - ``cfg``: dict from ``config.json``.
+    - ``scenario``: the env scenario object (for analytic decomposition).
+    """
+    cfg = json.loads((cell_dir / "config.json").read_text())
+    scenario = get_scenario_by_name(cfg["scenario"], num_agents=cfg["num_agents"])
+
+    def env_fn():
+        return BucketBrigadeEnv(scenario=scenario)
+
+    probe = env_fn()
+    obs_dim = flatten_dict_obs(probe.reset(seed=cfg["seed"])).shape[0]
+
+    trainer = JointPPOTrainer(
+        env_fn=env_fn,
+        num_agents=cfg["num_agents"],
+        obs_dim=obs_dim,
+        action_dims=cfg["action_dims"],
+        hidden_size=cfg["hidden_size"],
+        lr=cfg["lr"],
+        ppo_epochs=cfg["ppo_epochs"],
+        minibatch_size=cfg["minibatch_size"],
+        value_coef=cfg["value_coef"],
+        entropy_coef=cfg["entropy_coef"],
+        normalize_returns=cfg.get("normalize_returns", False),
+        device=cfg.get("device", "cpu"),
+        seed=cfg["seed"],
+    )
+
+    if load_policies:
+        for i in range(cfg["num_agents"]):
+            sd = torch.load(
+                cell_dir / f"policies/agent_{i}.pt", map_location=cfg.get("device", "cpu")
+            )
+            trainer.policies[i].load_state_dict(sd)
+
+    steps = rollout_steps if rollout_steps is not None else cfg["rollout_steps"]
+    rollout = trainer.collect_rollout(steps)
+
+    # Sanity-check the curator's claim about dtype/shape before we proceed.
+    assert isinstance(rollout.rewards, dict), (
+        f"rollout.rewards is {type(rollout.rewards)}, expected dict — STOP"
+    )
+    sample = rollout.rewards[0]
+    assert isinstance(sample, torch.Tensor) and sample.ndim == 1, (
+        f"rollout.rewards[0] is {type(sample)} with shape {getattr(sample,'shape',None)}; "
+        "expected torch.Tensor[T]"
+    )
+
+    n = cfg["num_agents"]
+    R = torch.stack([rollout.rewards[i] for i in range(n)]).cpu().numpy()
+    A = torch.stack([rollout.actions[i] for i in range(n)]).cpu().numpy()
+    return R, A, cfg, scenario
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report(
+    label: str,
+    R: np.ndarray,
+    A: np.ndarray,
+    scenario,
+) -> dict:
+    """Print + return the per-agent verdict block for one rollout."""
+    n = R.shape[0]
+    work_cost = float(scenario.cost_to_work_one_night)
+    rest_reward = 0.5  # hard-coded in BucketBrigadeEnv._compute_rewards
+    print(f"\n{'=' * 72}\n{label}\nR.shape = {R.shape}, A.shape = {A.shape}\n{'=' * 72}")
+
+    summary = {}
+    for i in range(n):
+        r = R[i]
+        a = A[i]  # [T, 2]
+        stats = per_agent_stats(r)
+
+        # Action-reward R² on the packed 20-class action (10 houses x 2 modes).
+        packed = a[:, 0] * 2 + a[:, 1]
+        r2_packed = conditional_mean_r2(r, packed)
+        # Side-channel: binary work/rest only.
+        r2_work = conditional_mean_r2(r, a[:, 1])
+
+        # Analytic decomposition of the work/rest term:
+        # +0.5 on rest steps, -cost_to_work_one_night on work steps.
+        work_mask = a[:, 1] == 1  # WORK == 1
+        wr_term = np.where(work_mask, -work_cost, rest_reward).astype(np.float32)
+        residual = r - wr_term  # team + ownership (+ stochastic env)
+
+        wr_mean = float(wr_term.mean())
+        wr_std = float(wr_term.std())
+        res_mean = float(residual.mean())
+        res_std = float(residual.std())
+
+        # Verdict per H1 rubric (#190 ACs)
+        h1_cv = stats["cv"] < 0.05
+        h1_r2 = r2_packed < 0.01 if not np.isnan(r2_packed) else False
+        if h1_cv and h1_r2:
+            verdict = "H1 CONFIRMED (degenerate signal)"
+        elif (not h1_cv) and (not h1_r2):
+            verdict = "H1 RULED OUT (signal varies and is action-coupled)"
+        else:
+            verdict = "H1 AMBIGUOUS (mixed signal — see decomposition)"
+
+        print(
+            f"\nagent_{i}:"
+            f"\n  mean={stats['mean']:.4f}  std={stats['std']:.4f}  "
+            f"CV={stats['cv']:.4f}"
+            f"\n  p10/p50/p90 = {stats['p10']:.3f} / {stats['p50']:.3f} / {stats['p90']:.3f}"
+            f"\n  work_rate = {work_mask.mean():.3f}  "
+            f"wr_term(mean,std) = ({wr_mean:.3f}, {wr_std:.3f})  "
+            f"residual(mean,std) = ({res_mean:.3f}, {res_std:.3f})"
+            f"\n  R²(packed_20cls) = {r2_packed:.6f}  "
+            f"R²(work/rest only) = {r2_work:.6f}"
+            f"\n  --> {verdict}"
+        )
+
+        summary[f"agent_{i}"] = {
+            **stats,
+            "work_rate": float(work_mask.mean()),
+            "wr_term_mean": wr_mean,
+            "wr_term_std": wr_std,
+            "residual_mean": res_mean,
+            "residual_std": res_std,
+            "r2_packed": float(r2_packed),
+            "r2_work": float(r2_work),
+            "verdict": verdict,
+        }
+
+    print("\nHistogram of all per-step rewards (flattened across agents and steps):")
+    print(text_histogram(R.flatten()))
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cell",
+        type=Path,
+        default=Path("/tmp/h1_cell"),
+        help="Trained-cell directory containing config.json + policies/.",
+    )
+    parser.add_argument(
+        "--no-baseline",
+        action="store_true",
+        help="Skip the random-init comparison rollout.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional JSON path to save the numeric summary.",
+    )
+    args = parser.parse_args()
+
+    if not (args.cell / "config.json").exists():
+        raise SystemExit(
+            f"Cell not found at {args.cell}. See the script docstring for "
+            "rsync instructions, or train a fresh 50-iter cell."
+        )
+
+    # 1) Trained-policy rollout.
+    R, A, cfg, scenario = run_one_rollout(args.cell, load_policies=True)
+    trained_summary = report(
+        f"TRAINED CELL: {args.cell}  "
+        f"(scenario={cfg['scenario']}, lambda_red={cfg['lambda_red']}, "
+        f"seed={cfg['seed']}, num_iterations={cfg['num_iterations']})",
+        R,
+        A,
+        scenario,
+    )
+
+    # 2) Random-init baseline rollout (same env, same config).
+    baseline_summary = None
+    if not args.no_baseline:
+        Rb, Ab, _, _ = run_one_rollout(args.cell, load_policies=False)
+        baseline_summary = report(
+            f"RANDOM-INIT BASELINE (same config, no loaded policies)",
+            Rb,
+            Ab,
+            scenario,
+        )
+
+    # 3) Optional: dump numerics to JSON for the report.
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(
+                {
+                    "cell": str(args.cell),
+                    "cfg": cfg,
+                    "trained": trained_summary,
+                    "random_baseline": baseline_summary,
+                },
+                indent=2,
+            )
+        )
+        print(f"\nWrote summary JSON to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+++ b/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -159,7 +160,9 @@ def run_one_rollout(
     if load_policies:
         for i in range(cfg["num_agents"]):
             sd = torch.load(
-                cell_dir / f"policies/agent_{i}.pt", map_location=cfg.get("device", "cpu")
+                cell_dir / f"policies/agent_{i}.pt",
+                map_location=cfg.get("device", "cpu"),
+                weights_only=True,
             )
             trainer.policies[i].load_state_dict(sd)
 
@@ -172,7 +175,7 @@ def run_one_rollout(
     )
     sample = rollout.rewards[0]
     assert isinstance(sample, torch.Tensor) and sample.ndim == 1, (
-        f"rollout.rewards[0] is {type(sample)} with shape {getattr(sample,'shape',None)}; "
+        f"rollout.rewards[0] is {type(sample)} with shape {getattr(sample, 'shape', None)}; "
         "expected torch.Tensor[T]"
     )
 
@@ -197,7 +200,9 @@ def report(
     n = R.shape[0]
     work_cost = float(scenario.cost_to_work_one_night)
     rest_reward = 0.5  # hard-coded in BucketBrigadeEnv._compute_rewards
-    print(f"\n{'=' * 72}\n{label}\nR.shape = {R.shape}, A.shape = {A.shape}\n{'=' * 72}")
+    print(
+        f"\n{'=' * 72}\n{label}\nR.shape = {R.shape}, A.shape = {A.shape}\n{'=' * 72}"
+    )
 
     summary = {}
     for i in range(n):
@@ -272,8 +277,12 @@ def main() -> None:
     parser.add_argument(
         "--cell",
         type=Path,
-        default=Path("/tmp/h1_cell"),
-        help="Trained-cell directory containing config.json + policies/.",
+        default=Path(tempfile.gettempdir()) / "h1_cell",
+        help=(
+            "Trained-cell directory containing config.json + policies/. "
+            "Defaults to <system-tempdir>/h1_cell (the conventional rsync "
+            "target documented in the script docstring)."
+        ),
     )
     parser.add_argument(
         "--no-baseline",
@@ -310,7 +319,7 @@ def main() -> None:
     if not args.no_baseline:
         Rb, Ab, _, _ = run_one_rollout(args.cell, load_policies=False)
         baseline_summary = report(
-            f"RANDOM-INIT BASELINE (same config, no loaded policies)",
+            "RANDOM-INIT BASELINE (same config, no loaded policies)",
             Rb,
             Ab,
             scenario,

--- a/research_notebook/2026-05-15_h1_rollout_rewards.md
+++ b/research_notebook/2026-05-15_h1_rollout_rewards.md
@@ -1,0 +1,93 @@
+# H1 diagnostic: per-step rollout reward distribution
+
+**Issue:** [#190](https://github.com/rjwalters/bucket-brigade/issues/190)
+**Date:** 2026-05-15
+**Author:** Builder (agent-5)
+
+## TL;DR
+
+**Verdict: H1 is *ambiguous-leaning-falsified*.** The pure "near-constant per-step reward" version of H1 (CV < 0.05) is **falsified**: aggregate per-agent CV sits at **0.33-0.36** for the trained Phase-3-stuck cell. However the *spirit* of H1 — that the action-controllable component of the per-step reward is too weak to drive policy improvement — is **broadly supported**: the variance of the per-step reward is almost entirely carried by the team-reward term (residual std ≈ 25), while the analytic work/rest action term has std ≈ 0.4, and the action-reward R² on the full 20-class packed action is **0.011-0.036** — i.e. ≤ ~4% of per-step reward variance is explainable by the agent's own action choice. Trained-policy R² is within a factor of 2-6 of the random-init baseline, indicating the trained policy is barely better than random at producing action-reward coupling.
+
+The right fix is *not* "the signal is constant" (#193's framing of H1 as written). It is: **per-step reward is dominated by a team term that is approximately exogenous from each agent's instantaneous action.** Sibling issues #191 (per-agent attribution) and #193 (reward-shaping) are the natural follow-ups.
+
+## Method
+
+- **Cell:** `runs/p3_183_phase3/L1_norm/default/lambda_0e0/seed_42` from `$COMPUTE_HOST_PRIMARY` (`robbs-mac-studio`); 500 iterations, scenario=`default`, λ_red=0.0, seed=42, `normalize_returns=true`. Rsynced to `/tmp/h1_cell`.
+- **Script:** [`experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py`](../experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py).
+- **Procedure:** load the 4 trained policies; run one `trainer.collect_rollout(2048)`; stack `rollout.rewards` (a `Dict[int, torch.Tensor]`) into an `ndarray[N=4, T=2048]`; compute per-agent stats, analytic work/rest decomposition, and action-reward R² on the 20-class packed action `a[:,0]*2 + a[:,1]`. Repeat with a fresh random-init policy as a baseline.
+
+The curator-noted dtype claim (`Dict[int, torch.Tensor]`, each `[T]` `float32`) was **verified** at runtime via `assert` — no quiet patching needed.
+
+## Per-agent numbers (trained cell, scenario=default, 500-iter, seed 42)
+
+| Agent | mean   | std    | CV      | p10    | p50    | p90    | work_rate | wr_term std | residual std | R²(packed) | R²(work) |
+|-------|-------:|-------:|--------:|-------:|-------:|-------:|----------:|------------:|-------------:|-----------:|---------:|
+| 0     | 74.19  | 24.98  | 0.337   | 37.5   | 79.5   | 99.5   | 0.998     | 0.044       | 24.98        | 0.0126     | 0.00019  |
+| 1     | 74.88  | 25.19  | 0.336   | 38.5   | 80.5   | 100.5  | 0.137     | 0.344       | 25.17        | 0.0136     | 0.00247  |
+| 2     | 75.07  | 24.74  | 0.330   | 38.5   | 80.5   | 100.5  | 0.294     | 0.456       | 24.73        | 0.0109     | 0.00153  |
+| 3     | 75.10  | 24.85  | 0.331   | 38.5   | 80.5   | 100.5  | 0.202     | 0.401       | 24.81        | 0.0361     | 0.01273  |
+
+Random-init baseline (same env / config) shows CV ≈ 0.355, R²(packed) ≈ 0.006-0.011 — i.e. **the trained policy lifts R² from ~0.008 to ~0.018 on average, a meaningful but tiny absolute amount; it does not reduce CV** (variance is set by env dynamics, not policy).
+
+## Histogram (trained cell, all (N × T) per-step rewards)
+
+```
+  [ -44.500,  -34.767)      4
+  [ -34.767,  -25.033)      4
+  [ -25.033,  -15.300)      0
+  [ -15.300,   -5.567)      8
+  [  -5.567,    4.167)     60 #
+  [   4.167,   13.900)     39
+  [  13.900,   23.633)    337 ########
+  [  23.633,   33.367)    100 ##
+  [  33.367,   43.100)    688 ################
+  [  43.100,   52.833)    208 ####
+  [  52.833,   62.567)   1100 ##########################
+  [  62.567,   72.300)    372 ########
+  [  72.300,   82.033)   2252 #####################################################
+  [  82.033,   91.767)    516 ############
+  [  91.767,  101.500)   2504 ############################################################
+```
+
+The distribution is clearly **non-degenerate** — it's bimodal-skewed with most mass at ~80 (most houses safe ⇒ team_reward ≈ 90 of 100) and a secondary mass near 35-45 (partial saves). The original H1 framing ("near-constant signal, CV < 0.05") doesn't fit this picture.
+
+## Interpretation against #190's rubric
+
+The curator's rubric in the issue:
+
+| Condition | Verdict |
+|-----------|---------|
+| CV < 0.05 AND R² < 0.01 | H1 confirmed (degenerate signal) |
+| CV low, R² > 0.05 | H1 ruled out; PPO failing |
+| CV high, R² > 0.05 | H1 ruled out; signal informative |
+
+Our case is **CV high (~0.33) AND R² low (~0.018)**. The rubric doesn't list this cell explicitly. The right reading:
+
+- **CV >> 0.05** → the per-step reward is not "near-constant." The aggregate-CV operationalization of H1 is **falsified**.
+- **But R² is also low (~0.018, well under 0.05)** → most of that variance is action-independent. The signal is "informative-about-the-world" (team state changes) but **not informative-about-the-agent's-own-instantaneous-action**.
+
+In other words: the variance in the per-step reward is coming from the team term reacting to environment stochasticity (`prob_house_catches_fire=0.02`, fire spread, etc.), not from the agent's action choice. Per the env code at `bucket_brigade_env.py:248-298`, the team term is `100 * saved_fraction - 100 * burned_fraction`, shared across all 4 agents, and this dominates per-step magnitude (mean ~75 from team vs. mean |wr_term| ≈ 0.4 from work/rest).
+
+This points the post-mortem at **credit assignment / advantage estimation** rather than "the signal is constant":
+
+- The team term is a shared baseline that GAE will mostly route into the value-function and zero out in the advantage (good).
+- What remains in the advantage *should* be the action-controllable component — but R²(work) ≈ 0.001-0.013 means the work/rest signal is genuinely faint per-step relative to the residual stochasticity.
+- The 10-way location action is similarly weak in R² (R²(packed) is only modestly higher than R²(work)).
+
+So H1's underlying intuition has a kernel of truth — the action-controllable per-step reward is dwarfed by env stochasticity — but the *operationalization* (low aggregate CV) was the wrong proxy. The right diagnostic going forward is **R²(advantage, action)** post-GAE, not R²(raw reward, action).
+
+## Recommended follow-ups
+
+1. **#191 (per-agent attribution audit):** is the per-agent reward actually distinguishing the agent from its teammates? Given the work_rates `(0.998, 0.137, 0.294, 0.202)`, agent_0 is in a "work-always" basin while the others are mostly resting — yet the four mean per-step rewards differ by < 1 unit (74.2 vs 75.1). The team term is *swamping* per-agent distinctions.
+2. **Post-GAE diagnostic:** compute R² of the *GAE advantage* on the action (not the raw reward). This is the quantity PPO's loss actually depends on. The reward signal could be informative-in-principle but the advantage flat-in-practice (or vice versa).
+3. **#193 (reward-shaping proposal):** consider down-weighting the team term in the per-agent reward (e.g. credit-assignment baseline subtraction, or a difference-rewards/AAMAS-style decomposition). Even halving the team coefficient would lift R²(packed) by an order of magnitude purely from the variance-ratio shift.
+
+## Artifacts
+
+- Script: `experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py` (committed).
+- Raw JSON summary: `/tmp/h1_summary.json` (not committed — reproducible from the script).
+- Trained cell: `/tmp/h1_cell` (not committed; rsync from `$COMPUTE_HOST_PRIMARY` per script docstring).
+
+## One-line verdict
+
+**H1 as written (CV < 0.05) is falsified, but its underlying intuition is supported: per-step reward variance is dominated by environment stochasticity in the team term, leaving the action-controllable component below R² ≈ 0.02 on the packed 20-class action — too faint for PPO to extract reliably.**


### PR DESCRIPTION
## Summary

Standalone diagnostic at `experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py` that loads a trained P3 cell, runs one `trainer.collect_rollout(2048)`, and reports per-agent reward stats, an analytic work/rest decomposition, and an action-reward R² on the 20-class packed action (10 houses x rest/work). Also runs a random-init baseline for comparison.

Findings written up at `research_notebook/2026-05-15_h1_rollout_rewards.md`.

## Verdict on H1

- **Cell:** `runs/p3_183_phase3/L1_norm/default/lambda_0e0/seed_42` rsynced from `$COMPUTE_HOST_PRIMARY` (500-iter, scenario=default, λ_red=0.0, normalize_returns=true).
- **Per-agent CV:** 0.330 - 0.337 (well above the original < 0.05 smoking-gun threshold).
- **R²(packed_20cls):** 0.011 - 0.036 (mean ~0.018) — below the 0.05 "informative" threshold.
- **Decomposition:** residual (team + ownership) std ≈ 25 dominates; work/rest term std ≈ 0.4.
- **Random-init baseline:** CV ≈ 0.36, R²(packed) ≈ 0.005 - 0.011. Trained policy barely lifts R² above random.

**H1 as written is falsified** (signal is not near-constant), but its **underlying intuition is supported**: per-step variance is carried by the shared team-reward term reacting to env stochasticity, leaving the action-controllable component too weak for PPO to extract. Next steps point at #191 (per-agent attribution) and #193 (reward shaping), and at running this same R² test on the GAE advantage rather than the raw reward.

## Scope

- Diagnostic-only deliverable. No `train.py` / `joint_trainer.py` / env changes.
- Curator's dtype claim (`Dict[int, torch.Tensor]`) verified at runtime via `assert` before any stacking.

## Test plan

- [x] Manual: `uv run python experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py --cell /tmp/h1_cell --out /tmp/h1_summary.json` runs in < 30 s on CPU.
- [x] Output reports per-agent mean/std/CV/p10/p50/p90 + R²(packed) + R²(work/rest) + analytic work/rest decomposition.
- [x] Output includes a text histogram of the per-step reward distribution.
- [x] Random-init baseline rollout reported alongside the trained one for variance attribution.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)