### PR TITLE
fix(env): per-agent observation differentiation via identity one-hot tail

### DIFF
--- a/bucket_brigade/envs/puffer_env_rust.py
+++ b/bucket_brigade/envs/puffer_env_rust.py
@@ -103,8 +103,20 @@ class RustPufferBucketBrigade(gym.Env):
         # Track last observation
         self._last_obs: Optional[Dict[str, np.ndarray]] = None
 
-        # PufferLib observation/action spaces
-        obs_size = 10 + self.num_agents + self.num_agents + (self.num_agents * 2) + 10
+        # PufferLib observation/action spaces.
+        # Issue #204 — the flattened observation now ends with a per-agent
+        # identity one-hot of length ``num_agents`` so per-agent obs vectors
+        # are distinct. This wrapper only exposes the trained agent's view
+        # (always ``agent_id=0``), but the dim must include the identity
+        # tail so downstream policy networks size their input layer correctly.
+        obs_size = (
+            10
+            + self.num_agents
+            + self.num_agents
+            + (self.num_agents * 2)
+            + 10
+            + self.num_agents  # identity one-hot (issue #204)
+        )
         self.observation_space = spaces.Box(
             low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float32
         )
@@ -237,12 +249,27 @@ class RustPufferBucketBrigade(gym.Env):
     def _flatten_observation(
         self, obs: Dict[str, np.ndarray], agent_id: int
     ) -> np.ndarray:
-        """Convert observation dict to flat array for PufferLib."""
+        """Convert observation dict to flat array for PufferLib.
+
+        Issue #204: the flat layout now ends with a length-``num_agents``
+        identity one-hot for ``agent_id`` so per-agent observations are
+        provably distinct. The previous layout dropped ``agent_id``
+        entirely, which was the latent half of the "identical input to all
+        agents" PPO bug.
+        """
         houses = obs["houses"].astype(np.float32)
         signals = obs["signals"].astype(np.float32)
         locations = obs["locations"].astype(np.float32)
         last_actions = obs["last_actions"].flatten().astype(np.float32)
         scenario_info = obs["scenario_info"].astype(np.float32)
+
+        if not 0 <= agent_id < self.num_agents:
+            raise ValueError(
+                f"_flatten_observation: agent_id {agent_id} out of range "
+                f"[0, {self.num_agents})"
+            )
+        identity = np.zeros(self.num_agents, dtype=np.float32)
+        identity[agent_id] = 1.0
 
         # Concatenate all observation components
         flat_obs = np.concatenate(
@@ -252,6 +279,7 @@ class RustPufferBucketBrigade(gym.Env):
                 locations,  # N values
                 last_actions,  # N*2 values
                 scenario_info,  # 10 values
+                identity,  # N values (issue #204)
             ]
         )
 
@@ -276,8 +304,15 @@ class RustPufferBucketBrigadeVectorized(RustPufferBucketBrigade):
         super().__init__(**kwargs)
         self.num_envs = num_envs
 
-        # Vectorized observation space
-        obs_size = 10 + self.num_agents + self.num_agents + (self.num_agents * 2) + 10
+        # Vectorized observation space (issue #204 — include identity one-hot tail).
+        obs_size = (
+            10
+            + self.num_agents
+            + self.num_agents
+            + (self.num_agents * 2)
+            + 10
+            + self.num_agents  # identity one-hot (issue #204)
+        )
         self.observation_space = spaces.Box(
             low=-np.inf, high=np.inf, shape=(num_envs, obs_size), dtype=np.float32
         )

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -20,10 +20,15 @@ Typical use::
     def env_fn():
         return BucketBrigadeEnv(num_agents=4)
 
+    # obs_dim now includes a per-agent identity one-hot tail (issue #204).
+    # For N=4 agents and the default 10-house layout, this is 42 + 4 = 46.
+    # In practice, derive it from a probe:
+    #   obs = env.reset(); obs_dim = flatten_dict_obs(obs, agent_id=0,
+    #       num_agents=4).shape[0]
     trainer = JointPPOTrainer(
         env_fn=env_fn,
         num_agents=4,
-        obs_dim=42,
+        obs_dim=46,
         action_dims=[10, 2],
         redundancy_coef=0.01,
     )
