### PR TITLE
fix: auto-format generated Python output and silence pre-existing bandit hits

### DIFF
--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -40,10 +40,18 @@ class Scenario:
 
     # Individual rewards (ownership-based, per-agent vectors of length num_agents)
     # Scalar inputs are auto-promoted in __post_init__ for backward compat.
-    reward_own_house_survives: Union[float, List[float]]  # Per-agent reward when own house survives
-    reward_other_house_survives: Union[float, List[float]]  # Per-agent reward when other house survives
-    penalty_own_house_burns: Union[float, List[float]]  # Per-agent penalty when own house burns
-    penalty_other_house_burns: Union[float, List[float]]  # Per-agent penalty when other house burns
+    reward_own_house_survives: Union[
+        float, List[float]
+    ]  # Per-agent reward when own house survives
+    reward_other_house_survives: Union[
+        float, List[float]
+    ]  # Per-agent reward when other house survives
+    penalty_own_house_burns: Union[
+        float, List[float]
+    ]  # Per-agent penalty when own house burns
+    penalty_other_house_burns: Union[
+        float, List[float]
+    ]  # Per-agent penalty when other house burns
 
     # Costs and structure
     cost_to_work_one_night: float  # Cost incurred when agent chooses to work
@@ -344,7 +352,6 @@ def minimal_specialization_scenario(num_agents: int) -> Scenario:
     )
 
 
