### PR TITLE
test: surface missing Rust extension instead of silently skipping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "research: marks tests validating research findings (deselect with '-m \"not research\"')",
     "torch_required: marks tests requiring torch/RL dependencies",
+    "requires_rust: marks tests that require the bucket-brigade-core Rust extension to be built (run bucket-brigade-core/build.sh; set BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 to skip instead of fail)",
 ]
 addopts = "--strict-markers"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,29 @@ This module provides:
 - Shared fixtures for common test objects
 """
 
+import os
+
 import pytest
+
+
+# Env var that converts a missing Rust extension from a hard collection
+# failure into an explicit skip for `requires_rust` tests. Intended for the
+# rare Python-only test run (e.g. on a machine without a Rust toolchain).
+RUST_ESCAPE_HATCH_ENV = "BUCKET_BRIGADE_ALLOW_MISSING_RUST"
+
+# Path the user is told to run to fix a missing Rust extension. The literal
+# string is referenced in the UsageError below and asserted by tests; keep
+# it in sync.
+RUST_BUILD_SCRIPT = "bucket-brigade-core/build.sh"
+
+
+def _rust_core_available() -> bool:
+    """Return True iff ``bucket_brigade_core`` can be imported in this env."""
+    try:
+        import bucket_brigade_core  # noqa: F401
+    except ImportError:
+        return False
+    return True
 
 
 def pytest_configure(config):
@@ -30,15 +52,52 @@ def pytest_configure(config):
         "markers",
         "torch_required: marks tests requiring torch/RL dependencies",
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_rust: marks tests that require the bucket-brigade-core Rust extension to be built",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     """
-    Automatically skip tests with missing dependencies.
-
-    This function checks for optional dependencies and automatically skips
-    tests that require them if they're not installed.
+    Automatically skip tests with missing dependencies, and surface a loud
+    error (or explicit skip) when ``requires_rust`` tests are collected
+    without the Rust extension importable.
     """
+    # ------------------------------------------------------------------
+    # `requires_rust` handling — see issue #189.
+    #
+    # Behaviour:
+    #   - Rust importable                            -> run normally.
+    #   - Rust missing AND escape-hatch env unset    -> UsageError (loud).
+    #   - Rust missing AND escape-hatch env set      -> explicit skip with
+    #     a message naming the env var (NOT a silent skip).
+    # ------------------------------------------------------------------
+    requires_rust_items = [item for item in items if "requires_rust" in item.keywords]
+
+    if requires_rust_items and not _rust_core_available():
+        escape_hatch = os.environ.get(RUST_ESCAPE_HATCH_ENV, "").strip()
+        if escape_hatch in {"", "0", "false", "False"}:
+            raise pytest.UsageError(
+                "bucket_brigade_core (Rust extension) is not importable, but "
+                f"{len(requires_rust_items)} test(s) marked @pytest.mark.requires_rust "
+                "were collected.\n"
+                f"  Fix: run `bash {RUST_BUILD_SCRIPT}` to build & install the extension "
+                "into the active venv.\n"
+                f"  Escape hatch: set {RUST_ESCAPE_HATCH_ENV}=1 to skip these tests "
+                "instead of failing (intended for Python-only runs without a Rust "
+                "toolchain)."
+            )
+        # Escape hatch: convert to explicit skips with a clear reason.
+        skip_rust = pytest.mark.skip(
+            reason=(
+                f"Rust extension not built, skipping per {RUST_ESCAPE_HATCH_ENV}=1 "
+                f"(build with `bash {RUST_BUILD_SCRIPT}` to run these tests)"
+            )
+        )
+        for item in requires_rust_items:
+            item.add_marker(skip_rust)
+
     # Check for torch availability
     try:
         import torch  # noqa: F401
@@ -149,7 +208,8 @@ def pytest_report_header(config):
     """Add custom information to pytest header."""
 
     headers = []
-    headers.append("bucket-brigade-core available: Yes")
+    rust_present = "Yes" if _rust_core_available() else "No"
+    headers.append(f"bucket-brigade-core available: {rust_present}")
 
     # Check optional dependencies
     try:

--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -1,25 +1,27 @@
-"""Tests for Rust core integration."""
+"""Tests for Rust core integration.
+
+The tests in this module exercise the Rust extension and therefore require
+``bucket_brigade_core`` to be importable. They are tagged with
+``@pytest.mark.requires_rust`` so the central conftest hook surfaces a
+loud collection error (or an explicit skip when
+``BUCKET_BRIGADE_ALLOW_MISSING_RUST=1`` is set) instead of silently
+skipping when the extension hasn't been built — see issue #189.
+"""
 
 import pytest
 import numpy as np
 
 
+@pytest.mark.requires_rust
 class TestRustCoreIntegration:
     """Test integration between Python and Rust core."""
 
     def test_rust_core_availability(self):
         """Test that Rust core can be imported."""
-        try:
-            from bucket_brigade_core import BucketBrigade, SCENARIOS
+        from bucket_brigade_core import BucketBrigade, SCENARIOS
 
-            rust_available = True
-        except ImportError:
-            rust_available = False
-            pytest.skip("Rust core not available")
-
-        if rust_available:
-            assert BucketBrigade is not None
-            assert SCENARIOS is not None
+        assert BucketBrigade is not None
+        assert SCENARIOS is not None
 
     def test_rust_vs_python_consistency(self):
         """Test that Rust and Python implementations produce consistent results.
