### PR TITLE
diag(p3): re-derive RAND_BASELINE on post-#197/#198 main (247.58)

### DIFF
--- a/experiments/p3_specialization/analyze_174.py
+++ b/experiments/p3_specialization/analyze_174.py
@@ -23,11 +23,17 @@ specified in issue #174:
 Each condition has 5 seeds (42..46). All cells use scenario=default,
 lambda_red=0, num_iterations=50, rollout_steps=2048.
 
-Random per-step team-reward baseline on default = 293.4 (re-derived in PR
-#196 / issue #192, n=1000 episodes; 95% CI [288.87, 297.78]). The original
-#145 value (308) was an n=50 outlier and sits outside the n=1000 CI.
+Random per-step team-reward baseline on default = 247.58 (re-derived in
+issue #218 on post-#197/#198 main at commit ``a38667b5``, n=1000 episodes,
+seeds 42..46; 95% CI [241.07, 253.89]). PR #196's previous value of 293.4
+measured the pre-#197 reward function and is therefore stale — PR #205
+(#197) rebalanced ownership rewards 20x on ``default``, which lowered the
+random per-step mean (random play burns houses more often than it saves
+them, so the larger ownership term contributes net-negative reward).
+The original #145 value (308) was an n=50 outlier on the pre-rebalance
+function.
 
-Acceptance bar = CI upper bound of the re-derived random baseline (297.78).
+Acceptance bar = CI upper bound of the re-derived random baseline (253.89).
 "Crosses bar" therefore means "statistically distinguishable from random,"
 not "exceeds an arbitrary buffer above a noisy single-sample baseline."
 The original #174 acceptance bar of 320 (= 308 + 12) was derived from the
@@ -51,8 +57,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-RAND_BASELINE = 293.4
-ACCEPTANCE_BAR = 297.78
+RAND_BASELINE = 247.58
+ACCEPTANCE_BAR = 253.89
 SEEDS = [42, 43, 44, 45, 46]
 NUM_AGENTS = 4
 

--- a/experiments/p3_specialization/analyze_plateau.py
+++ b/experiments/p3_specialization/analyze_plateau.py
@@ -45,18 +45,24 @@ import numpy as np
 # Hard-coded baselines (random-policy and heuristic per-step team reward).
 # These are not in the metrics files; they were measured separately.
 #
-# The ``default`` random baseline was re-derived in PR #196 / issue #192 using
-# ``diagnostics/random_baseline.py`` (n=1000 episodes, 5 seeds): 293.39 with
-# 95% bootstrap CI [288.87, 297.78]. The previous value (308.0, from #145 at
-# n=50) was an outlier on the right tail of a high-variance distribution and
-# sits outside the n=1000 CI. See ``research_notebook/2026-05-15_h3_random_baseline.md``.
+# The ``default`` random baseline was re-derived in issue #218 against current
+# post-#197/#198 main using ``diagnostics/random_baseline.py`` (n=1000 episodes,
+# 5 seeds at commit ``a38667b5``): 247.58 with 95% bootstrap CI [241.07, 253.89].
+# The previous value (293.4, from PR #196 at n=1000) measured the pre-#197/#198
+# reward function and is therefore stale — PR #205 (#197) rebalanced ownership
+# rewards 20x on ``default``, which lowered the random per-step mean (random
+# agents burn houses more often than they save them, so the larger ownership
+# term contributes net-negative reward at random play). The original 308 value
+# from #145 (n=50) was a separate high-variance outlier on the pre-rebalance
+# function. See ``research_notebook/2026-05-15_h3_random_baseline.md`` and the
+# 2026-05-16 amendment in ``2026-05-14_p3_specialization_results.md``.
 #
 # The ``trivial_cooperation`` and ``chain_reaction`` random values, and the
 # three ``heuristic`` values, share the same uncommitted #145 provenance and
 # remain flagged for sibling re-derivation (see issue #202 follow-up).
 BASELINES: Dict[str, Dict[str, float]] = {
     "trivial_cooperation": {"random": 400.0, "heuristic": 400.0},
-    "default": {"random": 293.4, "heuristic": 307.0},
+    "default": {"random": 247.58, "heuristic": 307.0},
     "chain_reaction": {"random": 233.0, "heuristic": 226.0},
 }
 

--- a/research_notebook/2026-05-14_p3_specialization_results.md
+++ b/research_notebook/2026-05-14_p3_specialization_results.md
@@ -132,3 +132,31 @@ After #192's diagnostic (PR #196, commit `ec6e521c`) re-derived the random basel
 - F2 (reward strictly worse at every λ > 0) verdict: was previously "not triggered" (reward essentially constant in λ). The constancy-in-λ finding is unchanged; the interpretation of constancy moves from "PPO learned no specialization at any λ" to "PPO did not move from random at any λ." Both are consistent with the same data; the second is the honest framing given the corrected baseline.
 
 The canonical baseline script is now at `experiments/p3_specialization/diagnostics/random_baseline.py` (#192 / PR #196). The matching diagnostic write-up lives at `research_notebook/2026-05-15_h3_random_baseline.md`.
+
+## Amendment (2026-05-16): re-derived random baseline on post-#197/#198 main (issue #218)
+
+The 293.4 figure from the 2026-05-15 amendment above is itself stale. PR #196 ran the diagnostic on the pre-#197 reward function. PR #205 (#197) then rebalanced ownership rewards 20x on `default` (`reward_own_house_survives` 1.0 → 20.0, `penalty_own_house_burns` 2.0 → 40.0; team rewards unchanged) and PR #206 (#198) made the per-agent reward field structural (vector promotion, no behavior change on `default`). Net effect: the same uniform-random policy that produced 293.4 on the pre-rebalance function now produces a different number, because the larger ownership term contributes net-negative reward at random play (random agents burn more than they save).
+
+Re-ran `experiments/p3_specialization/diagnostics/random_baseline.py` against current main (commit `a38667b5`) on `COMPUTE_HOST_PRIMARY`, defaults (n=1000 episodes, 5 seeds 42..46; n=250 MLP at 5×50):
+
+- **Uniform-random per-step team reward on `default`**: **247.58, 95% CI [241.07, 253.89]** (n=1000).
+- **Uniform-random per-episode**: 3261.95, 95% CI [3175.52, 3345.19].
+- **Episode length**: median 13, mean 13.18, range [13, 16]. Unchanged from PR #196.
+- **Random-init MLP iter-0 per-step**: 241.20, 95% CI [228.04, 254.29] (n=250). The MLP mean differs from uniform-random by 6.4 (just outside the script's ±5 verdict, but the MLP CI [228.04, 254.29] brackets the uniform-random mean of 247.58, so the two are statistically consistent at this n).
+
+Side-by-side:
+
+| baseline | per-step mean | 95% CI | acceptance bar (CI hi) | provenance |
+|---|---|---|---|---|
+| #145 cited | 308.0 | — (n=50, single seed) | 320 (= 308 + 12) | uncommitted protocol on pre-rebalance env |
+| #196 re-derivation (pre-#197) | 293.4 | [288.87, 297.78] (n=1000) | 297.78 | PR #196 / `ec6e521c` |
+| **#218 re-derivation (post-#197/#198, current)** | **247.58** | **[241.07, 253.89] (n=1000)** | **253.89** | this run / `a38667b5` |
+
+**Implications:**
+
+- `RAND_BASELINE` and `ACCEPTANCE_BAR` in `experiments/p3_specialization/analyze_174.py` and the `BASELINES["default"]["random"]` constant in `experiments/p3_specialization/analyze_plateau.py` updated to the new numbers.
+- The H3 regression-test band `H3_RANDOM_PER_STEP_RANGE_DEFAULT = [220, 290]` in `tests/test_env_health_diagnostics.py` already brackets 247.58 — no test change needed. The window was deliberately widened in PR #211 specifically to accommodate the post-#197/#198 scale.
+- The "PPO sits at random" reading of the #145 sweep is unchanged in spirit: the sweep was run on the pre-rebalance env (where the random baseline was 293.4), and the iter-49 means there (~290) still sit inside the pre-rebalance random CI [288.87, 297.78]. The 2026-05-15 amendment's conclusion ("PPO is at random, not below it") stands for the data it describes; the absolute scale just doesn't apply to runs on current main.
+- Judge's PR #215 spot-check (n=20, per-step mean 238.5) was directionally correct and inside the new n=1000 CI's loose neighborhood, confirming the rebalance had lowered the random baseline materially.
+
+References: issue #218; PR #205 (#197 ownership rebalance, commit `cee2000a`); PR #206 (#198 per-agent vector promotion, commit `19afcd76`); PR #196 (prior n=1000 derivation, commit `ec6e521c`); PR #215 (Judge spot-check that flagged the staleness).


### PR DESCRIPTION
## Summary

Re-derives the `default`-scenario random per-step team-reward baseline against current `main` (commit `a38667b5`, post-#197/#198/#199), correcting the stale 293.4 figure that PR #196 measured under the pre-rebalance reward function. Updates `RAND_BASELINE` and `ACCEPTANCE_BAR` in the two P3 analysis scripts plus the dated research-notebook amendment.

## Why the previous value was stale

PR #196 (commit `ec6e521c`) measured 293.4 with the canonical n=1000 protocol — but on the pre-#197 reward function. PR #205 (#197) then rebalanced ownership rewards 20x on `default` (`reward_own_house_survives` 1.0 → 20.0, `penalty_own_house_burns` 2.0 → 40.0; team rewards unchanged). Counter-intuitively this *lowered* the random per-step mean: random agents burn more houses than they save, so the larger ownership term contributes net-negative reward at random play. Judge's PR #215 spot-check (n=20, per-step 238.5) flagged the staleness; this PR closes that loop with the canonical n=1000 measurement.

## Side-by-side

| baseline | per-step mean | 95% CI | acceptance bar (CI hi) | provenance |
|---|---|---|---|---|
| #145 cited | 308.0 | — (n=50, single seed) | 320 (= 308 + 12) | uncommitted; pre-rebalance |
| #196 (pre-#197) | 293.4 | [288.87, 297.78] (n=1000) | 297.78 | PR #196 / `ec6e521c` |
| **#218 (current main)** | **247.58** | **[241.07, 253.89] (n=1000)** | **253.89** | this PR / `a38667b5` |

## Changes

- `experiments/p3_specialization/analyze_174.py` — `RAND_BASELINE` 293.4 → 247.58; `ACCEPTANCE_BAR` 297.78 → 253.89; module docstring rewritten with post-#197/#198 provenance.
- `experiments/p3_specialization/analyze_plateau.py` — `BASELINES["default"]["random"]` 293.4 → 247.58; provenance comment rewritten.
- `research_notebook/2026-05-14_p3_specialization_results.md` — new 2026-05-16 amendment section (the prior 2026-05-15 amendment that introduced 293.4 is preserved unchanged).

## Run provenance

- Host: `COMPUTE_HOST_PRIMARY` (Mac Studio).
- Commit at run time: `a38667b50c583af2cfb6a52b399cf6f6c80ccf47`.
- Command: `uv run python experiments/p3_specialization/diagnostics/random_baseline.py` (all defaults: 5 seeds 42..46, 200 episodes/seed for uniform-random = n=1000; 5×50 = n=250 for the MLP iter-0 sanity check).
- Output:
  ```
  === Uniform-random ===
    per-episode  : mean=3261.95, 95% CI=[3175.52, 3345.19], n=1000
    per-step     : mean=247.58, 95% CI=[241.07, 253.89], n=1000
    episode length: median=13, mean=13.18, min=13, max=16
  === Random-init MLP (iter-0, untrained PolicyNetwork) ===
    per-step     : mean=241.20, 95% CI=[228.04, 254.29], n=250
    episode length: median=13, mean=13.23
  ```

**Note for Judge on the random-init MLP check:** the script's verdict line reports `Random-init MLP within ±5 of uniform-random: False` because the means differ by 6.4 per-step (247.58 vs 241.20). The MLP n is only 250 (vs n=1000 for uniform-random), and the MLP's 95% CI [228.04, 254.29] easily brackets the uniform-random mean of 247.58, so the two are statistically consistent at this sample size. The ±5 threshold is a heuristic in the script, not a hard regression. Flagging in case the Judge wants to push for tighter MLP n or treat this as worth its own investigation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `random_baseline.py` run on current `main` (post-#197/#198/#199), seeds 42..46, n=1000, prints bootstrap 95% CI | ✅ | Output above; tmux session on `COMPUTE_HOST_PRIMARY` |
| `RAND_BASELINE` updated at `analyze_plateau.py:59` and `analyze_174.py:54` | ✅ | Both files set to 247.58 |
| `ACCEPTANCE_BAR` updated at `analyze_174.py:55` to new CI upper bound | ✅ | Set to 253.89 |
| Docstring/comment blocks updated with new numbers and "post-#197/#198 main" provenance | ✅ | Both files |
| Random-init MLP iter-0 reported (n=250) | ✅ | 241.20 [228.04, 254.29]; see note above re ±5 verdict |
| Dated notebook amendment with provenance (SHA, host, seeds, n, side-by-side pre/post numbers) | ✅ | New 2026-05-16 section appended; existing 2026-05-15 amendment preserved |
| H3 regression band `H3_RANDOM_PER_STEP_RANGE_DEFAULT` re-confirmed against new mean | ✅ | `[220, 290]` already brackets 247.58 — no change needed; `test_h3_random_baseline_default_in_range` passes locally |
| PR body documents pre-rebalance (293.4 / 297.78) vs post-rebalance numbers side-by-side and links #215 spot-check | ✅ | See table above; #215 referenced |

## Test Plan

- [x] H3 regression test (`tests/test_env_health_diagnostics.py::test_h3_random_baseline_default_in_range`) passes locally with the new `RAND_BASELINE` (the test re-runs n=50 random baseline at test time and asserts inside the `[220, 290]` band).
- [x] Reproducibility: the bootstrap CI half-width is ≈ ±6.4 per-step at n=1000 (rough rule of thumb: doubling n shrinks CI by √2; matches the script's printed CI).
- [x] Episode-length stability: median 13, range [13, 16] — identical to PR #196's run, confirming the ownership rewards (paid at termination) didn't change termination dynamics.
- [ ] `uv run pytest tests/test_env_health_diagnostics.py --run-slow -v` full pass — H3 test verified individually; not running the full slow suite locally since H2 in particular re-runs ablations.
- [ ] End-to-end run of `analyze_174.py` not exercised because the gitignored ablation run data isn't present in the worktree; the constants update is the contract here.

Closes #218