-
 # Registry of all scenarios
 SCENARIO_REGISTRY = {
     "default": default_scenario,
@@ -361,7 +368,6 @@ SCENARIO_REGISTRY = {
     "mixed_motivation": mixed_motivation_scenario,
     "minimal_specialization": minimal_specialization_scenario,
 }
-
 
 
 def get_scenario_by_name(name: str, num_agents: int) -> Scenario:

--- a/bucket_brigade/training/game_simulator.py
+++ b/bucket_brigade/training/game_simulator.py
@@ -60,7 +60,7 @@ class Matchmaker:
 
         elif strategy == "random":
             # Completely random sampling
-            agents = random.sample(
+            agents = random.sample(  # nosec B311 - non-cryptographic agent sampling for training
                 range(self.population_size), k=self.num_agents_per_game
             )
             for agent_id in agents:
@@ -312,7 +312,7 @@ class GameSimulator:
 
         for episode in range(num_episodes):
             # Run episode in a random environment
-            env_id = random.randint(0, self.num_games - 1)
+            env_id = random.randint(0, self.num_games - 1)  # nosec B311 - non-cryptographic env selection for training
             trajectories = self.run_episode(env_id)
 
             # Distribute experiences to GPU learners

--- a/experiments/p3_specialization/diagnostics/audit_reward_attribution.py
+++ b/experiments/p3_specialization/diagnostics/audit_reward_attribution.py
@@ -32,7 +32,9 @@ from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
 from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
 
 
-def run_rollouts(scenario_name="default", seeds=tuple(range(20)), max_nights_per_ep=200):
+def run_rollouts(
+    scenario_name="default", seeds=tuple(range(20)), max_nights_per_ep=200
+):
     """Roll out a few episodes with uniform-random actions and decompose
     each per-step reward into (team, ownership, work_cost).
 
@@ -68,10 +70,9 @@ def run_rollouts(scenario_name="default", seeds=tuple(range(20)), max_nights_per
             # and the prev_houses captured at the start of the step.
             saved = int(np.sum(env.houses == env.SAFE))
             ruined = int(np.sum(env.houses == env.RUINED))
-            team = (
-                scenario.team_reward_house_survives * (saved / 10.0)
-                - scenario.team_penalty_house_burns * (ruined / 10.0)
-            )
+            team = scenario.team_reward_house_survives * (
+                saved / 10.0
+            ) - scenario.team_penalty_house_burns * (ruined / 10.0)
 
             own = np.zeros(4, dtype=np.float64)
             work = np.zeros(4, dtype=np.float64)
@@ -219,18 +220,26 @@ def main():
     print("Magnitudes (mean of absolute value):")
     m = summary["magnitudes"]
     print(f"  team component         {m['mean_abs_team']:8.3f}")
-    print(f"  ownership component    {m['mean_abs_ownership_per_agent']:8.3f}  (per agent)")
+    print(
+        f"  ownership component    {m['mean_abs_ownership_per_agent']:8.3f}  (per agent)"
+    )
     print(f"  work cost              {m['mean_abs_work_per_agent']:8.3f}  (per agent)")
     print()
     print("Per-step magnitude ratios:")
     r = summary["ratios"]
     to = r["team_over_ownership"]
     tw = r["team_over_work_cost"]
-    print(f"  |team| / |ownership|  median={to['median']:.2f}  "
-          f"p75={to['p75']:.2f}  p95={to['p95']:.2f}  (n={to['n']})")
-    print(f"  |team| / |work_cost|  median={tw['median']:.2f}  "
-          f"p75={tw['p75']:.2f}  p95={tw['p95']:.2f}  (n={tw['n']})")
-    print(f"  fraction of steps with zero ownership: {r['frac_steps_ownership_zero']:.3f}")
+    print(
+        f"  |team| / |ownership|  median={to['median']:.2f}  "
+        f"p75={to['p75']:.2f}  p95={to['p95']:.2f}  (n={to['n']})"
+    )
+    print(
+        f"  |team| / |work_cost|  median={tw['median']:.2f}  "
+        f"p75={tw['p75']:.2f}  p95={tw['p95']:.2f}  (n={tw['n']})"
+    )
+    print(
+        f"  fraction of steps with zero ownership: {r['frac_steps_ownership_zero']:.3f}"
+    )
     print()
     print("Pairwise agent reward correlation matrix (4x4):")
     for row in summary["pairwise_corr"]:
@@ -241,13 +250,14 @@ def main():
     print()
     print(f"Team variance:                  {summary['team_var']:.4f}")
     print(f"Mean per-agent reward variance: {summary['mean_per_agent_var']:.4f}")
-    print(f"Team-share lower bound on corr: "
-          f"{summary['team_share_lower_bound_on_corr']:.4f}")
-    print()
-    verdict_h2 = (
-        (to["median"] is not None and to["median"] >= 10.0)
-        or summary["min_off_diag_corr"] > 0.95
+    print(
+        f"Team-share lower bound on corr: "
+        f"{summary['team_share_lower_bound_on_corr']:.4f}"
     )
+    print()
+    verdict_h2 = (to["median"] is not None and to["median"] >= 10.0) or summary[
+        "min_off_diag_corr"
+    ] > 0.95
     print(f"H2 VERDICT: {'CONFIRMED' if verdict_h2 else 'NOT CONFIRMED'}")
 
     out_dir = Path(__file__).resolve().parent / "results"

--- a/experiments/p3_specialization/diagnostics/issue199_baselines.py
+++ b/experiments/p3_specialization/diagnostics/issue199_baselines.py
@@ -60,9 +60,7 @@ def _run_random_episode(
     return total_reward, int(env.night)
 
 
-def _run_specialist_episode(
-    env: BucketBrigadeEnv, seed: int
-) -> Tuple[float, int]:
+def _run_specialist_episode(env: BucketBrigadeEnv, seed: int) -> Tuple[float, int]:
     """One specialist-policy episode. Returns (team_reward, nights_played)."""
     obs = env.reset(seed=seed)
     total_reward = 0.0
@@ -73,17 +71,23 @@ def _run_specialist_episode(
     return total_reward, int(env.night)
 
 
-def _bootstrap_ci(arr: np.ndarray, n_boot: int = 10_000, alpha: float = 0.05) -> Tuple[float, float]:
+def _bootstrap_ci(
+    arr: np.ndarray, n_boot: int = 10_000, alpha: float = 0.05
+) -> Tuple[float, float]:
     rng = np.random.default_rng(0)
     n = len(arr)
     boots = np.empty(n_boot, dtype=np.float64)
     for i in range(n_boot):
         idx = rng.integers(0, n, size=n)
         boots[i] = arr[idx].mean()
-    return float(np.percentile(boots, 100 * alpha / 2)), float(np.percentile(boots, 100 * (1 - alpha / 2)))
+    return float(np.percentile(boots, 100 * alpha / 2)), float(
+        np.percentile(boots, 100 * (1 - alpha / 2))
+    )
 
 
-def _summarize(label: str, per_step: np.ndarray, per_ep: np.ndarray, lengths: np.ndarray) -> dict:
+def _summarize(
+    label: str, per_step: np.ndarray, per_ep: np.ndarray, lengths: np.ndarray
+) -> dict:
     lo, hi = _bootstrap_ci(per_step)
     return {
         "label": label,
@@ -157,8 +161,12 @@ def _measure(scenario_name: str, num_agents: int, episodes: int, seed: int) -> d
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--episodes", type=int, default=50,
-                    help="Number of episodes per baseline. #199 spec asks for 50.")
+    ap.add_argument(
+        "--episodes",
+        type=int,
+        default=50,
+        help="Number of episodes per baseline. #199 spec asks for 50.",
+    )
     ap.add_argument("--num-agents", type=int, default=4)
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument(

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -100,7 +100,9 @@ def run_mlp_episode(
     total_reward = 0.0
     while not env.done:
         obs_t = torch.from_numpy(obs).unsqueeze(0)
-        joint_action = np.zeros((trainer.num_agents, len(trainer.action_dims)), dtype=np.int64)
+        joint_action = np.zeros(
+            (trainer.num_agents, len(trainer.action_dims)), dtype=np.int64
+        )
         with torch.no_grad():
             for i, policy in enumerate(trainer.policies):
                 a, _, _, _ = policy.get_action_and_value(obs_t)
@@ -112,14 +114,18 @@ def run_mlp_episode(
     return total_reward, int(env.night)
 
 
-def bootstrap_ci(arr: np.ndarray, n_boot: int = 10_000, alpha: float = 0.05) -> Tuple[float, float]:
+def bootstrap_ci(
+    arr: np.ndarray, n_boot: int = 10_000, alpha: float = 0.05
+) -> Tuple[float, float]:
     rng = np.random.default_rng(0)
     boots = np.empty(n_boot, dtype=np.float64)
     n = len(arr)
     for i in range(n_boot):
         idx = rng.integers(0, n, size=n)
         boots[i] = arr[idx].mean()
-    return float(np.percentile(boots, 100 * alpha / 2)), float(np.percentile(boots, 100 * (1 - alpha / 2)))
+    return float(np.percentile(boots, 100 * alpha / 2)), float(
+        np.percentile(boots, 100 * (1 - alpha / 2))
+    )
 
 
 def summarize(label: str, arr: np.ndarray) -> str:
@@ -129,18 +135,34 @@ def summarize(label: str, arr: np.ndarray) -> str:
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--episodes-per-seed", type=int, default=200,
-                    help="Episodes per seed for uniform-random. #145 used 50 (single seed); "
-                         "default 200 across 5 seeds tightens the CI.")
-    ap.add_argument("--seeds", type=int, default=5, help="Number of seeds (42, 43, ...).")
-    ap.add_argument("--mlp-episodes-per-seed", type=int, default=50,
-                    help="Episodes per seed for random-init MLP (slower).")
-    ap.add_argument("--no-mlp", action="store_true", help="Skip the random-init MLP pass.")
+    ap.add_argument(
+        "--episodes-per-seed",
+        type=int,
+        default=200,
+        help="Episodes per seed for uniform-random. #145 used 50 (single seed); "
+        "default 200 across 5 seeds tightens the CI.",
+    )
+    ap.add_argument(
+        "--seeds", type=int, default=5, help="Number of seeds (42, 43, ...)."
+    )
+    ap.add_argument(
+        "--mlp-episodes-per-seed",
+        type=int,
+        default=50,
+        help="Episodes per seed for random-init MLP (slower).",
+    )
+    ap.add_argument(
+        "--no-mlp", action="store_true", help="Skip the random-init MLP pass."
+    )
     args = ap.parse_args()
 
     scenario = get_scenario_by_name(SCENARIO_NAME, num_agents=NUM_AGENTS)
-    print(f"Scenario: {SCENARIO_NAME}, num_agents={NUM_AGENTS}, min_nights={scenario.min_nights}")
-    print(f"Cited values: random={CITED_308} (issue #145), iter-0 MLP={CITED_290} (issue #183)")
+    print(
+        f"Scenario: {SCENARIO_NAME}, num_agents={NUM_AGENTS}, min_nights={scenario.min_nights}"
+    )
+    print(
+        f"Cited values: random={CITED_308} (issue #145), iter-0 MLP={CITED_290} (issue #183)"
+    )
     print()
 
     seeds = list(range(42, 42 + args.seeds))
@@ -164,11 +186,15 @@ def main() -> None:
     print("=== Uniform-random ===")
     print(summarize("  per-episode  ", rand_per_episode_arr))
     print(summarize("  per-step     ", rand_per_step_arr))
-    print(f"  episode length: median={int(np.median(rand_lengths_arr))}, "
-          f"mean={rand_lengths_arr.mean():.2f}, "
-          f"min={rand_lengths_arr.min()}, max={rand_lengths_arr.max()}")
+    print(
+        f"  episode length: median={int(np.median(rand_lengths_arr))}, "
+        f"mean={rand_lengths_arr.mean():.2f}, "
+        f"min={rand_lengths_arr.min()}, max={rand_lengths_arr.max()}"
+    )
     # Sanity: reproduce the 4012.34 / 13 ≈ 308.6 framing.
-    print(f"  per-episode / median-length = {rand_per_episode_arr.mean() / np.median(rand_lengths_arr):.2f}")
+    print(
+        f"  per-episode / median-length = {rand_per_episode_arr.mean() / np.median(rand_lengths_arr):.2f}"
+    )
     print()
 
     # ----- Random-init MLP iter-0 -----
@@ -191,14 +217,18 @@ def main() -> None:
             )
             mlp_env = BucketBrigadeEnv(scenario=scenario)
             for ep in range(args.mlp_episodes_per_seed):
-                ep_reward, nights = run_mlp_episode(trainer, mlp_env, seed=seed * 1000 + ep)
+                ep_reward, nights = run_mlp_episode(
+                    trainer, mlp_env, seed=seed * 1000 + ep
+                )
                 mlp_per_step.append(ep_reward / nights)
                 mlp_lengths.append(nights)
         mlp_per_step_arr = np.array(mlp_per_step)
         print("=== Random-init MLP (iter-0, untrained PolicyNetwork) ===")
         print(summarize("  per-step     ", mlp_per_step_arr))
-        print(f"  episode length: median={int(np.median(mlp_lengths))}, "
-              f"mean={np.mean(mlp_lengths):.2f}")
+        print(
+            f"  episode length: median={int(np.median(mlp_lengths))}, "
+            f"mean={np.mean(mlp_lengths):.2f}"
+        )
         print()
 
     # ----- Verdict -----

--- a/experiments/p3_specialization/dropout_eval.py
+++ b/experiments/p3_specialization/dropout_eval.py
@@ -42,7 +42,11 @@ def _build_policies(
         p = PolicyNetwork(
             obs_dim=obs_dim, action_dims=action_dims, hidden_size=hidden_size
         ).to(device)
-        state = torch.load(cell_dir / "policies" / f"agent_{i}.pt", map_location=device)
+        state = torch.load(
+            cell_dir / "policies" / f"agent_{i}.pt",
+            map_location=device,
+            weights_only=True,
+        )
         p.load_state_dict(state)
         p.eval()
         policies.append(p)

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -6,9 +6,46 @@ This script reads JSON definitions and generates Python modules.
 """
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
+
+
+def _format_with_ruff(path: Path) -> None:
+    """Run ``ruff format`` on the generated file.
+
+    Generated files are emitted with hand-rolled string concatenation, which
+    does not match ``ruff format``'s canonical style (quote style, trailing
+    commas, line wrapping). Without this post-write formatter pass, every
+    regeneration re-introduces the same lint failures the CI ``lint-python``
+    and ``pre-commit`` jobs check for (see issue #188).
+
+    We invoke ``ruff`` via ``uv run`` so the project's pinned version is used.
+    If ``uv``/``ruff`` is not on PATH (e.g., minimal CI image without uv),
+    fall back to invoking ``ruff`` directly. If neither is available we warn
+    but do not fail: regenerating must remain possible in odd environments,
+    and the CI lint job will surface the formatting drift anyway.
+    """
+    for argv in (
+        ["uv", "run", "ruff", "format", str(path)],
+        ["ruff", "format", str(path)],
+    ):
+        try:
+            subprocess.run(argv, check=True)
+            return
+        except FileNotFoundError:
+            continue
+        except subprocess.CalledProcessError as exc:
+            print(
+                f"⚠ ruff format failed on {path}: {exc}", file=sys.stderr
+            )
+            return
+    print(
+        f"⚠ ruff not found; skipping format of {path}. "
+        "Install ruff (or uv) to keep generated output lint-clean.",
+        file=sys.stderr,
+    )
 
 
 def generate_archetypes(json_path: Path, output_path: Path):
@@ -55,6 +92,9 @@ def generate_archetypes(json_path: Path, output_path: Path):
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, 'w') as f:
         f.write(code)
+
+    # Re-format with ruff so the next CI run stays green (issue #188).
+    _format_with_ruff(output_path)
 
     print(f"✓ Generated {output_path}")
 
@@ -264,6 +304,9 @@ def generate_scenarios(json_path: Path, output_path: Path):
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, 'w') as f:
         f.write(code)
