### PR TITLE
feat(diagnostics): add env-health regression suite (H1+H2+H3)

### DIFF
--- a/bucket_brigade/diagnostics/__init__.py
+++ b/bucket_brigade/diagnostics/__init__.py
@@ -1,0 +1,171 @@
+"""Diagnostic helpers shared between standalone scripts and pytest regressions.
+
+This module exposes hermetic, importable building blocks used by the H1/H2/H3
+diagnostics under ``experiments/p3_specialization/diagnostics/`` and by the
+slow regression test in ``tests/test_env_health_diagnostics.py`` (issue #201).
+
+Why this module exists
+----------------------
+The standalone scripts under ``experiments/p3_specialization/diagnostics/``
+were originally built for ad-hoc investigation and pull data from on-disk
+artifacts (e.g. ``inspect_rollout_rewards.py`` rsyncs a trained cell into
+``/tmp/h1_cell``). For the env-health regression test to run hermetically in
+CI/local sweeps it needs the same per-rollout statistics computed against a
+freshly-constructed, random-init ``JointPPOTrainer`` — no on-disk dependency.
+
+The functions here factor out that "rollout → per-agent stats" path so both
+callers share a single source of truth.
+
+Public API
+----------
+- :func:`random_init_rollout_stats` — H1 hermetic: random-init MLP rollout
+  returning per-agent CV and action-reward R².
+- :func:`per_agent_reward_stats` — shared CV/percentile helper.
+- :func:`conditional_mean_r2` — class-mean regressor R² (action ↔ reward).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy reward statistics (no torch dependency)
+# ---------------------------------------------------------------------------
+
+
+def per_agent_reward_stats(r: np.ndarray) -> Dict[str, float]:
+    """Distributional stats for a single agent's per-step reward series.
+
+    Mirrors ``inspect_rollout_rewards.per_agent_stats`` so the hermetic
+    pytest path and the on-disk diagnostic path return identical numbers.
+    """
+    mean = float(r.mean())
+    std = float(r.std())
+    cv = std / (abs(mean) + 1e-9)
+    p10, p50, p90 = (float(x) for x in np.percentile(r, [10, 50, 90]))
+    return {"mean": mean, "std": std, "cv": cv, "p10": p10, "p50": p50, "p90": p90}
+
+
+def conditional_mean_r2(r: np.ndarray, labels: np.ndarray) -> float:
+    """R² of the optimal class-mean regressor of ``r`` on ``labels``.
+
+    Equivalent to 1 − SS_within / SS_total — i.e. the fraction of per-step
+    reward variance explained by the discrete action label. Returns NaN if
+    ``r`` has zero variance (degenerate case).
+    """
+    ss_total = float(((r - r.mean()) ** 2).sum())
+    if ss_total <= 1e-12:
+        return float("nan")
+    pred = np.zeros_like(r, dtype=np.float64)
+    for lab in np.unique(labels):
+        mask = labels == lab
+        pred[mask] = r[mask].mean()
+    ss_res = float(((r - pred) ** 2).sum())
+    return 1.0 - ss_res / ss_total
+
+
+# ---------------------------------------------------------------------------
+# Hermetic random-init rollout (H1)
+# ---------------------------------------------------------------------------
+
+
+def random_init_rollout_stats(
+    scenario_name: str = "default",
+    *,
+    num_agents: int = 4,
+    hidden_size: int = 64,
+    rollout_steps: int = 2048,
+    seed: int = 42,
+) -> Tuple[np.ndarray, np.ndarray, List[Dict[str, Any]]]:
+    """Run one rollout under a fresh random-init ``JointPPOTrainer``.
+
+    Hermetic version of the H1 diagnostic — no ``/tmp/h1_cell`` dependency.
+    Builds a ``JointPPOTrainer`` with the canonical phase-3 hyperparameters
+    (``hidden_size=64``, ``num_agents=4``, ``action_dims=[10, 2]``) and runs
+    ``trainer.collect_rollout(rollout_steps)``. Returns the per-step reward
+    matrix, action matrix, and per-agent stats dicts.
+
+    This mirrors the trained-cell path in
+    ``experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py``
+    but skips the on-disk policy load, so it is safe to call from pytest.
+
+    Parameters
+    ----------
+    scenario_name : str
+        Name in ``SCENARIO_REGISTRY`` (e.g. ``"default"``,
+        ``"minimal_specialization"``).
+    num_agents : int
+        Number of agents in the env (default 4, matching phase-3 cells).
+    hidden_size : int
+        Policy MLP hidden size (default 64, matching ``CellConfig``).
+    rollout_steps : int
+        Number of synchronized env steps to collect. 2048 matches the
+        default ``rollout_steps`` used in #190's diagnostic.
+    seed : int
+        RNG seed for both torch and numpy.
+
+    Returns
+    -------
+    R : ndarray ``[N, T]``
+        Per-step rewards per agent.
+    A : ndarray ``[N, T, 2]``
+        Per-step ``[house_index, work_flag]`` actions per agent.
+    per_agent : list of dict
+        One dict per agent with keys: ``mean``, ``std``, ``cv``, ``p10``,
+        ``p50``, ``p90``, ``r2_packed`` (20-class action), ``r2_work``
+        (binary work/rest only).
+    """
+    # Local imports — torch may be unavailable in CI lite installs, and this
+    # module otherwise has no heavy deps.
+    import torch
+
+    from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+    from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+    from bucket_brigade.training.joint_trainer import (
+        JointPPOTrainer,
+        flatten_dict_obs,
+    )
+
+    scenario = get_scenario_by_name(scenario_name, num_agents=num_agents)
+
+    def env_fn() -> BucketBrigadeEnv:
+        return BucketBrigadeEnv(scenario=scenario)
+
+    probe = env_fn()
+    obs_dim = flatten_dict_obs(probe.reset(seed=seed)).shape[0]
+
+    trainer = JointPPOTrainer(
+        env_fn=env_fn,
+        num_agents=num_agents,
+        obs_dim=obs_dim,
+        action_dims=[10, 2],
+        hidden_size=hidden_size,
+        seed=seed,
+    )
+
+    rollout = trainer.collect_rollout(rollout_steps)
+
+    R = torch.stack([rollout.rewards[i] for i in range(num_agents)]).cpu().numpy()
+    A = torch.stack([rollout.actions[i] for i in range(num_agents)]).cpu().numpy()
+
+    per_agent: List[Dict[str, Any]] = []
+    for i in range(num_agents):
+        r = R[i]
+        a = A[i]
+        stats = per_agent_reward_stats(r)
+        packed = a[:, 0] * 2 + a[:, 1]  # 10 houses × {rest, work}
+        stats["r2_packed"] = float(conditional_mean_r2(r, packed))
+        stats["r2_work"] = float(conditional_mean_r2(r, a[:, 1]))
+        per_agent.append(stats)
+
+    return R, A, per_agent
+
+
+__all__ = [
+    "conditional_mean_r2",
+    "per_agent_reward_stats",
+    "random_init_rollout_stats",
+]

--- a/experiments/p3_specialization/diagnostics/README.md
+++ b/experiments/p3_specialization/diagnostics/README.md
@@ -1,0 +1,124 @@
+# Env-health diagnostics (issue #201)
+
+Three standalone scripts plus an aggregator + pytest regression suite that
+together answer the question:
+
+> Is the env in a state where independent PPO *could plausibly* learn?
+
+If any of the H-checks below regress, gradient signal has been silently
+broken — usually by an env-side change (reward rebalance, new scenario,
+ownership-vector refactor, etc.).
+
+---
+
+## Scripts
+
+| File | Hypothesis | What it measures |
+|------|------------|------------------|
+| `inspect_rollout_rewards.py` | **H1** (#190) | Per-agent reward CV + action-reward R² from one rollout. |
+| `audit_reward_attribution.py` | **H2** (#191) | Per-step decomposition into (team, ownership, work_cost) + pairwise reward correlation. |
+| `random_baseline.py` | **H3** (#192) | Uniform-random per-step team reward on `default`; re-derives the cited 308. |
+| `check_env_health.sh` | aggregator | Runs H1+H2+H3 sequentially, tees logs, prints a summary table. |
+| `issue199_baselines.py` | (separate) | Specialist baseline harness for issue #199. |
+
+### H1 (hermetic mode)
+
+`inspect_rollout_rewards.py` originally rsynced a trained cell into
+`/tmp/h1_cell`. The `--hermetic` flag added in #201 skips that path and
+runs only a random-init rollout against a freshly-constructed
+`JointPPOTrainer`. This is what the aggregator and the pytest regression
+test use; the trained-cell path is still available for ad-hoc
+investigation.
+
+```bash
+# Aggregator — what you want 90% of the time.
+bash experiments/p3_specialization/diagnostics/check_env_health.sh           # default scenario
+bash experiments/p3_specialization/diagnostics/check_env_health.sh minimal_specialization
+
+# Just the regression bar (asserts thresholds, fails CI-style):
+uv run pytest tests/test_env_health_diagnostics.py --run-slow -v
+```
+
+---
+
+## Thresholds (the "plausibly trainable" rubric)
+
+These match `tests/test_env_health_diagnostics.py` exactly — single source
+of truth lives in that file's module-level constants.
+
+| Check | Threshold | Meaning of a regression |
+|-------|-----------|-------------------------|
+| H1: per-agent CV | `> 0.05` for **any** agent | Reward variance has collapsed; PPO sees a flat signal. |
+| H1: action-reward R² | `> 0.01` for **any** agent | Actions don't move reward at all; gradient is noise. |
+| H2: median \|team\|/\|ownership\| ratio | `< 5×` | Team term dominates per-agent reward; nothing left to specialize on. |
+| H2: min pairwise reward correlation | `< 0.95` | All four agent reward streams are basically the same scalar. |
+| H3: uniform-random per-step reward (default) | `∈ [220, 290]` | Env reward magnitudes have shifted from the post-#197/#198 baseline (~250). |
+
+H1 is an "OR" gate per agent (CV or R²) because either side is enough to
+prove the signal isn't degenerate. H2 is two independent "AND" gates
+(ratio AND correlation) because both pathologies can independently kill
+PPO. H3 is an absolute scale check on `default` only — `random_baseline.py`
+hard-codes that scenario because it re-derives a specific cited number.
+
+### Why these thresholds and not stricter ones
+
+We want this suite to catch *order-of-magnitude* regressions, not
+statistical jitter. The committed result JSONs under `results/` show
+typical values well inside the bounds:
+
+- `h2_reward_attribution.json` (default): median ratio = 3.0, min corr = 0.71
+- `h2_reward_attribution_minimal_specialization.json`: median ratio = 0.12,
+  min corr = 0.04
+
+Tightening past those values would couple the test to seed-level noise.
+
+---
+
+## Runtime budget
+
+- `check_env_health.sh default` — under 2 min wall time on a Mac Studio (CPU).
+- `pytest tests/test_env_health_diagnostics.py --run-slow` — under 1 min;
+  H1 fixtures use 1024 rollout steps (vs the script's 2048) to keep it fast
+  while preserving statistical signal.
+
+Both are gated behind `slow` because even sub-second-per-call workloads
+add up across the matrix and the suite is run on-demand, not per-commit.
+
+---
+
+## Non-goals
+
+- **CI fast-lane integration** — see issue #201 Layer 3. The default CI
+  lane uses `-m "not slow and not integration"`; this suite is correctly
+  excluded from that lane.
+- **Auto-running on every env change** — these are diagnostic tools, not
+  acceptance gates. Run them when you change reward shaping or add a
+  scenario.
+- **Negative-case automated test** — verifying the suite fails on a
+  deliberately broken scenario is a one-shot human-driven check, not
+  worth the maintenance cost of fixturing.
+
+---
+
+## Adding new scenarios to the regression suite
+
+1. Add the scenario name to the two parametrize lists in
+   `test_h1_reward_signal_not_degenerate` and the H2 tests.
+2. Add entries to the `H1_MIN_CV_OR_R2`, `H2_MAX_TEAM_TO_OWN_RATIO`, and
+   `H2_MAX_MIN_PAIRWISE_CORR` dicts at the top of the test file.
+3. Run `bash check_env_health.sh <new_scenario>` once to confirm the
+   numbers are in the same regime, then commit.
+
+H3's range is `default`-specific by design and does not generalize across
+scenarios — extending it would require re-running the protocol from
+issue #145 on each new scenario.
+
+---
+
+## Related issues / PRs
+
+- #190, #191, #192 — the three diagnostic hypotheses (H1/H2/H3).
+- PR #194 (H2), PR #195 / commit `2130586d` (H1), PR #196 / commit `ec6e521c` (H3) — original commits.
+- #197 (team-vs-ownership rebalance), #198 (per-agent ownership vectors),
+  #199 (minimal_specialization scenario) — the env changes this suite is
+  meant to catch silently regressing.

--- a/experiments/p3_specialization/diagnostics/check_env_health.sh
+++ b/experiments/p3_specialization/diagnostics/check_env_health.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Env-health diagnostic aggregator (issue #201).
+#
+# Runs H1 (rollout-reward inspector, hermetic mode), H2 (reward attribution),
+# and H3 (random baseline) sequentially against a single scenario, captures
+# their logs, and prints a final summary table.
+#
+# Usage:
+#   bash experiments/p3_specialization/diagnostics/check_env_health.sh [scenario]
+#
+# Defaults to scenario=default. Exits non-zero if any sub-script crashes;
+# does NOT enforce numeric thresholds (that is the job of the pytest
+# regression suite, tests/test_env_health_diagnostics.py).
+
+set -uo pipefail
+
+SCENARIO="${1:-default}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+# Resolve repo root from this script's location so the script works whether
+# invoked from the repo root, the diagnostics dir, or any other cwd.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "${SCRIPT_DIR}/../../.." && pwd )"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+mkdir -p "${RESULTS_DIR}"
+
+LOG_PREFIX="${RESULTS_DIR}/check_env_health_${SCENARIO}_${TIMESTAMP}"
+H1_LOG="${LOG_PREFIX}_h1.log"
+H2_LOG="${LOG_PREFIX}_h2.log"
+H3_LOG="${LOG_PREFIX}_h3.log"
+
+H1_SCRIPT="${SCRIPT_DIR}/inspect_rollout_rewards.py"
+H2_SCRIPT="${SCRIPT_DIR}/audit_reward_attribution.py"
+H3_SCRIPT="${SCRIPT_DIR}/random_baseline.py"
+
+# Track per-stage exit codes so we can produce a useful summary even when one
+# stage crashes. The script's final exit code is the bitwise-OR of these so
+# a single sub-crash is detectable in CI/wrapper scripts.
+H1_RC=0
+H2_RC=0
+H3_RC=0
+
+echo "============================================================"
+echo "env-health diagnostics — scenario=${SCENARIO}"
+echo "  H1 log: ${H1_LOG}"
+echo "  H2 log: ${H2_LOG}"
+echo "  H3 log: ${H3_LOG}"
+echo "============================================================"
+
+cd "${REPO_ROOT}"
+
+# ---- H1: rollout-reward inspector (hermetic random-init mode) -------------
+echo
+echo "--- H1: inspect_rollout_rewards.py --hermetic --scenario=${SCENARIO} ---"
+uv run python "${H1_SCRIPT}" --hermetic --scenario "${SCENARIO}" \
+  2>&1 | tee "${H1_LOG}"
+H1_RC="${PIPESTATUS[0]}"
+
+# ---- H2: reward attribution audit -----------------------------------------
+echo
+echo "--- H2: audit_reward_attribution.py --scenario=${SCENARIO} ---"
+uv run python "${H2_SCRIPT}" --scenario "${SCENARIO}" \
+  2>&1 | tee "${H2_LOG}"
+H2_RC="${PIPESTATUS[0]}"
+
+# ---- H3: random baseline (always scenario=default per script design) ------
+echo
+echo "--- H3: random_baseline.py (scenario hard-coded to default) ---"
+# H3 only supports the "default" scenario because it re-derives a specific
+# cited number (308) from issue #145. Skip with a clear note if the user
+# asked for a different scenario.
+if [[ "${SCENARIO}" == "default" ]]; then
+  uv run python "${H3_SCRIPT}" --episodes-per-seed 50 --seeds 2 --no-mlp \
+    2>&1 | tee "${H3_LOG}"
+  H3_RC="${PIPESTATUS[0]}"
+else
+  echo "H3 skipped: random_baseline.py hard-codes scenario=default" \
+    | tee "${H3_LOG}"
+fi
+
+# ---- Summary --------------------------------------------------------------
+echo
+echo "============================================================"
+echo "SUMMARY — scenario=${SCENARIO}"
+echo "============================================================"
+
+extract() {
+  local file="$1"
+  local pattern="$2"
+  if [[ -f "${file}" ]]; then
+    grep -E "${pattern}" "${file}" | head -5 || true
+  fi
+}
+
+echo
+echo "H1 (per-agent reward CV + action-reward R²):"
+extract "${H1_LOG}" '^agent_[0-9]+:|CV=|R²\(packed|--> H1'
+
+echo
+echo "H2 (team/ownership ratio + pairwise reward correlation):"
+extract "${H2_LOG}" 'team\|ownership\|mean_abs|median=|Mean off-diagonal|Min off-diagonal|Team-share|H2 VERDICT'
+
+echo
+echo "H3 (uniform-random baseline reward/step):"
+extract "${H3_LOG}" 'per-step|per-episode|Verdict|Uniform-random per-step'
+
+echo
+echo "Exit codes:  H1=${H1_RC}  H2=${H2_RC}  H3=${H3_RC}"
+echo "============================================================"
+
+# Aggregate: non-zero if any stage crashed.
+exit $(( H1_RC | H2_RC | H3_RC ))

--- a/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+++ b/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
@@ -61,6 +61,10 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from bucket_brigade.diagnostics import (
+    conditional_mean_r2,
+    per_agent_reward_stats as per_agent_stats,
+)
 from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
 from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
 from bucket_brigade.training.joint_trainer import (
@@ -72,33 +76,12 @@ from bucket_brigade.training.joint_trainer import (
 # ---------------------------------------------------------------------------
 # Statistics helpers
 # ---------------------------------------------------------------------------
-
-
-def per_agent_stats(r: np.ndarray) -> dict:
-    """Distributional stats for a single agent's per-step reward series."""
-    mean = float(r.mean())
-    std = float(r.std())
-    cv = std / (abs(mean) + 1e-9)
-    p10, p50, p90 = (float(x) for x in np.percentile(r, [10, 50, 90]))
-    return {"mean": mean, "std": std, "cv": cv, "p10": p10, "p50": p50, "p90": p90}
-
-
-def conditional_mean_r2(r: np.ndarray, labels: np.ndarray) -> float:
-    """R² of the optimal class-mean regressor of ``r`` on ``labels``.
-
-    Equivalent to 1 − SS_within / SS_total — i.e. the fraction of
-    per-step reward variance explained by the action label.
-    Returns NaN if ``r`` has zero variance.
-    """
-    ss_total = float(((r - r.mean()) ** 2).sum())
-    if ss_total <= 1e-12:
-        return float("nan")
-    pred = np.zeros_like(r, dtype=np.float64)
-    for lab in np.unique(labels):
-        mask = labels == lab
-        pred[mask] = r[mask].mean()
-    ss_res = float(((r - pred) ** 2).sum())
-    return 1.0 - ss_res / ss_total
+# ``per_agent_stats`` and ``conditional_mean_r2`` were factored out into
+# ``bucket_brigade.diagnostics`` in issue #201 so the env-health regression
+# test (``tests/test_env_health_diagnostics.py``) can share the same
+# implementation without depending on ``/tmp/h1_cell``. Imported above; the
+# names are re-bound for backwards compatibility with any external callers
+# of this script's module namespace.
 
 
 def text_histogram(values: np.ndarray, n_bins: int = 15, width: int = 60) -> str:
@@ -281,13 +264,41 @@ def main() -> None:
         help=(
             "Trained-cell directory containing config.json + policies/. "
             "Defaults to <system-tempdir>/h1_cell (the conventional rsync "
-            "target documented in the script docstring)."
+            "target documented in the script docstring). Ignored when "
+            "--hermetic is set."
         ),
     )
     parser.add_argument(
         "--no-baseline",
         action="store_true",
         help="Skip the random-init comparison rollout.",
+    )
+    parser.add_argument(
+        "--hermetic",
+        action="store_true",
+        help=(
+            "Skip the trained-cell path entirely and run only a random-init "
+            "rollout against a freshly-constructed JointPPOTrainer. Used by "
+            "the env-health regression suite (issue #201) so the diagnostic "
+            "is runnable without on-disk cell dependencies."
+        ),
+    )
+    parser.add_argument(
+        "--scenario",
+        default="default",
+        help="Scenario name (only used in --hermetic mode).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seed for --hermetic mode (default 42, matches phase-3 cells).",
+    )
+    parser.add_argument(
+        "--rollout-steps",
+        type=int,
+        default=2048,
+        help="Rollout step count for --hermetic mode (default 2048).",
     )
     parser.add_argument(
         "--out",
@@ -297,33 +308,75 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if not (args.cell / "config.json").exists():
-        raise SystemExit(
-            f"Cell not found at {args.cell}. See the script docstring for "
-            "rsync instructions, or train a fresh 50-iter cell."
-        )
+    # ------------------------------------------------------------------
+    # Hermetic mode: random-init rollout only, no on-disk dependency.
+    # Wired up for issue #201's env-health aggregator (check_env_health.sh)
+    # so the script runs end-to-end without rsyncing a trained cell.
+    # ------------------------------------------------------------------
+    if args.hermetic:
+        from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
 
-    # 1) Trained-policy rollout.
-    R, A, cfg, scenario = run_one_rollout(args.cell, load_policies=True)
-    trained_summary = report(
-        f"TRAINED CELL: {args.cell}  "
-        f"(scenario={cfg['scenario']}, lambda_red={cfg['lambda_red']}, "
-        f"seed={cfg['seed']}, num_iterations={cfg['num_iterations']})",
-        R,
-        A,
-        scenario,
-    )
+        scenario = get_scenario_by_name(args.scenario, num_agents=4)
 
-    # 2) Random-init baseline rollout (same env, same config).
-    baseline_summary = None
-    if not args.no_baseline:
-        Rb, Ab, _, _ = run_one_rollout(args.cell, load_policies=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Build a minimal config.json so we can re-use run_one_rollout.
+            shim_cell = Path(tmpdir)
+            cfg = {
+                "scenario": args.scenario,
+                "num_agents": 4,
+                "action_dims": [10, 2],
+                "hidden_size": 64,
+                "lr": 3e-4,
+                "ppo_epochs": 4,
+                "minibatch_size": 256,
+                "value_coef": 0.5,
+                "entropy_coef": 0.01,
+                "normalize_returns": False,
+                "device": "cpu",
+                "seed": args.seed,
+                "rollout_steps": args.rollout_steps,
+                "lambda_red": 0.0,
+                "num_iterations": 0,
+            }
+            (shim_cell / "config.json").write_text(json.dumps(cfg))
+            R, A, cfg, scenario = run_one_rollout(shim_cell, load_policies=False)
+
         baseline_summary = report(
-            "RANDOM-INIT BASELINE (same config, no loaded policies)",
-            Rb,
-            Ab,
+            f"HERMETIC RANDOM-INIT (scenario={args.scenario}, seed={args.seed})",
+            R,
+            A,
             scenario,
         )
+        trained_summary = None
+    else:
+        if not (args.cell / "config.json").exists():
+            raise SystemExit(
+                f"Cell not found at {args.cell}. See the script docstring for "
+                "rsync instructions, train a fresh 50-iter cell, or pass "
+                "--hermetic for a random-init-only run."
+            )
+
+        # 1) Trained-policy rollout.
+        R, A, cfg, scenario = run_one_rollout(args.cell, load_policies=True)
+        trained_summary = report(
+            f"TRAINED CELL: {args.cell}  "
+            f"(scenario={cfg['scenario']}, lambda_red={cfg['lambda_red']}, "
+            f"seed={cfg['seed']}, num_iterations={cfg['num_iterations']})",
+            R,
+            A,
+            scenario,
+        )
+
+        # 2) Random-init baseline rollout (same env, same config).
+        baseline_summary = None
+        if not args.no_baseline:
+            Rb, Ab, _, _ = run_one_rollout(args.cell, load_policies=False)
+            baseline_summary = report(
+                "RANDOM-INIT BASELINE (same config, no loaded policies)",
+                Rb,
+                Ab,
+                scenario,
+            )
 
     # 3) Optional: dump numerics to JSON for the report.
     if args.out is not None:
@@ -331,7 +384,7 @@ def main() -> None:
         args.out.write_text(
             json.dumps(
                 {
-                    "cell": str(args.cell),
+                    "cell": "hermetic" if args.hermetic else str(args.cell),
                     "cfg": cfg,
                     "trained": trained_summary,
                     "random_baseline": baseline_summary,

--- a/tests/test_env_health_diagnostics.py
+++ b/tests/test_env_health_diagnostics.py
@@ -1,0 +1,330 @@
+"""Env-health regression suite (issue #201).
+
+Wraps the three diagnostic scripts under
+``experiments/p3_specialization/diagnostics/`` (H1/H2/H3) as numerical
+regression assertions. The intent is to catch silent breakage of the
+reward signal when env-side changes land (e.g. team-vs-ownership rebalance
+in #197, per-agent ownership vectors in #198, new scenarios in #199).
+
+Marked ``@pytest.mark.slow`` so the CI fast lane (``-m "not slow and not
+integration"``) skips it. Run locally with::
+
+    uv run pytest tests/test_env_health_diagnostics.py --run-slow -v
+
+Thresholds are derived from the rubric in issue #201:
+
+H1 (reward signal not degenerate)
+    For at least one agent: CV > 0.05 OR action-reward R² > 0.01. If both
+    are below those bounds for every agent the gradient signal is
+    effectively flat — see #190.
+
+H2 (team and ownership rewards plausibly trainable)
+    Median ``|team| / |ownership|`` ratio < 5× AND min pairwise agent-reward
+    correlation < 0.95. Above those bounds independent PPO is dominated by
+    a shared team signal that no single agent can move — see #183/#197.
+
+H3 (uniform-random baseline holds the post-#197/#198 scale on ``default``)
+    Mean uniform-random per-step team reward ∈ [220, 290] on the
+    ``default`` scenario (current baseline ~250). Issue #145 cited 308,
+    but the team-vs-ownership rebalance in #197/#198 shifted the absolute
+    scale; a regression *outside* the new window means the env reward
+    magnitudes have shifted again.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+# Ensure ``experiments/p3_specialization/diagnostics/`` is importable so we
+# can re-use the H2/H3 driver functions directly (rather than reimplementing
+# them here). H1 lives in ``bucket_brigade.diagnostics`` so no path hack is
+# needed for it.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DIAG_DIR = _REPO_ROOT / "experiments" / "p3_specialization" / "diagnostics"
+if str(_DIAG_DIR) not in sys.path:
+    sys.path.insert(0, str(_DIAG_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Thresholds (single source of truth — keep these aligned with the rubric
+# in the issue body and ``experiments/p3_specialization/diagnostics/README``).
+# ---------------------------------------------------------------------------
+
+H1_MIN_CV_OR_R2 = {
+    # (cv_threshold, r2_threshold) — H1 passes if for any agent
+    # cv > cv_threshold OR r2_packed > r2_threshold. The default scenario
+    # has high team-share, so the per-agent CV easily clears 0.05 even
+    # though R² stays low (#190 finding). On minimal_specialization the
+    # ownership signal dominates so R² is the more informative side.
+    "default": (0.05, 0.01),
+    "minimal_specialization": (0.05, 0.01),
+}
+
+H2_MAX_TEAM_TO_OWN_RATIO = {
+    # Median |team|/|ownership| ratio per scenario. Both committed JSONs
+    # under ``experiments/p3_specialization/diagnostics/results/`` show
+    # values well below 5x (default: 3.0, minimal_specialization: 0.12)
+    # after the #197/#198 rebalance.
+    "default": 5.0,
+    "minimal_specialization": 5.0,
+}
+
+H2_MAX_MIN_PAIRWISE_CORR = {
+    # Min off-diagonal pairwise agent-reward correlation. Above 0.95 means
+    # every agent's reward signal is essentially the team term; PPO has
+    # nothing to specialize on. Committed JSONs show default=0.71,
+    # minimal_specialization=0.04.
+    "default": 0.95,
+    "minimal_specialization": 0.95,
+}
+
+H3_RANDOM_PER_STEP_RANGE_DEFAULT = (220.0, 290.0)
+# Window centered on the post-#197/#198 uniform-random baseline (~250).
+# Issue #145 cited 308, but the team-vs-ownership rebalance in #197 and the
+# per-agent ownership vectors in #198 shifted the absolute scale downward —
+# the H3 script run against current main reports per-step ~250 (250.39 mean,
+# 95% CI [237, 263] with n=250 episodes). We pick ±~15% around that to
+# catch order-of-magnitude regressions without coupling to seed noise.
+# The cited 308 in random_baseline.py's docstring is preserved as historical
+# context but is no longer the current baseline.
+
+
+# ---------------------------------------------------------------------------
+# Shared rollout fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def h2_rollouts():
+    """One uniform-random rollout per scenario for the H2 audit.
+
+    Computed once per test module to keep the slow suite under the issue's
+    5-minute budget. Returns ``{scenario_name: summary_dict}`` where each
+    summary mirrors ``audit_reward_attribution.summarize`` output.
+    """
+    from audit_reward_attribution import run_rollouts, summarize  # type: ignore
+
+    out = {}
+    for scenario in ("default", "minimal_specialization"):
+        team, own, work, reward = run_rollouts(
+            scenario_name=scenario, seeds=tuple(range(10))
+        )
+        out[scenario] = summarize(team, own, work, reward)
+    return out
+
+
+@pytest.fixture(scope="module")
+def h1_random_init():
+    """Hermetic H1 random-init rollout per scenario.
+
+    Uses ``bucket_brigade.diagnostics.random_init_rollout_stats`` so the
+    test does not depend on any on-disk trained cell.
+    """
+    torch = pytest.importorskip("torch")  # noqa: F841 (skip if no RL extras)
+    from bucket_brigade.diagnostics import random_init_rollout_stats
+
+    out = {}
+    for scenario in ("default", "minimal_specialization"):
+        # 1024 steps is enough to get stable CV/R² for the regression bar
+        # while keeping the test fast (~1-2s per scenario).
+        _R, _A, per_agent = random_init_rollout_stats(
+            scenario_name=scenario, rollout_steps=1024, seed=42
+        )
+        out[scenario] = per_agent
+    return out
+
+
+# ---------------------------------------------------------------------------
+# H1: reward signal is not degenerate (#190)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("scenario", ["default", "minimal_specialization"])
+def test_h1_reward_signal_not_degenerate(h1_random_init, scenario) -> None:
+    """At least one agent has CV > threshold OR action-R² > threshold.
+
+    Inverts the #190 rubric: "CV < 0.05 AND R² < 0.01 for every agent"
+    means H1 (degenerate signal) is confirmed. We want H1 to remain
+    *ruled out* for both scenarios.
+    """
+    per_agent = h1_random_init[scenario]
+    cv_thresh, r2_thresh = H1_MIN_CV_OR_R2[scenario]
+
+    passes = []
+    for stats in per_agent:
+        # R² can be NaN if the agent's rewards have zero variance. Treat
+        # NaN as "no signal" (False) so the degeneracy check is strict.
+        r2 = stats["r2_packed"]
+        r2_ok = not np.isnan(r2) and r2 > r2_thresh
+        cv_ok = stats["cv"] > cv_thresh
+        passes.append(cv_ok or r2_ok)
+
+    summary = [
+        f"agent_{i}: cv={s['cv']:.4f}, r2_packed={s['r2_packed']:.4f}"
+        for i, s in enumerate(per_agent)
+    ]
+    assert any(passes), (
+        f"H1 degeneracy regression on scenario={scenario}: "
+        f"every agent has cv <= {cv_thresh} AND r2_packed <= {r2_thresh}. "
+        f"Per-agent stats: {summary}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# H2: team and ownership rewards are plausibly trainable (#183, #197)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("scenario", ["default", "minimal_specialization"])
+def test_h2_team_to_ownership_ratio(h2_rollouts, scenario) -> None:
+    """Median |team|/|ownership| ratio must stay below the per-scenario cap.
+
+    A regression above 5x means the team component dominates per-agent
+    rewards so strongly that independent PPO has nothing to specialize
+    on (failure mode tracked in #183).
+    """
+    summary = h2_rollouts[scenario]
+    median = summary["ratios"]["team_over_ownership"]["median"]
+    cap = H2_MAX_TEAM_TO_OWN_RATIO[scenario]
+    assert median is not None and median < cap, (
+        f"H2 regression on scenario={scenario}: "
+        f"median |team|/|ownership| = {median} (cap {cap}). "
+        f"Full ratio summary: {summary['ratios']['team_over_ownership']}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("scenario", ["default", "minimal_specialization"])
+def test_h2_min_pairwise_reward_correlation(h2_rollouts, scenario) -> None:
+    """Min off-diagonal pairwise reward correlation must stay below cap.
+
+    If every pair of agents has correlation > 0.95, the per-agent rewards
+    are essentially the same scalar and PPO can't differentiate roles.
+    """
+    summary = h2_rollouts[scenario]
+    min_corr = summary["min_off_diag_corr"]
+    cap = H2_MAX_MIN_PAIRWISE_CORR[scenario]
+    assert min_corr < cap, (
+        f"H2 regression on scenario={scenario}: "
+        f"min pairwise reward correlation = {min_corr:.4f} (cap {cap}). "
+        f"Full pairwise matrix: {summary['pairwise_corr']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# H3: uniform-random per-step baseline tracks the cited 308 (#145, #196)
+# ---------------------------------------------------------------------------
+
+
+def _random_baseline_per_step_default(
+    *, episodes_per_seed: int, seeds: int
+) -> Tuple[float, int]:
+    """Re-derive the uniform-random per-step team reward on ``default``.
+
+    Inlined uniform-random rollout — equivalent to
+    ``random_baseline.run_random_episode`` but does not import the H3
+    script (whose transitive imports pull in torch via the training
+    package; we want this test to remain runnable in the no-RL CI install).
+    """
+    from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+    from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+
+    scenario = get_scenario_by_name("default", num_agents=4)
+    per_step = []
+    for seed in range(42, 42 + seeds):
+        rng = np.random.default_rng(seed)
+        env = BucketBrigadeEnv(scenario=scenario)
+        for _ in range(episodes_per_seed):
+            env.reset(seed=int(rng.integers(0, 2**31 - 1)))
+            total_reward = 0.0
+            while not env.done:
+                # MultiDiscrete([10, 2]) per agent — see
+                # bucket_brigade_env.py:117 for the verified shape.
+                actions = np.stack(
+                    [
+                        rng.integers(0, 10, size=env.num_agents),
+                        rng.integers(0, 2, size=env.num_agents),
+                    ],
+                    axis=-1,
+                ).astype(np.int64)
+                _, rewards, _, _ = env.step(actions)
+                total_reward += float(rewards.sum())
+            nights = int(env.night)
+            per_step.append(total_reward / nights)
+    arr = np.asarray(per_step)
+    return float(arr.mean()), int(arr.size)
+
+
+@pytest.mark.slow
+def test_h3_random_baseline_default_in_range() -> None:
+    """Mean uniform-random per-step team reward stays in the #145 window.
+
+    Window is intentionally wide (~±5%): this test catches order-of-
+    magnitude regressions in reward scaling, not Monte-Carlo jitter.
+    """
+    mean_per_step, n = _random_baseline_per_step_default(episodes_per_seed=25, seeds=2)
+    lo, hi = H3_RANDOM_PER_STEP_RANGE_DEFAULT
+    assert lo <= mean_per_step <= hi, (
+        f"H3 regression on scenario=default: "
+        f"uniform-random per-step mean = {mean_per_step:.2f} "
+        f"outside [{lo}, {hi}] (n={n} episodes). "
+        f"Tracks issue #145 / PR #196."
+    )
+
+
+# ---------------------------------------------------------------------------
+# H2: spot-check that committed result JSONs still parse (anti-rot)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "h2_reward_attribution.json",
+        "h2_reward_attribution_minimal_specialization.json",
+    ],
+)
+def test_committed_h2_jsons_have_expected_schema(filename) -> None:
+    """The fixture JSONs we compare future runs against must keep schema.
+
+    Anti-rot guard: if someone changes ``audit_reward_attribution.py``'s
+    output shape, this test breaks before the regression assertions above
+    silently start matching nonsense.
+    """
+    path = (
+        _REPO_ROOT
+        / "experiments"
+        / "p3_specialization"
+        / "diagnostics"
+        / "results"
+        / filename
+    )
+    if not path.exists():
+        pytest.skip(f"committed result file not present: {path}")
+
+    data = json.loads(path.read_text())
+    required_keys = {
+        "n_steps",
+        "n_agents",
+        "magnitudes",
+        "ratios",
+        "pairwise_corr",
+        "mean_off_diag_corr",
+        "min_off_diag_corr",
+        "team_var",
+        "mean_per_agent_var",
+        "team_share_lower_bound_on_corr",
+    }
+    missing = required_keys - data.keys()
+    assert not missing, f"{filename} missing keys: {missing}"
+    assert "team_over_ownership" in data["ratios"]
+    assert "team_over_work_cost" in data["ratios"]


### PR DESCRIPTION
## Summary

Wraps the H1+H2+H3 diagnostic scripts under
`experiments/p3_specialization/diagnostics/` as a standing regression
suite so env-side reward-structure changes (the #197/#198 family, and
future ones) get caught when they silently break the gradient signal
that independent PPO depends on.

## Changes

- New `experiments/p3_specialization/diagnostics/check_env_health.sh`:
  bash aggregator that runs H1/H2/H3 sequentially, tees per-stage logs
  under `results/`, and prints a headline-number summary table. Exits
  non-zero on sub-script crash; does not enforce thresholds.
- New `tests/test_env_health_diagnostics.py` (`@pytest.mark.slow`):
  numerical regression assertions for the H1 degeneracy rubric, the H2
  team:ownership ratio + min pairwise correlation bounds (parametrized
  over `default` and `minimal_specialization`), and the H3 uniform-
  random per-step scale on `default`. Plus a schema check on the
  committed `h2_reward_attribution*.json` fixtures.
- New `bucket_brigade/diagnostics/__init__.py`: shared rollout +
  statistics helpers (`random_init_rollout_stats`,
  `per_agent_reward_stats`, `conditional_mean_r2`) used by both the
  H1 script and the pytest H1 path so they compute identical numbers.
- Refactored `inspect_rollout_rewards.py`:
  - Imports its stat helpers from `bucket_brigade.diagnostics` (the
    originals lived in this file; kept as re-exports for back-compat).
  - New `--hermetic` flag runs only the random-init rollout against a
    freshly-constructed `JointPPOTrainer`, removing the `/tmp/h1_cell`
    dependency so the aggregator and pytest path are runnable in CI.
    The trained-cell path is preserved unchanged for ad-hoc use.
- New `experiments/p3_specialization/diagnostics/README.md`: documents
  the rubric, thresholds, runtime budget, and non-goals.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `check_env_health.sh` runs end-to-end on `default` in under 5 min | done | Local run: ~30s total wall time on Mac Studio CPU. |
| Summary table prints all six headline numbers | done | H1 (per-agent CV + R^2), H2 (team:ownership ratio, min pairwise corr, team-share lower bound), H3 (uniform-random per-step + per-episode); aggregator output shown in commit run. |
| `tests/test_env_health_diagnostics.py` added, marked `@pytest.mark.slow`, four assertions | done | 4 H-check tests + 1 schema guard + 2 parametrized scenarios = 9 collected tests; H3 currently default-only per `random_baseline.py`. |
| Test passes on current `main` for `default` and `minimal_specialization` | done | `uv run pytest tests/test_env_health_diagnostics.py --run-slow -v`: 9 passed in 2.4s. |
| CI fast lane skips the slow test | done | `uv run pytest tests/test_env_health_diagnostics.py -m "not slow and not integration"`: 9 deselected, 0 collected. |
| README documents thresholds inline | done | `experiments/p3_specialization/diagnostics/README.md` includes the full rubric table. |
| Negative-case smoke (manual) | n/a per issue | Issue explicitly marks this as "no automated negative-case test needed." |

## Test Plan

- `uv run pytest tests/test_env_health_diagnostics.py --run-slow -v`
  - 9 tests, all pass in ~2.4s on a Mac Studio (CPU).
- `uv run pytest tests/test_env_health_diagnostics.py -m "not slow and not integration"`
  - 9 deselected, confirming the suite stays out of the CI fast lane.
- `bash experiments/p3_specialization/diagnostics/check_env_health.sh default`
  - Runs end-to-end, prints summary table, exit 0.
- `uv run ruff check` + `uv run ruff format --check` on all new/modified files: clean.

## Notes for the reviewer

- The H3 window is `[220, 290]` per-step, not the `[285, 325]` proposed in
  the issue. Re-deriving against current `main` (post-#197/#198) gives
  ~250 per-step, ~58 below the originally cited 308 from issue #145. The
  test file's threshold block has an inline comment explaining why.
- The H3 script (`random_baseline.py`) is hard-coded to scenario=default
  because it re-derives a specific cited number; the aggregator emits a
  clear "skipped" line when run on other scenarios. Out of scope to
  generalize per the issue.
- No changes to `analyze_plateau.py` or `analyze_174.py` per the note
  about issue #202 owning those files.

Closes #201