@@ -50,22 +55,60 @@ from bucket_brigade.training.normalizers import RunningMeanStd
 __all__ = ["JointPPOTrainer", "RolloutBuffer", "flatten_dict_obs"]
 
 
-def flatten_dict_obs(obs: Dict[str, np.ndarray]) -> np.ndarray:
+def flatten_dict_obs(
+    obs: Dict[str, np.ndarray],
+    agent_id: Optional[int] = None,
+    num_agents: Optional[int] = None,
+) -> np.ndarray:
     """Flatten the dict observation returned by ``BucketBrigadeEnv`` into
     a 1-D float32 array suitable for ``PolicyNetwork``.
 
-    Layout: ``[houses(10), signals(N), locations(N), last_actions(2N),
-    scenario_info(10)]``.
+    Layout when ``agent_id`` is ``None`` (legacy, no per-agent identity):
+        ``[houses(10), signals(N), locations(N), last_actions(2N),
+        scenario_info(10)]``.
+
+    Layout when ``agent_id`` is given (issue #204 — per-agent
+    differentiation via one-hot identity tail):
+        ``[houses(10), signals(N), locations(N), last_actions(2N),
+        scenario_info(10), identity_one_hot(num_agents)]``.
+
+    Args:
+        obs: Dict observation from ``BucketBrigadeEnv._get_observation``.
+        agent_id: If provided, append a one-hot identity slot of length
+            ``num_agents`` so per-agent flattened observations are
+            distinct. This is the latent-bug fix described in #204 —
+            the Python flatteners previously dropped the ``agent_id``
+            field that ``AgentObservation`` already carries, which
+            caused ``collect_rollout`` to feed identical input to every
+            agent.
+        num_agents: Length of the identity one-hot. Required when
+            ``agent_id`` is provided. Typically the env's ``num_agents``.
+
+    Raises:
+        ValueError: If ``agent_id`` is given without ``num_agents``, or
+            ``agent_id`` is outside ``[0, num_agents)``.
     """
-    return np.concatenate(
-        [
-            np.asarray(obs["houses"], dtype=np.float32),
-            np.asarray(obs["signals"], dtype=np.float32),
-            np.asarray(obs["locations"], dtype=np.float32),
-            np.asarray(obs["last_actions"], dtype=np.float32).flatten(),
-            np.asarray(obs["scenario_info"], dtype=np.float32),
-        ]
-    )
+    base = [
+        np.asarray(obs["houses"], dtype=np.float32),
+        np.asarray(obs["signals"], dtype=np.float32),
+        np.asarray(obs["locations"], dtype=np.float32),
+        np.asarray(obs["last_actions"], dtype=np.float32).flatten(),
+        np.asarray(obs["scenario_info"], dtype=np.float32),
+    ]
+    if agent_id is None:
+        return np.concatenate(base)
+    if num_agents is None:
+        raise ValueError(
+            "flatten_dict_obs: num_agents must be provided when agent_id is given"
+        )
+    if not 0 <= agent_id < num_agents:
+        raise ValueError(
+            f"flatten_dict_obs: agent_id {agent_id} out of range [0, {num_agents})"
+        )
+    identity = np.zeros(num_agents, dtype=np.float32)
+    identity[agent_id] = 1.0
+    base.append(identity)
+    return np.concatenate(base)
 
 
 @dataclass
@@ -74,7 +117,11 @@ class RolloutBuffer:
 
     Shapes (with ``T`` = num_steps, ``N`` = num_agents, ``A`` = ``len(action_dims)``):
 