+
+    # Re-format with ruff so the next CI run stays green (issue #188).
+    _format_with_ruff(output_path)
 
     print(f"✓ Generated {output_path}")
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -683,9 +683,7 @@ class TestPerAgentOwnershipRewards:
         # owns exactly one of houses 0..3, and houses 4..9 cycle owners.
         env.house_owners = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1], dtype=np.int8)
         # Stage a save event for EVERY agent's first owned house (houses 0..3).
-        env._prev_houses_state = np.array(
-            [env.BURNING] * 4 + [0] * 6, dtype=np.int8
-        )
+        env._prev_houses_state = np.array([env.BURNING] * 4 + [0] * 6, dtype=np.int8)
         env.houses = np.zeros(10, dtype=np.int8)  # all SAFE
         actions = np.zeros((env.num_agents, 2), dtype=np.int8)  # all REST
         rewards = env._compute_rewards(actions)

--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -68,9 +68,7 @@ class TestRustCoreIntegration:
             # Python ``step`` returns ``(obs, rewards, dones, info)``;
             # ``dones`` is a per-agent array but all entries match
             # ``self.done`` so taking [0] is sufficient.
-            _, python_rewards, python_dones, _ = python_env.step(
-                np.array(action_set)
-            )
+            _, python_rewards, python_dones, _ = python_env.step(np.array(action_set))
             python_done = bool(python_dones[0])
 
             # Rewards should match within float tolerance.


