### PR TITLE
fix(scenarios): reject unknown distance_metric in Rust + add allowlist

### DIFF
--- a/bucket-brigade-core/src/engine/core.rs
+++ b/bucket-brigade-core/src/engine/core.rs
@@ -78,6 +78,15 @@ pub(super) fn ring_dist_10(a: u8, b: u8) -> u8 {
 
 impl BucketBrigade {
     pub fn new(scenario: Scenario, num_agents: usize, seed: Option<u64>) -> Self {
+        // Issue #222: fail fast on allowlisted-but-unrecognized fields.
+        // `engine/rewards.rs` unconditionally uses ring-arc geometry, so an
+        // unknown `distance_metric` would silently fall back to it. Mirroring
+        // the Python `Scenario.__post_init__` validator here keeps every
+        // engine-construction path (Rust literal, PyScenario kwargs, WASM JSON)
+        // consistent.
+        scenario
+            .validate()
+            .unwrap_or_else(|e| panic!("Invalid Scenario passed to BucketBrigade::new: {e}"));
         let agent_home_positions = derive_agent_home_positions(&scenario, num_agents);
         let mut engine = Self {
             houses: vec![0; 10],

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -1,6 +1,20 @@
 use super::*;
 use crate::SCENARIOS;
 
+/// Issue #222: ``BucketBrigade::new`` must reject a programmatically
+/// constructed ``Scenario`` whose ``distance_metric`` is outside the allowlist.
+/// Without this, the engine silently runs ring-arc geometry on an unknown
+/// metric string (the dispatch in ``engine/rewards.rs`` doesn't branch on the
+/// field).
+#[test]
+#[should_panic(expected = "distance_metric")]
+fn test_engine_rejects_unknown_distance_metric() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.distance_metric = "bogus".to_string();
+    // Must panic from BucketBrigade::new -> Scenario::validate.
+    let _ = BucketBrigade::new(scenario, 4, Some(42));
+}
+
 #[test]
 fn test_engine_creation() {
     let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
@@ -384,7 +398,10 @@ fn test_ownership_penalty() {
     // Per-step rewards now include rest, team rewards, and ownership penalties
     // Agent 0: rest (+0.5) + team reward (~80) + ownership penalty (-2.0) = ~78.5
     // Others: rest (+0.5) + team reward (~80) = ~80.5
-    assert!(result.rewards[0] < result.rewards[1], "Agent 0 should have lower reward due to ruined house");
+    assert!(
+        result.rewards[0] < result.rewards[1],
+        "Agent 0 should have lower reward due to ruined house"
+    );
     // Agent 0's reward should still be positive due to large team reward
     assert!(
         result.rewards[0] > 70.0,
@@ -506,7 +523,11 @@ fn test_large_population_game_completion() {
     }
 
     // Should complete within reasonable steps
-    assert!(steps < max_steps, "Game should complete within {} steps", max_steps);
+    assert!(
+        steps < max_steps,
+        "Game should complete within {} steps",
+        max_steps
+    );
 
     // Get final results
     let game_result = engine.get_result();

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -114,31 +114,36 @@ impl PyScenario {
             obj.extract::<Vec<f32>>(py)
         }
 
-        Ok(Self {
-            inner: Scenario {
-                prob_fire_spreads_to_neighbor,
-                prob_solo_agent_extinguishes_fire,
-                prob_house_catches_fire,
-                team_reward_house_survives,
-                team_penalty_house_burns,
-                cost_to_work_one_night,
-                min_nights,
-                reward_own_house_survives: to_vec(py, reward_own_house_survives)?,
-                reward_other_house_survives: to_vec(py, reward_other_house_survives)?,
-                penalty_own_house_burns: to_vec(py, penalty_own_house_burns)?,
-                penalty_other_house_burns: to_vec(py, penalty_other_house_burns)?,
-                // Issue #203 spatial-cost fields. The PyScenario constructor
-                // doesn't yet accept these (kwargs would break backward
-                // compat); to use them from Python pull the scenario out of
-                // ``bucket_brigade_core.SCENARIOS["positional_default"]`` (the
-                // SCENARIOS dict preserves all fields). Manually-constructed
-                // PyScenarios default to the pre-#203 behavior so existing
-                // callers are unchanged.
-                agent_home_positions: Vec::new(),
-                distance_cost_alpha: 0.0,
-                distance_metric: "ring_arc".to_string(),
-            },
-        })
+        let inner = Scenario {
+            prob_fire_spreads_to_neighbor,
+            prob_solo_agent_extinguishes_fire,
+            prob_house_catches_fire,
+            team_reward_house_survives,
+            team_penalty_house_burns,
+            cost_to_work_one_night,
+            min_nights,
+            reward_own_house_survives: to_vec(py, reward_own_house_survives)?,
+            reward_other_house_survives: to_vec(py, reward_other_house_survives)?,
+            penalty_own_house_burns: to_vec(py, penalty_own_house_burns)?,
+            penalty_other_house_burns: to_vec(py, penalty_other_house_burns)?,
+            // Issue #203 spatial-cost fields. The PyScenario constructor
+            // doesn't yet accept these (kwargs would break backward
+            // compat); to use them from Python pull the scenario out of
+            // ``bucket_brigade_core.SCENARIOS["positional_default"]`` (the
+            // SCENARIOS dict preserves all fields). Manually-constructed
+            // PyScenarios default to the pre-#203 behavior so existing
+            // callers are unchanged.
+            agent_home_positions: Vec::new(),
+            distance_cost_alpha: 0.0,
+            distance_metric: "ring_arc".to_string(),
+        };
+        // Issue #222: route programmatic construction through the allowlist
+        // validator. The literal above is safe today but the helper keeps the
+        // chokepoint singular for future kwargs additions.
+        inner
+            .validate()
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+        Ok(Self { inner })
     }
 
     #[getter]
@@ -397,7 +402,11 @@ impl PyVectorEnv {
     ///
     /// Returns:
     ///     Tuple of (observations, rewards, dones, infos) where each is batched
-    fn step(&mut self, py: Python, actions: Vec<Vec<u8>>) -> PyResult<(PyObject, PyObject, PyObject, PyObject)> {
+    fn step(
+        &mut self,
+        py: Python,
+        actions: Vec<Vec<u8>>,
+    ) -> PyResult<(PyObject, PyObject, PyObject, PyObject)> {
         if actions.len() != self.num_envs {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "Expected {} actions, got {}",
@@ -413,7 +422,7 @@ impl PyVectorEnv {
         for (env, action) in self.envs.iter_mut().zip(actions.iter()) {
             if action.len() != 2 {
                 return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Each action must have exactly 2 elements [house_id, mode]"
+                    "Each action must have exactly 2 elements [house_id, mode]",
                 ));
             }
 
@@ -444,7 +453,8 @@ impl PyVectorEnv {
     /// Get batched observations for a specific agent across all environments
     fn get_observations_batch(&self, py: Python, agent_id: usize) -> PyResult<PyObject> {
         // Collect observations from all environments
-        let observations: Vec<Vec<f32>> = self.envs
+        let observations: Vec<Vec<f32>> = self
+            .envs
             .iter()
             .map(|env| {
                 let obs = env.get_observation(agent_id);

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -51,10 +51,40 @@ fn default_distance_cost_alpha() -> f32 {
     0.0
 }
 
+/// Allowed values for `Scenario::distance_metric`.
+///
+/// `engine/rewards.rs` currently consumes `distance_cost_alpha + ring_dist_10(...)`
+/// unconditionally — it does not branch on `distance_metric`. That makes any
+/// unrecognized string a silent ring-arc fallback. To prevent that, the
+/// deserializer (`deserialize_distance_metric`) and the programmatic-construction
+/// chokepoint (`Scenario::validate`) both reject any value not listed here.
+///
+/// Keep in sync with the Python validator in
+/// `bucket_brigade/envs/scenarios_generated.py::Scenario.__post_init__`.
+pub const ALLOWED_DISTANCE_METRICS: &[&str] = &["ring_arc"];
+
 /// Default for `Scenario::distance_metric`. `"ring_arc"` is the only supported
 /// value today; the field is future-proofing for alternative geometries.
 fn default_distance_metric() -> String {
     "ring_arc".to_string()
+}
+
+/// Custom serde deserializer for `Scenario::distance_metric` that enforces the
+/// `ALLOWED_DISTANCE_METRICS` allowlist. Without this, the field accepts any
+/// string and silently falls back to ring-arc geometry at runtime (since
+/// `engine/rewards.rs` never reads the field) — see issue #222.
+fn deserialize_distance_metric<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    let s = String::deserialize(deserializer)?;
+    if !ALLOWED_DISTANCE_METRICS.contains(&s.as_str()) {
+        return Err(D::Error::custom(format!(
+            "Scenario.distance_metric={s:?} is not supported; allowed values: {ALLOWED_DISTANCE_METRICS:?}"
+        )));
+    }
+    Ok(s)
 }
 
 /// Default for `Scenario::agent_home_positions`. Empty means "fall back to the
@@ -110,8 +140,32 @@ pub struct Scenario {
     pub agent_home_positions: Vec<u8>,
     #[serde(default = "default_distance_cost_alpha")]
     pub distance_cost_alpha: f32,
-    #[serde(default = "default_distance_metric")]
+    #[serde(
+        default = "default_distance_metric",
+        deserialize_with = "deserialize_distance_metric"
+    )]
     pub distance_metric: String,
+}
+
+impl Scenario {
+    /// Validate fields that have allowlist constraints.
+    ///
+    /// The serde deserializer (`deserialize_distance_metric`) catches unknown
+    /// `distance_metric` values on the JSON path, but programmatic construction
+    /// (e.g. building a `Scenario` literal in Rust, the `PyScenario::new`
+    /// kwargs path, or the WASM constructor) bypasses serde entirely. This
+    /// helper is the single chokepoint for re-checking the allowlist on those
+    /// paths; it is called from `BucketBrigade::new` so the engine fails fast
+    /// rather than running with a silent ring-arc fallback (issue #222).
+    pub fn validate(&self) -> Result<(), String> {
+        if !ALLOWED_DISTANCE_METRICS.contains(&self.distance_metric.as_str()) {
+            return Err(format!(
+                "Scenario.distance_metric={:?} is not supported; allowed values: {:?}",
+                self.distance_metric, ALLOWED_DISTANCE_METRICS
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Predefined scenarios.
@@ -595,14 +649,8 @@ mod tests {
         let scenario: Scenario = serde_json::from_str(json).unwrap();
         // Scalar 1.0 should expand to MAX_AGENTS == 10 entries.
         assert_eq!(scenario.reward_own_house_survives.len(), MAX_AGENTS);
-        assert!(scenario
-            .reward_own_house_survives
-            .iter()
-            .all(|&v| v == 1.0));
-        assert!(scenario
-            .penalty_own_house_burns
-            .iter()
-            .all(|&v| v == 2.0));
+        assert!(scenario.reward_own_house_survives.iter().all(|&v| v == 1.0));
+        assert!(scenario.penalty_own_house_burns.iter().all(|&v| v == 2.0));
     }
 
     #[test]
@@ -624,7 +672,10 @@ mod tests {
         let scenario = SCENARIOS.get("minimal_specialization").unwrap();
         assert_eq!(scenario.team_reward_house_survives, 10.0);
         assert_eq!(scenario.team_penalty_house_burns, 10.0);
-        assert!(scenario.reward_own_house_survives.iter().all(|&v| v == 50.0));
+        assert!(scenario
+            .reward_own_house_survives
+            .iter()
+            .all(|&v| v == 50.0));
         assert!(scenario
             .reward_other_house_survives
             .iter()
@@ -662,30 +713,48 @@ mod tests {
     fn test_trivial_cooperation_is_easy() {
         let scenario = SCENARIOS.get("trivial_cooperation").unwrap();
         // Should have high extinguish rate and low spread
-        assert!(scenario.prob_solo_agent_extinguishes_fire >= 0.8, "Trivial cooperation should have high extinguish rate");
-        assert!(scenario.prob_fire_spreads_to_neighbor <= 0.2, "Trivial cooperation should have low spread rate");
-        assert!(scenario.cost_to_work_one_night <= 0.5, "Trivial cooperation should have low work cost");
+        assert!(
+            scenario.prob_solo_agent_extinguishes_fire >= 0.8,
+            "Trivial cooperation should have high extinguish rate"
+        );
+        assert!(
+            scenario.prob_fire_spreads_to_neighbor <= 0.2,
+            "Trivial cooperation should have low spread rate"
+        );
+        assert!(
+            scenario.cost_to_work_one_night <= 0.5,
+            "Trivial cooperation should have low work cost"
+        );
     }
 
     #[test]
     fn test_greedy_neighbor_creates_social_dilemma() {
         let scenario = SCENARIOS.get("greedy_neighbor").unwrap();
         // Should have high work cost to create free-riding incentive
-        assert!(scenario.cost_to_work_one_night >= 0.8, "Greedy neighbor should have high work cost to create social dilemma");
+        assert!(
+            scenario.cost_to_work_one_night >= 0.8,
+            "Greedy neighbor should have high work cost to create social dilemma"
+        );
     }
 
     #[test]
     fn test_early_containment_is_aggressive() {
         let scenario = SCENARIOS.get("early_containment").unwrap();
         // Should have high spread rate requiring fast response
-        assert!(scenario.prob_fire_spreads_to_neighbor >= 0.3, "Early containment should have high spread rate");
+        assert!(
+            scenario.prob_fire_spreads_to_neighbor >= 0.3,
+            "Early containment should have high spread rate"
+        );
     }
 
     #[test]
     fn test_chain_reaction_has_highest_spread() {
         let scenario = SCENARIOS.get("chain_reaction").unwrap();
         // Chain reaction should have the highest spread rate
-        assert!(scenario.prob_fire_spreads_to_neighbor >= 0.4, "Chain reaction should have very high spread rate");
+        assert!(
+            scenario.prob_fire_spreads_to_neighbor >= 0.4,
+            "Chain reaction should have very high spread rate"
+        );
         for (name, other) in SCENARIOS.iter() {
             if name != &"chain_reaction" {
                 assert!(
@@ -701,33 +770,57 @@ mod tests {
     fn test_rest_trap_has_highest_extinguish_rate() {
         let scenario = SCENARIOS.get("rest_trap").unwrap();
         // Rest trap should have very high extinguish rate (fires usually extinguish themselves)
-        assert!(scenario.prob_solo_agent_extinguishes_fire >= 0.9, "Rest trap should have very high extinguish rate");
-        assert!(scenario.prob_fire_spreads_to_neighbor <= 0.1, "Rest trap should have very low spread rate");
-        assert!(scenario.cost_to_work_one_night <= 0.3, "Rest trap should have low work cost");
+        assert!(
+            scenario.prob_solo_agent_extinguishes_fire >= 0.9,
+            "Rest trap should have very high extinguish rate"
+        );
+        assert!(
+            scenario.prob_fire_spreads_to_neighbor <= 0.1,
+            "Rest trap should have very low spread rate"
+        );
+        assert!(
+            scenario.cost_to_work_one_night <= 0.3,
+            "Rest trap should have low work cost"
+        );
     }
 
     #[test]
     fn test_sparse_heroics_has_long_games() {
         let scenario = SCENARIOS.get("sparse_heroics").unwrap();
         // Sparse heroics should have longer minimum game length
-        assert!(scenario.min_nights >= 15, "Sparse heroics should have longer minimum nights");
+        assert!(
+            scenario.min_nights >= 15,
+            "Sparse heroics should have longer minimum nights"
+        );
     }
 
     #[test]
     fn test_deceptive_calm_has_long_games() {
         let scenario = SCENARIOS.get("deceptive_calm").unwrap();
         // Deceptive calm should have longer games with occasional sparks
-        assert!(scenario.min_nights >= 15, "Deceptive calm should have longer minimum nights");
-        assert!(scenario.prob_house_catches_fire >= 0.03, "Deceptive calm should have occasional sparks");
+        assert!(
+            scenario.min_nights >= 15,
+            "Deceptive calm should have longer minimum nights"
+        );
+        assert!(
+            scenario.prob_house_catches_fire >= 0.03,
+            "Deceptive calm should have occasional sparks"
+        );
     }
 
     #[test]
     fn test_overcrowding_has_low_efficiency() {
         let scenario = SCENARIOS.get("overcrowding").unwrap();
         // Overcrowding should have low extinguish efficiency
-        assert!(scenario.prob_solo_agent_extinguishes_fire <= 0.4, "Overcrowding should have low extinguish efficiency");
+        assert!(
+            scenario.prob_solo_agent_extinguishes_fire <= 0.4,
+            "Overcrowding should have low extinguish efficiency"
+        );
         // May also have lower team reward
-        assert!(scenario.team_reward_house_survives <= 100.0, "Overcrowding may have reduced rewards");
+        assert!(
+            scenario.team_reward_house_survives <= 100.0,
+            "Overcrowding may have reduced rewards"
+        );
     }
 
     #[test]
@@ -737,16 +830,26 @@ mod tests {
         let hard = SCENARIOS.get("hard").unwrap();
 
         // Easy should have easier parameters than default
-        assert!(easy.prob_solo_agent_extinguishes_fire > default_scenario.prob_solo_agent_extinguishes_fire,
-                "Easy should have higher extinguish rate than default");
-        assert!(easy.prob_fire_spreads_to_neighbor < default_scenario.prob_fire_spreads_to_neighbor,
-                "Easy should have lower spread rate than default");
+        assert!(
+            easy.prob_solo_agent_extinguishes_fire
+                > default_scenario.prob_solo_agent_extinguishes_fire,
+            "Easy should have higher extinguish rate than default"
+        );
+        assert!(
+            easy.prob_fire_spreads_to_neighbor < default_scenario.prob_fire_spreads_to_neighbor,
+            "Easy should have lower spread rate than default"
+        );
 
         // Hard should have harder parameters than default
-        assert!(hard.prob_solo_agent_extinguishes_fire < default_scenario.prob_solo_agent_extinguishes_fire,
-                "Hard should have lower extinguish rate than default");
-        assert!(hard.prob_fire_spreads_to_neighbor > default_scenario.prob_fire_spreads_to_neighbor,
-                "Hard should have higher spread rate than default");
+        assert!(
+            hard.prob_solo_agent_extinguishes_fire
+                < default_scenario.prob_solo_agent_extinguishes_fire,
+            "Hard should have lower extinguish rate than default"
+        );
+        assert!(
+            hard.prob_fire_spreads_to_neighbor > default_scenario.prob_fire_spreads_to_neighbor,
+            "Hard should have higher spread rate than default"
+        );
     }
 
     #[test]
@@ -762,10 +865,16 @@ mod tests {
             if name == &"overcrowding" || name == &"minimal_specialization" {
                 continue;
             }
-            assert_eq!(scenario.team_reward_house_survives, 100.0,
-                      "Scenario '{}' should use standard reward (100)", name);
-            assert_eq!(scenario.team_penalty_house_burns, 100.0,
-                      "Scenario '{}' should use standard penalty (100)", name);
+            assert_eq!(
+                scenario.team_reward_house_survives, 100.0,
+                "Scenario '{}' should use standard reward (100)",
+                name
+            );
+            assert_eq!(
+                scenario.team_penalty_house_burns, 100.0,
+                "Scenario '{}' should use standard penalty (100)",
+                name
+            );
         }
     }
 
@@ -787,7 +896,10 @@ mod tests {
         assert_eq!(scenario.team_reward_house_survives, 100.0);
         assert_eq!(scenario.team_penalty_house_burns, 100.0);
         assert_eq!(scenario.cost_to_work_one_night, 0.5);
-        assert!(scenario.reward_own_house_survives.iter().all(|&v| v == 20.0));
+        assert!(scenario
+            .reward_own_house_survives
+            .iter()
+            .all(|&v| v == 20.0));
         assert!(scenario.penalty_own_house_burns.iter().all(|&v| v == 40.0));
         // New spatial knobs.
         assert_eq!(scenario.agent_home_positions, vec![0u8, 3, 5, 8]);
@@ -851,5 +963,124 @@ mod tests {
         assert_eq!(scenario.distance_cost_alpha, 0.0);
         assert_eq!(scenario.distance_metric, "ring_arc");
         assert!(scenario.agent_home_positions.is_empty());
+    }
+
+    /// Issue #222: unknown ``distance_metric`` values must be rejected at
+    /// deserialization time. Without this guard, the engine silently falls
+    /// back to ring-arc geometry because ``engine/rewards.rs`` never branches
+    /// on the field.
+    #[test]
+    fn test_unknown_distance_metric_rejected_in_deserialize() {
+        let json = r#"{
+            "prob_fire_spreads_to_neighbor": 0.25,
+            "prob_solo_agent_extinguishes_fire": 0.5,
+            "prob_house_catches_fire": 0.02,
+            "team_reward_house_survives": 100.0,
+            "team_penalty_house_burns": 100.0,
+            "reward_own_house_survives": 1.0,
+            "reward_other_house_survives": 0.0,
+            "penalty_own_house_burns": 2.0,
+            "penalty_other_house_burns": 0.0,
+            "cost_to_work_one_night": 0.5,
+            "min_nights": 12,
+            "distance_metric": "euclidean"
+        }"#;
+        let err = serde_json::from_str::<Scenario>(json)
+            .expect_err("euclidean should be rejected by the allowlist");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("distance_metric") && msg.contains("euclidean"),
+            "Deserialization error should name the offending field and value, got: {msg}"
+        );
+        assert!(
+            msg.contains("ring_arc"),
+            "Error should advertise the allowed values, got: {msg}"
+        );
+    }
+
+    /// Empty-string, mixed-case, and trailing-whitespace variants must all be
+    /// rejected — only the exact ``"ring_arc"`` literal is supported.
+    #[test]
+    fn test_distance_metric_edge_cases_rejected_in_deserialize() {
+        for bogus in ["", "Ring_Arc", "ring_arc ", "RING_ARC", " ring_arc"] {
+            let json = format!(
+                r#"{{
+                    "prob_fire_spreads_to_neighbor": 0.25,
+                    "prob_solo_agent_extinguishes_fire": 0.5,
+                    "prob_house_catches_fire": 0.02,
+                    "team_reward_house_survives": 100.0,
+                    "team_penalty_house_burns": 100.0,
+                    "reward_own_house_survives": 1.0,
+                    "reward_other_house_survives": 0.0,
+                    "penalty_own_house_burns": 2.0,
+                    "penalty_other_house_burns": 0.0,
+                    "cost_to_work_one_night": 0.5,
+                    "min_nights": 12,
+                    "distance_metric": "{bogus}"
+                }}"#
+            );
+            assert!(
+                serde_json::from_str::<Scenario>(&json).is_err(),
+                "Expected rejection for distance_metric={bogus:?}, but it was accepted"
+            );
+        }
+    }
+
+    /// Programmatic construction path: building a ``Scenario`` literal with a
+    /// bogus ``distance_metric`` should fail ``validate()``. This guards every
+    /// non-serde construction site (PyScenario, WasmScenario, engine init).
+    #[test]
+    fn test_validate_rejects_unknown_distance_metric() {
+        let scenario = Scenario {
+            prob_fire_spreads_to_neighbor: 0.25,
+            prob_solo_agent_extinguishes_fire: 0.5,
+            prob_house_catches_fire: 0.02,
+            team_reward_house_survives: 100.0,
+            team_penalty_house_burns: 100.0,
+            cost_to_work_one_night: 0.5,
+            min_nights: 12,
+            reward_own_house_survives: per_agent(1.0),
+            reward_other_house_survives: per_agent(0.0),
+            penalty_own_house_burns: per_agent(2.0),
+            penalty_other_house_burns: per_agent(0.0),
+            agent_home_positions: default_agent_home_positions(),
+            distance_cost_alpha: default_distance_cost_alpha(),
+            distance_metric: "bogus".to_string(),
+        };
+        let err = scenario
+            .validate()
+            .expect_err("bogus metric should fail validate()");
+        assert!(
+            err.contains("distance_metric"),
+            "Error should name the field, got: {err}"
+        );
+        assert!(
+            err.contains("bogus"),
+            "Error should name the offending value, got: {err}"
+        );
+        assert!(
+            err.contains("ring_arc"),
+            "Error should list allowed values, got: {err}"
+        );
+    }
+
+    /// ``validate()`` should accept every value listed in the allowlist (and
+    /// every predefined scenario which uses the canonical default).
+    #[test]
+    fn test_validate_accepts_known_distance_metrics() {
+        for (name, scenario) in SCENARIOS.iter() {
+            assert!(
+                scenario.validate().is_ok(),
+                "Predefined scenario {name:?} should pass validate()"
+            );
+        }
+    }
+
+    /// Allowlist invariant: ``"ring_arc"`` is always allowed and the default
+    /// matches an allowed value.
+    #[test]
+    fn test_allowlist_contains_default_metric() {
+        assert!(ALLOWED_DISTANCE_METRICS.contains(&"ring_arc"));
+        assert!(ALLOWED_DISTANCE_METRICS.contains(&default_distance_metric().as_str()));
     }
 }

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -101,43 +101,40 @@ impl WasmScenario {
         reward_other_house_survives: Option<f32>,
         penalty_own_house_burns: Option<f32>,
         penalty_other_house_burns: Option<f32>,
-    ) -> WasmScenario {
+    ) -> Result<WasmScenario, JsValue> {
         const DEFAULT_LEN: usize = 10;
-        Self {
-            inner: Scenario {
-                prob_fire_spreads_to_neighbor,
-                prob_solo_agent_extinguishes_fire,
-                prob_house_catches_fire,
-                team_reward_house_survives,
-                team_penalty_house_burns,
-                cost_to_work_one_night,
-                min_nights,
-                reward_own_house_survives: vec![
-                    reward_own_house_survives.unwrap_or(100.0);
-                    DEFAULT_LEN
-                ],
-                reward_other_house_survives: vec![
-                    reward_other_house_survives.unwrap_or(50.0);
-                    DEFAULT_LEN
-                ],
-                penalty_own_house_burns: vec![
-                    penalty_own_house_burns.unwrap_or(0.0);
-                    DEFAULT_LEN
-                ],
-                penalty_other_house_burns: vec![
-                    penalty_other_house_burns.unwrap_or(0.0);
-                    DEFAULT_LEN
-                ],
-                // Issue #203 spatial-cost fields. The WASM constructor uses
-                // pre-#203 defaults so existing JS/TS callers are unchanged.
-                // To consume the `positional_default` scenario from JS, use
-                // the JSON serialization path (`Scenario::to_json` /
-                // `from_json`) which preserves the new fields.
-                agent_home_positions: Vec::new(),
-                distance_cost_alpha: 0.0,
-                distance_metric: "ring_arc".to_string(),
-            },
-        }
+        let inner = Scenario {
+            prob_fire_spreads_to_neighbor,
+            prob_solo_agent_extinguishes_fire,
+            prob_house_catches_fire,
+            team_reward_house_survives,
+            team_penalty_house_burns,
+            cost_to_work_one_night,
+            min_nights,
+            reward_own_house_survives: vec![
+                reward_own_house_survives.unwrap_or(100.0);
+                DEFAULT_LEN
+            ],
+            reward_other_house_survives: vec![
+                reward_other_house_survives.unwrap_or(50.0);
+                DEFAULT_LEN
+            ],
+            penalty_own_house_burns: vec![penalty_own_house_burns.unwrap_or(0.0); DEFAULT_LEN],
+            penalty_other_house_burns: vec![penalty_other_house_burns.unwrap_or(0.0); DEFAULT_LEN],
+            // Issue #203 spatial-cost fields. The WASM constructor uses
+            // pre-#203 defaults so existing JS/TS callers are unchanged.
+            // To consume the `positional_default` scenario from JS, use
+            // the JSON serialization path (`Scenario::to_json` /
+            // `from_json`) which preserves the new fields.
+            agent_home_positions: Vec::new(),
+            distance_cost_alpha: 0.0,
+            distance_metric: "ring_arc".to_string(),
+        };
+        // Issue #222: route programmatic construction through the allowlist
+        // validator so future kwargs additions can't reintroduce silent
+        // ring-arc fallback.
+        inner.validate().map_err(|e| JsValue::from_str(&e))?;
+        Ok(Self { inner })
     }
 
     #[wasm_bindgen]

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -123,6 +123,12 @@ class Scenario:
                         "is out of range [0, 10)."
                     )
             self.agent_home_positions = positions
+        # Keep in sync with the Rust allowlist in
+        # `bucket-brigade-core/src/scenarios.rs::ALLOWED_DISTANCE_METRICS`.
+        # Both sides reject unknown values to prevent silent ring-arc
+        # fallback (issue #222 — `engine/rewards.rs` does not branch on
+        # this field, so any unrecognized string would otherwise run
+        # ring-arc geometry).
         if self.distance_metric != "ring_arc":
             raise ValueError(
                 f"Scenario.distance_metric={self.distance_metric!r} "

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -225,6 +225,12 @@ def generate_scenarios(json_path: Path, output_path: Path):
                             "is out of range [0, 10)."
                         )
                 self.agent_home_positions = positions
+            # Keep in sync with the Rust allowlist in
+            # `bucket-brigade-core/src/scenarios.rs::ALLOWED_DISTANCE_METRICS`.
+            # Both sides reject unknown values to prevent silent ring-arc
+            # fallback (issue #222 — `engine/rewards.rs` does not branch on
+            # this field, so any unrecognized string would otherwise run
+            # ring-arc geometry).
             if self.distance_metric != "ring_arc":
                 raise ValueError(
                     f"Scenario.distance_metric={self.distance_metric!r} "


### PR DESCRIPTION
## Summary

Mirrors the Python `distance_metric` validator to the Rust + WASM sides. Previously, `engine/rewards.rs` consumed `distance_cost_alpha + ring_dist_10(...)` unconditionally — it never read `Scenario.distance_metric`, so any unrecognized string (e.g. a future `"euclidean"`) silently fell back to ring-arc geometry instead of failing fast. Issue #222 surfaces this as the deeper bug beyond the surface "Python validates, Rust does not" framing.

## Changes

- `bucket-brigade-core/src/scenarios.rs`: add `pub const ALLOWED_DISTANCE_METRICS: &[&str] = &["ring_arc"]`, a `deserialize_distance_metric` serde hook wired via `#[serde(deserialize_with = ...)]`, and a `Scenario::validate()` helper for the non-serde paths (Rust literal, kwargs).
- `bucket-brigade-core/src/engine/core.rs`: call `scenario.validate()` at the top of `BucketBrigade::new` so engine instantiation fails fast on an unknown metric.
- `bucket-brigade-core/src/python.rs`: route `PyScenario::new` through `validate()`, surfaced as a `PyValueError` to Python callers.
- `bucket-brigade-core/src/wasm.rs`: `WasmScenario::new` now returns `Result<_, JsValue>` and runs `validate()`.
- `bucket_brigade/envs/scenarios_generated.py` + `scripts/generate_python.py`: cross-reference comment pointing at the Rust allowlist so the two sides stay in sync.

Per issue guidance, the hardcoded `"ring_arc".to_string()` literals at `python.rs:139`, `wasm.rs:138`, `scenarios.rs:436`, and `engine/tests.rs:823` are intentionally left untouched (safe today; route through `validate()` for future-proofing).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rust raises a clear, allowlist-naming error on unknown `distance_metric` during JSON deserialization | done | `test_unknown_distance_metric_rejected_in_deserialize` asserts the error names the field, the bad value, and `ring_arc` |
| Rust raises a clear error on unknown `distance_metric` during `BucketBrigade::new` (programmatic-construction path) | done | `engine/tests.rs::test_engine_rejects_unknown_distance_metric` uses `#[should_panic(expected = "distance_metric")]` |
| Allowlist is a single named constant in Rust (`ALLOWED_DISTANCE_METRICS`) with a sync-pointer comment to the Python validator (and vice versa) | done | New const + doc comment in `scenarios.rs`; reciprocal "Keep in sync" comments in both `scenarios_generated.py` and `scripts/generate_python.py` |
| New Rust tests cover both deserialization rejection and engine-construction rejection | done | 5 new tests: deserialize-reject, edge-cases-reject (`""`, `"Ring_Arc"`, `"ring_arc "`, etc.), `validate()`-reject, `validate()`-accepts-known, allowlist-contains-default |
| Existing tests + every scenario in `SCENARIOS` and `definitions/scenarios.json` still load unchanged | done | Full `cargo test -p bucket-brigade-core` suite: 102 passed (was 97); full `tests/test_environment.py` suite: 43 passed, 4 skipped |
| (Optional) JSON-sidecar codegen for the allowlist | deferred | One entry today; lift into `definitions/` only if a second metric appears |

## Test Plan

- `cargo test -p bucket-brigade-core --lib` (102 pass, 5 new)
- `cargo fmt --check` clean
- `cargo clippy --lib --tests` (pre-existing warning on `engine/rewards.rs:63` unchanged; no new lints)
- `uv run pytest tests/test_environment.py` (43 pass, 4 skipped)
- Re-ran `python scripts/generate_python.py`; regenerated file matches the hand-edited one (cross-ref comment preserved by codegen).

Closes #222