-    - ``observations``: ``[T, obs_dim]`` --- same global obs for every agent at each step.
+    - ``observations``: ``[T, N, obs_dim]`` --- **per-agent** flattened
+      observation. Each agent sees the same global world state but a
+      different identity one-hot in the tail slot (issue #204). Prior to
+      #204 this was ``[T, obs_dim]`` and the same row was reused for every
+      agent, which made identical-policy convergence mathematically forced.
     - ``actions[i]``:   ``[T, A]`` --- agent i's actions.
     - ``log_probs[i]``: ``[T]``   --- log probability of the action under the
       rollout-time policy (used for PPO's old-policy ratio).
@@ -101,6 +148,9 @@ class JointPPOTrainer:
             ``(obs_dict, rewards[N], dones[N], info)``.
         num_agents: Number of agents N.
         obs_dim: Flattened observation dimension (see :func:`flatten_dict_obs`).
+            Must include the per-agent identity one-hot tail (i.e. it is the
+            length of ``flatten_dict_obs(obs, agent_id=i, num_agents=N)``,
+            *not* the legacy length without identity).
         action_dims: List of per-dimension action sizes (e.g. ``[10, 2]``).
         hidden_size: Hidden size of the shared trunk in each ``PolicyNetwork``.
         lr: Adam learning rate.
@@ -196,15 +246,33 @@ class JointPPOTrainer:
     # Rollout collection
     # ------------------------------------------------------------------
 
+    def _flatten_per_agent(self, obs_dict: Dict[str, np.ndarray]) -> np.ndarray:
+        """Flatten one dict observation into a per-agent ``[N, obs_dim]`` array.
+
+        Fixes the latent bug in #204 — every agent now gets its own row with
+        a distinct identity one-hot tail, instead of all sharing one global row.
+        """
+        rows = [
+            flatten_dict_obs(obs_dict, agent_id=i, num_agents=self.num_agents)
+            for i in range(self.num_agents)
+        ]
+        return np.stack(rows, axis=0)
+
     def _reset_env(self, seed: Optional[int] = None) -> None:
         obs = self.env.reset(seed=seed)
-        self._last_obs = flatten_dict_obs(obs)
+        # ``_last_obs`` is now ``[N, obs_dim]`` — one row per agent.
+        self._last_obs = self._flatten_per_agent(obs)
 
     @torch.no_grad()
     def _act_all(
-        self, obs_t: torch.Tensor
+        self, obs_per_agent_t: torch.Tensor
     ) -> Tuple[np.ndarray, List[torch.Tensor], List[torch.Tensor]]:
-        """Sample one action per agent given the same observation.
+        """Sample one action per agent given each agent's own observation row.
+
+        Args:
+            obs_per_agent_t: Tensor of shape ``[N, obs_dim]`` — agent ``i``
+                consumes row ``i``. This is the per-agent obs from #204;
+                previously the same row was passed to all N policies.
 
         Returns ``(joint_action [N, A], per-agent log_prob list, per-agent value list)``.
         """
@@ -214,15 +282,24 @@ class JointPPOTrainer:
         log_probs: List[torch.Tensor] = []
         values: List[torch.Tensor] = []
         for i, policy in enumerate(self.policies):
-            actions, lp, _, v = policy.get_action_and_value(obs_t)
+            obs_i = obs_per_agent_t[i : i + 1]  # [1, obs_dim]
+            actions, lp, _, v = policy.get_action_and_value(obs_i)
             joint_action[i] = actions[0].cpu().numpy()
             log_probs.append(lp[0])
             values.append(v[0])
         return joint_action, log_probs, values
 
     def collect_rollout(self, num_steps: int) -> RolloutBuffer:
-        """Run ``num_steps`` synchronized transitions, auto-resetting on done."""
-        observations = np.zeros((num_steps, self.obs_dim), dtype=np.float32)
+        """Run ``num_steps`` synchronized transitions, auto-resetting on done.
+
+        Issue #204: ``observations`` is now ``[T, N, obs_dim]`` — each agent
+        gets its own row per step with a distinct identity one-hot tail.
+        The previous shape ``[T, obs_dim]`` was a latent bug that fed
+        identical input to every agent.
+        """
+        observations = np.zeros(
+            (num_steps, self.num_agents, self.obs_dim), dtype=np.float32
+        )
         actions = np.zeros(
             (self.num_agents, num_steps, len(self.action_dims)), dtype=np.int64
         )
@@ -232,7 +309,7 @@ class JointPPOTrainer:
         dones = np.zeros(num_steps, dtype=np.float32)
 
         for t in range(num_steps):
-            obs_t = torch.from_numpy(self._last_obs).unsqueeze(0).to(self.device)
+            obs_t = torch.from_numpy(self._last_obs).to(self.device)  # [N, obs_dim]
             joint_action, lps, vs = self._act_all(obs_t)
 
             next_obs_dict, rew, done_arr, _ = self.env.step(joint_action)
@@ -249,7 +326,7 @@ class JointPPOTrainer:
             if done:
                 self._reset_env()
             else:
-                self._last_obs = flatten_dict_obs(next_obs_dict)
+                self._last_obs = self._flatten_per_agent(next_obs_dict)
 
         return RolloutBuffer(
             observations=torch.from_numpy(observations).to(self.device),
@@ -399,7 +476,11 @@ class JointPPOTrainer:
 
         for _epoch in range(self.ppo_epochs):
             idx = torch.randperm(t_total, device=self.device)[:mb_size]
-            obs_mb = rollout.observations[idx]
+            # Issue #204: ``rollout.observations`` is now ``[T, N, obs_dim]``.
+            # Each agent reads its own slice ``[:, i, :]`` so the identity
+            # one-hot tail differs per policy. Pre-#204 this was ``[T, obs_dim]``
+            # and a single shared ``obs_mb`` was passed to every encoder.
+            obs_mb_all = rollout.observations[idx]  # [mb, N, obs_dim]
 
             encoder_outputs: List[torch.Tensor] = []
             per_agent_losses: List[torch.Tensor] = []
@@ -409,6 +490,7 @@ class JointPPOTrainer:
                 old_lp_mb = rollout.log_probs[i][idx]
                 adv_mb = advantages[i][idx]
                 ret_mb = returns[i][idx]
+                obs_mb = obs_mb_all[:, i, :]  # [mb, obs_dim] — agent i's view
 
                 # One forward pass through the trunk; reuse features for
                 # action heads, value head, and the redundancy penalty.

--- a/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+++ b/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
@@ -122,7 +122,10 @@ def run_one_rollout(
         return BucketBrigadeEnv(scenario=scenario)
 
     probe = env_fn()
-    obs_dim = flatten_dict_obs(probe.reset(seed=cfg["seed"])).shape[0]
+    # Issue #204: obs_dim must include the per-agent identity one-hot tail.
+    obs_dim = flatten_dict_obs(
+        probe.reset(seed=cfg["seed"]), agent_id=0, num_agents=cfg["num_agents"]
+    ).shape[0]
 
     trainer = JointPPOTrainer(
         env_fn=env_fn,

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -92,25 +92,39 @@ def run_mlp_episode(
 
     Mirrors ``JointPPOTrainer._act_all`` but for one episode at a time so we
     can record the actual ``env.night`` at done for proper normalization.
+
+    Issue #204: each agent now sees its own row with a distinct identity
+    one-hot tail, matching ``JointPPOTrainer.collect_rollout``'s per-agent
+    obs layout. Previously the same flat obs was fed to every policy.
     """
     import torch  # local import to keep `--no-mlp` light
 
     obs_dict = env.reset(seed=seed)
-    obs = flatten_dict_obs(obs_dict)
+    n = trainer.num_agents
+    obs_rows = np.stack(
+        [flatten_dict_obs(obs_dict, agent_id=i, num_agents=n) for i in range(n)],
+        axis=0,
+    )
     total_reward = 0.0
     while not env.done:
-        obs_t = torch.from_numpy(obs).unsqueeze(0)
+        obs_t = torch.from_numpy(obs_rows)  # [N, obs_dim]
         joint_action = np.zeros(
             (trainer.num_agents, len(trainer.action_dims)), dtype=np.int64
         )
         with torch.no_grad():
             for i, policy in enumerate(trainer.policies):
-                a, _, _, _ = policy.get_action_and_value(obs_t)
+                a, _, _, _ = policy.get_action_and_value(obs_t[i : i + 1])
                 joint_action[i] = a[0].cpu().numpy()
         next_obs_dict, rewards, _, _ = env.step(joint_action)
         total_reward += float(rewards.sum())
         if not env.done:
-            obs = flatten_dict_obs(next_obs_dict)
+            obs_rows = np.stack(
+                [
+                    flatten_dict_obs(next_obs_dict, agent_id=i, num_agents=n)
+                    for i in range(n)
+                ],
+                axis=0,
+            )
     return total_reward, int(env.night)
 
 
@@ -200,9 +214,12 @@ def main() -> None:
     # ----- Random-init MLP iter-0 -----
     mlp_per_step_arr = None
     if not args.no_mlp:
-        # obs_dim from one reset: flatten_dict_obs layout = 10 + 3N + 10 = 22 + 3N
+        # obs_dim from one reset. Issue #204: include the per-agent identity
+        # one-hot tail (length N), giving 10 + 3N + 10 + N = 22 + 4N.
         env = BucketBrigadeEnv(scenario=scenario)
-        obs_dim = flatten_dict_obs(env.reset(seed=0)).shape[0]
+        obs_dim = flatten_dict_obs(
+            env.reset(seed=0), agent_id=0, num_agents=NUM_AGENTS
+        ).shape[0]
         mlp_per_step: list[float] = []
         mlp_lengths: list[int] = []
         for seed in seeds:

--- a/experiments/p3_specialization/dropout_eval.py
+++ b/experiments/p3_specialization/dropout_eval.py
@@ -71,14 +71,21 @@ def _run_episode(
     num_agents = len(policies)
     n_action_dims = 2
     while not env.done:
-        obs = flatten_dict_obs(obs_dict)
-        obs_t = torch.from_numpy(obs).unsqueeze(0).to(device)
+        # Issue #204: per-agent flat obs with identity one-hot tail.
+        obs_rows = np.stack(
+            [
+                flatten_dict_obs(obs_dict, agent_id=i, num_agents=num_agents)
+                for i in range(num_agents)
+            ],
+            axis=0,
+        )
+        obs_t = torch.from_numpy(obs_rows).to(device)  # [N, obs_dim]
         joint = np.zeros((num_agents, n_action_dims), dtype=np.int64)
         for i, policy in enumerate(policies):
             if i == dropout_agent:
                 joint[i] = [0, 0]  # no-op: rest at house 0
                 continue
-            actions, _, _, _ = policy.get_action_and_value(obs_t)
+            actions, _, _, _ = policy.get_action_and_value(obs_t[i : i + 1])
             joint[i] = actions[0].cpu().numpy()
         obs_dict, rewards, _, _ = env.step(joint)
         total_reward += float(rewards.sum())
@@ -108,7 +115,10 @@ def evaluate_cell(
 
     scenario = get_scenario_by_name(cfg["scenario"], num_agents=cfg["num_agents"])
     env_probe = BucketBrigadeEnv(scenario=scenario)
-    obs_dim = flatten_dict_obs(env_probe.reset(seed=0)).shape[0]
+    # Issue #204: obs_dim must include the per-agent identity one-hot tail.
+    obs_dim = flatten_dict_obs(
+        env_probe.reset(seed=0), agent_id=0, num_agents=cfg["num_agents"]
+    ).shape[0]
 
     device_t = torch.device(device)
     policies = _build_policies(

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -442,10 +442,14 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         env = BucketBrigadeEnv(scenario=scenario)
         return env
 
-    # Probe obs_dim from a single reset.
+    # Probe obs_dim from a single reset. Issue #204: include the per-agent
+    # identity one-hot tail so obs_dim matches what JointPPOTrainer actually
+    # consumes during rollouts.
     probe = env_fn()
     probe_obs = probe.reset(seed=cfg.seed)
-    obs_dim = flatten_dict_obs(probe_obs).shape[0]
+    obs_dim = flatten_dict_obs(probe_obs, agent_id=0, num_agents=cfg.num_agents).shape[
+        0
+    ]
 
     trainer = JointPPOTrainer(
         env_fn=env_fn,

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -32,7 +32,8 @@ def _make_trainer(
 ) -> JointPPOTrainer:
     env = _env_fn()
     obs = env.reset(seed=0)
-    obs_dim = flatten_dict_obs(obs).shape[0]
+    # Issue #204: obs_dim now includes the per-agent identity one-hot tail.
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
     return JointPPOTrainer(
         env_fn=_env_fn,
         num_agents=NUM_AGENTS,
@@ -64,12 +65,112 @@ class TestEnvResetRegression:
         assert ((env.houses == env.SAFE) | (env.houses == env.BURNING)).all()
 
 
+class TestPerAgentObsDifferentiation:
+    """Regression tests for the issue #204 latent bug: ``collect_rollout``
+    used to reuse one flat obs row for every agent, so PPO was provably
+    feeding identical input to all N policies. The Python flatteners
+    silently dropped the ``agent_id`` field that ``AgentObservation``
+    already carried (see ``bucket-brigade-core/src/lib.rs:43``).
+
+    After the fix, ``flatten_dict_obs(obs, agent_id=i, num_agents=N)``
+    appends a one-hot identity tail so per-agent flat obs vectors are
+    pairwise distinct, and ``collect_rollout`` stores them as
+    ``[T, N, obs_dim]`` instead of ``[T, obs_dim]``.
+    """
+
+    def test_flatten_dict_obs_legacy_no_identity(self):
+        """Backward-compat: legacy call without ``agent_id`` returns the
+        old length (no identity tail) so existing callers keep working."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        legacy = flatten_dict_obs(obs)
+        with_id = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS)
+        # The identity-equipped variant is exactly N elements longer.
+        assert with_id.shape[0] == legacy.shape[0] + NUM_AGENTS
+
+    def test_flatten_dict_obs_per_agent_differs(self):
+        """Acceptance criterion from #204: ``flatten_dict_obs(obs, agent_id=i)``
+        returns *different* vectors for ``i = 0..N-1`` on the same obs dict."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        rows = [
+            flatten_dict_obs(obs, agent_id=i, num_agents=NUM_AGENTS)
+            for i in range(NUM_AGENTS)
+        ]
+        for i in range(NUM_AGENTS):
+            for j in range(i + 1, NUM_AGENTS):
+                assert not np.array_equal(rows[i], rows[j]), (
+                    f"agents {i} and {j} got identical flat obs — "
+                    "identity one-hot tail is broken"
+                )
+        # And the only thing that differs is the last N elements (identity).
+        prefix_len = rows[0].shape[0] - NUM_AGENTS
+        for i in range(1, NUM_AGENTS):
+            assert np.array_equal(rows[0][:prefix_len], rows[i][:prefix_len]), (
+                "non-identity components leaked: per-agent obs should only "
+                "differ in the identity one-hot tail"
+            )
+
+    def test_flatten_dict_obs_requires_num_agents_with_agent_id(self):
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        with pytest.raises(ValueError):
+            flatten_dict_obs(obs, agent_id=0)
+        with pytest.raises(ValueError):
+            flatten_dict_obs(obs, agent_id=NUM_AGENTS, num_agents=NUM_AGENTS)
+        with pytest.raises(ValueError):
+            flatten_dict_obs(obs, agent_id=-1, num_agents=NUM_AGENTS)
+
+    def test_collect_rollout_per_agent_obs_distinct(self):
+        """Acceptance criterion from #204: ``RolloutBuffer.observations``
+        must expose per-agent rows that differ across agents at each step
+        (i.e. PPO is no longer fed identical input to all N policies)."""
+        trainer = _make_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+
+        obs = rollout.observations.cpu().numpy()  # [T, N, obs_dim]
+        assert obs.ndim == 3, "observations must be [T, N, obs_dim] post-#204"
+        assert obs.shape[1] == NUM_AGENTS
+
+        # At every step t and for every distinct agent pair (i, j),
+        # the rows must differ.
+        diffs = 0
+        for t in range(obs.shape[0]):
+            for i in range(NUM_AGENTS):
+                for j in range(i + 1, NUM_AGENTS):
+                    if not np.array_equal(obs[t, i], obs[t, j]):
+                        diffs += 1
+        expected_pairs = obs.shape[0] * (NUM_AGENTS * (NUM_AGENTS - 1) // 2)
+        assert diffs == expected_pairs, (
+            f"only {diffs}/{expected_pairs} (t, i<j) pairs had distinct obs — "
+            "the identity-tail latent-bug fix from #204 is not flowing through"
+        )
+
+    def test_collect_rollout_identity_tail_matches_agent_id(self):
+        """The last N components of each per-agent row must equal one-hot(i)."""
+        trainer = _make_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        obs = rollout.observations.cpu().numpy()  # [T, N, obs_dim]
+        tail = obs[..., -NUM_AGENTS:]
+        expected = np.eye(NUM_AGENTS, dtype=np.float32)
+        for t in range(obs.shape[0]):
+            assert np.array_equal(tail[t], expected), (
+                f"step {t}: identity one-hot tail does not match np.eye(N): "
+                f"got {tail[t]!r}"
+            )
+
+
 class TestRolloutCollection:
     def test_rollout_shapes(self):
         trainer = _make_trainer()
         rollout = trainer.collect_rollout(ROLLOUT_STEPS)
 
-        assert rollout.observations.shape == (ROLLOUT_STEPS, trainer.obs_dim)
+        # Issue #204: observations are now per-agent (`[T, N, obs_dim]`).
+        assert rollout.observations.shape == (
+            ROLLOUT_STEPS,
+            NUM_AGENTS,
+            trainer.obs_dim,
+        )
         assert rollout.dones.shape == (ROLLOUT_STEPS,)
         for i in range(NUM_AGENTS):
             assert rollout.actions[i].shape == (ROLLOUT_STEPS, len(ACTION_DIMS))
@@ -177,7 +278,9 @@ class TestGradientFlow:
         # Manually run one forward through every encoder on a shared batch and
         # backprop just the redundancy penalty. We can't easily isolate the
         # gradient from a regular .update() call, so this is an isolated check.
-        obs = trainer._last_obs
+        # Issue #204: ``_last_obs`` is now ``[N, obs_dim]`` — pick agent 0's row
+        # as a template for the batch.
+        obs = trainer._last_obs[0]
         obs_t = torch.from_numpy(np.tile(obs, (32, 1)))
         # Random observations so encoders produce non-degenerate features.
         obs_t = obs_t + 0.01 * torch.randn_like(obs_t)


### PR DESCRIPTION
## Summary

**Latent-bug fix** from issue #204. The Rust ``AgentObservation`` already carries ``agent_id`` (see ``bucket-brigade-core/src/lib.rs:43``) and the Rust ``obs_to_vector`` already appends it. But the two Python flatteners actually used by training — ``flatten_dict_obs`` (``joint_trainer.py:53``) and ``_flatten_observation`` (``puffer_env_rust.py:237``) — silently dropped it. Combined with ``JointPPOTrainer.collect_rollout`` reusing **one flat obs row for every agent** (``joint_trainer.py:77``), this meant PPO was provably feeding **identical input to all N policies** — making per-agent specialization mathematically impossible.

This PR implements **Option A** from the curator's enhancement: append a length-N identity one-hot to the flat obs, and fix ``collect_rollout`` to build per-agent rows. Scope is deliberately narrow to avoid conflict with #208 (MAPPO/centralized critic), which is also planned to touch ``joint_trainer.py``.

## The Latent Bug (prominent)

Before this PR, ``collect_rollout`` did:

```python
observations = np.zeros((num_steps, self.obs_dim), dtype=np.float32)  # [T, obs_dim]
...
for t in range(num_steps):
    obs_t = torch.from_numpy(self._last_obs).unsqueeze(0)  # one row
    joint_action, lps, vs = self._act_all(obs_t)           # same row to all N policies
    ...
    observations[t] = self._last_obs                       # same row stored once per t
```

Every one of the N agents received bit-for-bit identical input at every step. With identical input plus identical reward (the H2 diagnostic in #191/#194 already showed pairwise reward correlation ≈ 0.998 on ``default``), the per-agent gradient is identical and identical policy heads necessarily learn identical policies. This was a structural reason — independent of PPO hyperparameters — that the P3 specialization experiment plateaued.

## Changes

- **``flatten_dict_obs``** — new optional ``agent_id`` / ``num_agents`` kwargs append a length-N identity one-hot to the flat obs. Legacy call (no args) preserved for backward compat.
- **``RustPufferBucketBrigade._flatten_observation``** — always appends the identity one-hot (the method already received ``agent_id`` but ignored it). ``observation_space.shape`` extended by N to match.
- **``JointPPOTrainer``**:
  - ``collect_rollout`` builds per-agent obs via ``flatten_dict_obs(..., agent_id=i, num_agents=N)`` for every step and every agent.
  - ``RolloutBuffer.observations`` shape is now ``[T, N, obs_dim]`` (was ``[T, obs_dim]``).
  - ``_act_all`` takes a ``[N, obs_dim]`` tensor and indexes per-agent rows.
  - ``update()`` reads agent i's view via ``obs_mb_all[:, i, :]``.
- **Experiment scripts** (``train.py``, ``dropout_eval.py``, ``random_baseline.py``, ``inspect_rollout_rewards.py``) updated to probe ``obs_dim`` with the identity-tail variant and to feed each policy its own per-agent row.
- **Tests** — five new tests in ``test_joint_trainer.py`` (see Acceptance Criteria below). Existing tests updated for the new obs_dim and the per-agent rollout shape.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ``flatten_dict_obs(obs, agent_id=i)`` returns different vectors for ``i=0..N-1`` on the same obs dict | done | ``test_flatten_dict_obs_per_agent_differs`` |
| ``JointPPOTrainer.collect_rollout`` exposes per-agent observation tensors (no longer shares one flat row across agents) | done | ``test_collect_rollout_per_agent_obs_distinct`` + ``test_rollout_shapes`` (now ``[T, N, obs_dim]``) |
| ``RustPufferBucketBrigade.observation_space.shape`` updated to match the actual returned tensor dim | done | Smoke ran ``env.reset(); assert obs.shape == observation_space.shape`` — both ``(40,)`` for ``num_opponents=3`` (= ``num_agents=4``) |
| Existing observation tests continue to pass; new tests assert per-agent uniqueness of flat vectors | done | ``test_observation_utils.py``: 15 passed; ``test_environment.py``: 33 passed (4 unrelated skips); ``test_joint_trainer.py``: 15 passed (10 existing + 5 new) |
| Backwards compat with legacy ``flatten_dict_obs(obs)`` (no ``agent_id``) | done | ``test_flatten_dict_obs_legacy_no_identity`` |
| ``num_agents=1`` edge case — identity one-hot is ``[1.0]``, trainer still runs | covered | The identity construction in ``flatten_dict_obs`` handles ``num_agents=1`` directly; ``test_flatten_dict_obs_requires_num_agents_with_agent_id`` exercises the validation path |
| Smoke training on ``minimal_specialization`` showing non-degenerate policy divergence | deferred | Training/eval validation must run on ``COMPUTE_HOST_PRIMARY`` per ``CLAUDE.md``; explicitly out of scope for this PR per user instruction |

## Test Plan

Locally (all from the worktree):

```bash
.venv/bin/python -m pytest tests/test_joint_trainer.py        # 15 passed
.venv/bin/python -m pytest tests/test_observation_utils.py    # 15 passed
.venv/bin/python -m pytest tests/test_environment.py          # 33 passed, 4 skipped (unrelated)
.venv/bin/python -m pytest tests/ --ignore=tests/test_code_generation.py
# -> 243 passed, 46 skipped, 2 pre-existing failures in test_evolution.py
#    (verified pre-existing on main — RustFitnessEvaluator API + GA assertion)
```

Plus an end-to-end smoke confirming:
- ``flatten_dict_obs(obs, agent_id=0, num_agents=4).shape[0] == 42`` (was 38 without identity).
- ``trainer.collect_rollout(64).observations.shape == [64, 4, 42]``.
- ``rollout.observations[0, i, -4:]`` is ``one_hot(i)`` for i in 0..3.
- ``trainer.update(rollout)`` returns finite total_loss.

Training/eval validation is **deferred to** ``COMPUTE_HOST_PRIMARY`` per ``CLAUDE.md`` compute guidelines — no training runs locally. This PR is the structural fix + unit tests only.

## Coordination Note

Issue #208 (MAPPO / centralized critic) is also planned to modify ``bucket_brigade/training/joint_trainer.py``. To minimize conflict scope, this PR keeps changes narrowly focused on the observation-flatten path: only ``flatten_dict_obs``, ``_reset_env``, ``_flatten_per_agent``, ``_act_all``, ``collect_rollout``, and the single per-agent indexing line in ``update()`` are touched. No other refactors in ``joint_trainer.py``.

Closes #204