### PR DESCRIPTION
## Summary

CI's `lint-python` and `pre-commit` jobs have been red on `main` since before PR #179 because `ruff format --check` flagged 6 files and `bandit` flagged 3 findings — none introduced by individual PRs. Reviewers had to manually triage "not my PR" on every approval.

This PR fixes the **root cause** (generator emitting unformatted output) before reformatting the affected files, so the next regeneration cannot undo the work. It also annotates / fixes the 3 pre-existing bandit findings.

## Changes

**Generator fix (root cause — must happen first)**
- `scripts/generate_python.py`: new `_format_with_ruff()` helper invokes `uv run ruff format` (with bare-`ruff` fallback) on the output of both `generate_archetypes()` and `generate_scenarios()` after writing. This prevents the next regen from reintroducing the lint failure.

**Formatting cleanup (`ruff format`)**
- `bucket_brigade/envs/scenarios_generated.py` — regenerated; now formatter-clean by construction.
- `experiments/p3_specialization/diagnostics/audit_reward_attribution.py`
- `experiments/p3_specialization/diagnostics/issue199_baselines.py`
- `experiments/p3_specialization/diagnostics/random_baseline.py`
- `tests/test_environment.py`
- `tests/test_rust_integration.py`

**Bandit suppressions / fixes (with rationale comments)**
- `bucket_brigade/training/game_simulator.py:63` — `# nosec B311 - non-cryptographic agent sampling for training`
- `bucket_brigade/training/game_simulator.py:315` — `# nosec B311 - non-cryptographic env selection for training`
- `experiments/p3_specialization/dropout_eval.py:45` — switched to `torch.load(..., weights_only=True)` (preferred over `# nosec B614` per issue guidance, since these are our own checkpoint files)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `uv run pre-commit run --all-files` returns exit 0 | Pass | Ran locally; all hooks (ruff, ruff-format, trailing-whitespace, eof-fixer, check-yaml, large-files, merge-conflict, debug-statements, bandit) passed. |
| CI `lint-python` matches: `ruff format --check . --exclude .venv/ --exclude scripts/ --exclude node_modules/ --exclude web/node_modules/` exits 0 | Pass | `105 files already formatted` |
| Generator post-write `ruff format` step added to both `generate_archetypes` and `generate_scenarios` | Pass | New `_format_with_ruff()` helper called after `f.write(code)` in both functions. |
| Regen test: delete generated files, re-run generator, then `ruff format --check` exits 0 | Pass | Verified locally — both `archetypes_generated.py` and `scenarios_generated.py` come out formatter-clean. |
| No new linting suppressions added beyond the three bandit findings listed | Pass | Only the 2 `# nosec B311` annotations were added; B614 was fixed structurally rather than suppressed. |
| Bandit `# nosec` annotations include one-line explanatory comments (not bare tags) | Pass | Both `# nosec B311` lines include rationale. |
| Preferred fix for B614: `weights_only=True` rather than `# nosec` suppression | Pass | Used `torch.load(..., weights_only=True)` in `dropout_eval.py:45`. |

## Test Plan

- [x] `uv run pre-commit run --all-files` → all hooks pass
- [x] `uv run ruff format --check . --exclude .venv/ --exclude scripts/ --exclude node_modules/ --exclude web/node_modules/` → exit 0
- [x] Regen test: `rm` generated files, re-run `generate_python.py`, verify `ruff format --check` on outputs exits 0
- [x] `uv run pytest tests/test_environment.py tests/test_rust_integration.py` → 34 passed, 9 skipped (formatting-only changes, no behavioral impact)
- [ ] CI `lint-python` and `pre-commit` jobs both green on this PR (will verify post-push)

Closes #188

Also closes #210 as duplicate (same root-cause CI breakage; #210's 6-file ruff-format list is a strict subset of what this PR fixes).