### PR TITLE
docs: amend May-14 P3 notebook with corrected random baseline (293)

### DIFF
--- a/research_notebook/2026-05-14_p3_specialization_results.md
+++ b/research_notebook/2026-05-14_p3_specialization_results.md
@@ -117,3 +117,18 @@ Per the team's current operating posture (`file issues, don't do work`), the fol
 - Cell artifacts: `experiments/p3_specialization/runs/{scenario}/{lambda}/seed_{N}/` containing `metrics.json`, `config.json`, `policies/agent_*.pt`, `dropout_results.json`.
 - Aggregated: `experiments/p3_specialization/analysis.json`.
 - Code: this commit + d6d15c76 (env fix) + 99fa47ce (experiment infrastructure).
+
+## Amendment (2026-05-15): corrected random baseline
+
+After #192's diagnostic (PR #196, commit `ec6e521c`) re-derived the random baseline:
+
+- Uniform-random per-step reward on `default`: **293.39 ± [288.87, 297.78]** (n=1000), NOT 308.
+- The 308 value originally cited in #145 (and quoted on line 92 above) was a high-variance n=50 sample; reproducing #145's n=50 protocol gives 289.46 [271.91, 306.09].
+
+**Implications:**
+
+- The "PPO performs slightly below random" framing was an artifact. PPO at iter-49 (mean ~290) sits inside the random-action CI. **PPO is at random, not below it.**
+- F1 (CMI monotone) verdict unchanged: still falsified — CMI flat in λ regardless of baseline correction.
+- F2 (reward strictly worse at every λ > 0) verdict: was previously "not triggered" (reward essentially constant in λ). The constancy-in-λ finding is unchanged; the interpretation of constancy moves from "PPO learned no specialization at any λ" to "PPO did not move from random at any λ." Both are consistent with the same data; the second is the honest framing given the corrected baseline.
+
+The canonical baseline script is now at `experiments/p3_specialization/diagnostics/random_baseline.py` (#192 / PR #196). The matching diagnostic write-up lives at `research_notebook/2026-05-15_h3_random_baseline.md`.


### PR DESCRIPTION
## Summary

Appends a 2026-05-15 amendment section to `research_notebook/2026-05-14_p3_specialization_results.md` so the May-14 results page reflects the corrected uniform-random baseline derived in #192 / PR #196 (commit `ec6e521c`): 293.39 [288.87, 297.78] (n=1000), not 308.

## Changes

- Appended a new `## Amendment (2026-05-15): corrected random baseline` section (15 lines) to the end of the May-14 notebook, after the existing `Reproducibility` section.
- Documents the corrected baseline, explains why 308 was an n=50 right-tail sample, and reframes the F1/F2 interpretation: "PPO performs slightly below random" was an artifact — PPO at iter-49 (~290) sits inside the random-action CI, so PPO is *at* random, not below.
- Cross-links the canonical baseline script (`experiments/p3_specialization/diagnostics/random_baseline.py`) and the H3 diagnostic write-up (`research_notebook/2026-05-15_h3_random_baseline.md`).
- Line 92 of the original notebook is preserved verbatim (no in-place edit) to maintain the historical record, per the issue's explicit guidance.
- No other notebooks, scripts, or analysis code touched (the sweeping 308-references audit is a separate issue).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Amendment section appended at end of `2026-05-14_p3_specialization_results.md` (after current line 119) | Done | `git diff` shows insertion starts at original line 120 (final blank line); new content runs to line 134 |
| Original line 92 untouched | Done | `git diff` hunk header is `@@ -117,3 +117,18 @@` — line 92 is outside the hunk; pure append |
| Rest of original results table / prose untouched | Done | `git diff --stat` shows 1 file, 15 insertions, 0 deletions |
| Amendment references PR #196 and commit `ec6e521c` | Done | Both cited in the opening sentence of the amendment |
| Amendment cross-links the H3 write-up at `research_notebook/2026-05-15_h3_random_baseline.md` | Done | Final paragraph of the amendment |
| No other notebooks edited | Done | `git diff --stat` shows only the one target file |

## Test Plan

- Pure documentation change — no code paths affected, no tests to run.
- Reviewed diff to confirm scoped, additive change with original content (including the cited line 92) preserved verbatim.

Closes #200