@@ -33,7 +35,6 @@ class TestRustCoreIntegration:
         underlying PRNG implementations (``np.random.RandomState`` in Python
         vs ``Pcg64`` in Rust).
         """
-        pytest.importorskip("bucket_brigade_core")
         from bucket_brigade_core import BucketBrigade, SCENARIOS
         from bucket_brigade.envs import BucketBrigadeEnv
         from bucket_brigade.envs.scenarios_generated import (
@@ -91,10 +92,7 @@ class TestRustCoreIntegration:
 
     def test_rust_core_performance(self):
         """Test that Rust core performs well."""
-        try:
-            from bucket_brigade_core import BucketBrigade, SCENARIOS
-        except ImportError:
-            pytest.skip("Rust core not available")
+        from bucket_brigade_core import BucketBrigade, SCENARIOS
 
         import time
 
@@ -130,10 +128,7 @@ class TestRustCoreIntegration:
 
     def test_rust_core_reproducibility(self):
         """Test that Rust core produces reproducible results."""
-        try:
-            from bucket_brigade_core import BucketBrigade, SCENARIOS
-        except ImportError:
-            pytest.skip("Rust core not available")
+        from bucket_brigade_core import BucketBrigade, SCENARIOS
 
         scenario = SCENARIOS["trivial_cooperation"]
         num_agents = 4


### PR DESCRIPTION
## Summary

Replaces the silent-skip pattern in `tests/test_rust_integration.py` with a central, loud failure when the Rust extension isn't built. Adds a `requires_rust` pytest marker, a `conftest.py` collection hook that raises `pytest.UsageError` naming `bucket-brigade-core/build.sh`, and a `BUCKET_BRIGADE_ALLOW_MISSING_RUST=1` escape hatch that converts the failure into an explicit skip with a clear reason. Also fixes the lying header line in `tests/conftest.py` that unconditionally claimed `"bucket-brigade-core available: Yes"`.

This closes the failure mode where running `uv run pytest tests/test_rust_integration.py` in a fresh worktree (without rebuilding the Rust extension) reported `5 skipped` instead of either passing tests or a clear actionable error.

## Changes

- `pyproject.toml`: register `requires_rust` marker under `[tool.pytest.ini_options].markers` (satisfies `--strict-markers`).
- `tests/conftest.py`:
  - Add `_rust_core_available()` helper and `pytest_collection_modifyitems` logic that hard-fails on `requires_rust` tests when Rust is absent, with an env-var escape hatch.
  - Replace the hard-coded `"bucket-brigade-core available: Yes"` header line with an actual probe.
  - Register the new marker via `addinivalue_line` for IDE/tooling discoverability.
- `tests/test_rust_integration.py`:
  - Apply `@pytest.mark.requires_rust` at the class level.
  - Remove the redundant `try/except ImportError -> pytest.skip` blocks (3 of them) and the `pytest.importorskip("bucket_brigade_core")` call now governed by the central hook.
  - Update the module docstring to point at the new marker behaviour.
  - Leave the pre-existing `@pytest.mark.skip` on `test_rust_scenario_coverage` alone (out of scope per issue).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh worktree, Rust absent: clear `pytest.UsageError` naming the build script, never silent `5 skipped` | Pass | Ran `pytest tests/test_rust_integration.py -v` in fresh worktree pre-build: collector raised `UsageError: bucket_brigade_core (Rust extension) is not importable, but 5 test(s) marked @pytest.mark.requires_rust were collected. Fix: run \`bash bucket-brigade-core/build.sh\`...` |
| Rust present: 4 passed + 1 skipped, header reports "available: Yes" | Pass | After running `bucket-brigade-core/build.sh`: `4 passed, 1 skipped in 2.82s`; header reads `bucket-brigade-core available: Yes` |
| Header line accurately reports importability (no hard-coded "Yes") | Pass | Verified header switches between "Yes" and "No" depending on import status |
| `BUCKET_BRIGADE_ALLOW_MISSING_RUST=1` escape hatch skips with explicit message, not silently | Pass | `BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 pytest tests/test_rust_integration.py -v -rs` shows 4 skips with reason `"Rust extension not built, skipping per BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 (build with \`bash bucket-brigade-core/build.sh\` to run these tests)"` |
| `requires_rust` marker registered in `pyproject.toml` (satisfies `--strict-markers`) | Pass | Marker present at line 64; `--strict-markers` already in `addopts`; no UsageError about unregistered marker on any run |
| No new ruff/mypy hits | Pass | `ruff check tests/conftest.py tests/test_rust_integration.py` -> "All checks passed!" |
| CI behavior unchanged on main (CI builds Rust, all 4 tests run) | Pass | The collection hook is a no-op when Rust is importable; tests' bodies now use direct `from bucket_brigade_core import ...` which works identically |

## Test Plan

Performed locally on a fresh worktree (`.loom/worktrees/issue-189`):

- **Rust absent path**: `pytest tests/test_rust_integration.py -v` -> `UsageError` raised at collection, names `bash bucket-brigade-core/build.sh`, header reports `bucket-brigade-core available: No`. Verified.
- **Rust present path**: ran `bucket-brigade-core/build.sh`, re-ran the same command -> `4 passed, 1 skipped`, header reports `bucket-brigade-core available: Yes`. Verified.
- **Escape hatch**: `BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 pytest tests/test_rust_integration.py -v -rs` (Rust absent) -> 5 skips total (4 from the new marker hook + 1 pre-existing class skip), all with explicit messages. Verified.
- **Marker exclusion**: `pytest tests/test_rust_integration.py -m "not requires_rust"` -> `5 deselected`. Verified.
- **`--strict-markers`**: already enabled in `addopts`; no marker-registration warnings or errors. Verified.
- **Non-rust test smoke**: `pytest tests/test_agents.py -v` -> header line correct, no behavior change. Verified.

Closes #189