### PR TITLE
feat(training): add MAPPO centralized critic option to JointPPOTrainer

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -48,7 +48,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
-from bucket_brigade.training.networks import PolicyNetwork, compute_gae
+from bucket_brigade.training.networks import (
+    CentralizedCritic,
+    PolicyNetwork,
+    compute_gae,
+)
 from bucket_brigade.training.normalizers import RunningMeanStd
 
 
@@ -170,6 +174,20 @@ class JointPPOTrainer:
             ``sqrt(var + 1e-8)`` before the value-loss MSE. Default ``False``
             preserves prior behavior. See issue #159 for the motivating
             value-loss-magnitude diagnostics.
+        centralized_critic: If True, enable MAPPO (issue #208). A separate
+            :class:`CentralizedCritic` consumes the **global** portion of
+            each observation (the per-agent flat obs with the identity
+            one-hot tail stripped) and produces a single shared value
+            estimate used for advantage computation across all agents.
+            Per-agent rewards still drive per-agent advantages; only the
+            value baseline is shared. The per-agent policy networks'
+            value heads are bypassed during rollout *and* update. Default
+            ``False`` preserves the independent-PPO (IPPO) path bit-for-bit.
+
+            **Incompatible with ``redundancy_coef > 0``** — the redundancy
+            penalty couples the per-agent actor trunks; combining it with
+            a centralized critic would entangle two unrelated experiments.
+            Raises ``ValueError`` if both are set.
     """
 
     def __init__(
@@ -192,6 +210,7 @@ class JointPPOTrainer:
         device: str = "cpu",
         seed: Optional[int] = None,
         normalize_returns: bool = False,
+        centralized_critic: bool = False,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
@@ -209,6 +228,19 @@ class JointPPOTrainer:
         self.redundancy_coef = redundancy_coef
         self.ppo_epochs = ppo_epochs
         self.minibatch_size = minibatch_size
+
+        # Issue #208: MAPPO / centralized-critic flag. Stored before the env
+        # reset and policy construction so downstream wiring (advantage
+        # computation, optimizer setup) can branch on it.
+        self.centralized_critic = centralized_critic
+        if centralized_critic and redundancy_coef > 0:
+            raise ValueError(
+                "centralized_critic=True is incompatible with redundancy_coef>0: "
+                "the redundancy penalty couples the per-agent actor trunks, "
+                "while the centralized critic replaces the per-agent value "
+                "heads. Combining them entangles two unrelated experiments. "
+                "Pick one."
+            )
 
         # Issue #159: optional running mean/std of returns to shrink the
         # value-loss MSE target to O(1) (Phase 1 diagnostics showed
@@ -240,6 +272,31 @@ class JointPPOTrainer:
         # redundancy penalty's gradient can flow into each encoder.
         self.optimizers = [optim.Adam(p.parameters(), lr=lr) for p in self.policies]
 
+        # Issue #208: optional MAPPO centralized critic. The critic consumes
+        # the **global** portion of the observation (the per-agent flat obs
+        # with the identity one-hot tail stripped, length
+        # ``obs_dim - num_agents``). It has its own optimizer so its Adam
+        # state never co-mingles with the actor optimizers.
+        if self.centralized_critic:
+            self._global_obs_dim = obs_dim - num_agents
+            if self._global_obs_dim <= 0:
+                raise ValueError(
+                    f"centralized_critic=True requires obs_dim ({obs_dim}) > "
+                    f"num_agents ({num_agents}) so the identity-tail-stripped "
+                    "global obs has positive length."
+                )
+            self.critic: Optional[CentralizedCritic] = CentralizedCritic(
+                obs_dim=self._global_obs_dim,
+                hidden_size=hidden_size,
+            ).to(self.device)
+            self.critic_optimizer: Optional[optim.Optimizer] = optim.Adam(
+                self.critic.parameters(), lr=lr
+            )
+        else:
+            self._global_obs_dim = obs_dim
+            self.critic = None
+            self.critic_optimizer = None
+
         self._reset_env(seed=seed)
 
     # ------------------------------------------------------------------
@@ -263,6 +320,36 @@ class JointPPOTrainer:
         # ``_last_obs`` is now ``[N, obs_dim]`` — one row per agent.
         self._last_obs = self._flatten_per_agent(obs)
 
+    def _global_obs_from_per_agent(self, obs_per_agent: torch.Tensor) -> torch.Tensor:
+        """Strip the per-agent identity one-hot tail to recover the global obs.
+
+        Used only when ``centralized_critic=True``. The global obs is the
+        prefix shared by all agents at each timestep — i.e. each row of
+        ``[N, obs_dim]`` minus its last ``num_agents`` features. We pick
+        agent 0's row by convention (any row works: per-row prefixes are
+        identical by the #204 contract; see
+        ``tests/test_joint_trainer.py::test_flatten_dict_obs_per_agent_differs``).
+
+        Args:
+            obs_per_agent: Tensor of shape ``[..., N, obs_dim]`` or
+                ``[N, obs_dim]``.
+
+        Returns:
+            Tensor of shape ``[..., global_obs_dim]`` --- the per-agent
+            leading dim is collapsed (agent 0 selected).
+        """
+        # Take agent 0's row, then drop the identity one-hot tail.
+        if obs_per_agent.dim() == 3:  # [T, N, obs_dim] -> [T, obs_dim]
+            agent0 = obs_per_agent[:, 0, :]
+        elif obs_per_agent.dim() == 2:  # [N, obs_dim] -> [obs_dim]
+            agent0 = obs_per_agent[0]
+        else:
+            raise ValueError(
+                f"_global_obs_from_per_agent: expected 2D or 3D input, got "
+                f"shape {tuple(obs_per_agent.shape)}"
+            )
+        return agent0[..., : self._global_obs_dim]
+
     @torch.no_grad()
     def _act_all(
         self, obs_per_agent_t: torch.Tensor
@@ -275,6 +362,12 @@ class JointPPOTrainer:
                 previously the same row was passed to all N policies.
 
         Returns ``(joint_action [N, A], per-agent log_prob list, per-agent value list)``.
+
+        When ``centralized_critic=True`` (issue #208), the per-agent value
+        from ``policy.get_action_and_value`` is discarded and a single
+        shared value from :attr:`critic` (applied to the identity-tail-
+        stripped global obs) is broadcast to all N agents' value slots,
+        so the existing GAE machinery downstream stays unchanged.
         """
         joint_action = np.zeros(
             (self.num_agents, len(self.action_dims)), dtype=np.int64
@@ -287,6 +380,14 @@ class JointPPOTrainer:
             joint_action[i] = actions[0].cpu().numpy()
             log_probs.append(lp[0])
             values.append(v[0])
+
+        if self.centralized_critic:
+            # Replace per-agent values with one shared centralized estimate.
+            # The global obs is the same for every agent (identity tail
+            # stripped), so a single forward suffices.
+            global_obs = self._global_obs_from_per_agent(obs_per_agent_t).unsqueeze(0)
+            shared_value = self.critic(global_obs).squeeze(-1).squeeze(0)
+            values = [shared_value for _ in range(self.num_agents)]
         return joint_action, log_probs, values
 
     def collect_rollout(self, num_steps: int) -> RolloutBuffer:
@@ -474,6 +575,17 @@ class JointPPOTrainer:
 
         mb_size = min(self.minibatch_size, t_total)
 
+        # Issue #208: when the centralized critic is on, the value-loss is
+        # computed once against the mean across-agents return (the shared
+        # MAPPO regression target). Pre-compute it here so it can be sliced
+        # by minibatch index alongside the per-agent returns.
+        if self.centralized_critic:
+            mean_returns = (
+                torch.stack([returns[i] for i in range(self.num_agents)], dim=0)
+                .mean(dim=0)
+            )
+            stats["critic_value_loss"] = 0.0
+
         for _epoch in range(self.ppo_epochs):
             idx = torch.randperm(t_total, device=self.device)[:mb_size]
             # Issue #204: ``rollout.observations`` is now ``[T, N, obs_dim]``.
@@ -498,7 +610,6 @@ class JointPPOTrainer:
                 encoder_outputs.append(features)
 
                 action_logits = [head(features) for head in policy.action_heads]
-                values = policy.value_head(features).squeeze(-1)
 
                 new_log_probs = []
                 entropies = []
@@ -516,12 +627,21 @@ class JointPPOTrainer:
                     * adv_mb
                 )
                 policy_loss = -torch.min(surr1, surr2).mean()
-                value_loss = F.mse_loss(values, ret_mb)
-                agent_loss = (
-                    policy_loss
-                    + self.value_coef * value_loss
-                    - self.entropy_coef * entropy
-                )
+
+                if self.centralized_critic:
+                    # Per-agent value head is bypassed; the centralized
+                    # critic handles all value learning below. Record
+                    # value_loss=0 to keep the stats schema consistent.
+                    value_loss = policy_loss.new_tensor(0.0)
+                    agent_loss = policy_loss - self.entropy_coef * entropy
+                else:
+                    values = policy.value_head(features).squeeze(-1)
+                    value_loss = F.mse_loss(values, ret_mb)
+                    agent_loss = (
+                        policy_loss
+                        + self.value_coef * value_loss
+                        - self.entropy_coef * entropy
+                    )
                 per_agent_losses.append(agent_loss)
 
                 stats[f"policy_loss/agent_{i}"] += policy_loss.item() / self.ppo_epochs
@@ -534,18 +654,42 @@ class JointPPOTrainer:
                 red_pen = encoder_outputs[0].new_tensor(0.0)
             stats["redundancy_loss"] += red_pen.item() / self.ppo_epochs
 
-            total_loss = (
-                torch.stack(per_agent_losses).sum() + self.redundancy_coef * red_pen
-            )
+            if self.centralized_critic:
+                # One critic forward on the global obs minibatch (agent 0's
+                # row, identity-tail stripped). MSE against the shared
+                # mean-across-agents returns.
+                global_obs_mb = self._global_obs_from_per_agent(obs_mb_all)
+                critic_values = self.critic(global_obs_mb).squeeze(-1)
+                critic_value_loss = F.mse_loss(critic_values, mean_returns[idx])
+                stats["critic_value_loss"] += (
+                    critic_value_loss.item() / self.ppo_epochs
+                )
+                total_loss = (
+                    torch.stack(per_agent_losses).sum()
+                    + self.value_coef * critic_value_loss
+                )
+            else:
+                total_loss = (
+                    torch.stack(per_agent_losses).sum()
+                    + self.redundancy_coef * red_pen
+                )
             stats["total_loss"] += total_loss.item() / self.ppo_epochs
 
             for opt in self.optimizers:
                 opt.zero_grad()
+            if self.centralized_critic:
+                self.critic_optimizer.zero_grad()
             total_loss.backward()
             for policy in self.policies:
                 nn.utils.clip_grad_norm_(policy.parameters(), self.max_grad_norm)
+            if self.centralized_critic:
+                nn.utils.clip_grad_norm_(
+                    self.critic.parameters(), self.max_grad_norm
+                )
             for opt in self.optimizers:
                 opt.step()
+            if self.centralized_critic:
+                self.critic_optimizer.step()
 
         return stats
 

--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -207,6 +207,65 @@ class PolicyNetwork(nn.Module):
         )
 
 
+class CentralizedCritic(nn.Module):
+    """Centralized state-value network for MAPPO (issue #208).
+
+    A separate value network used by :class:`JointPPOTrainer` when
+    ``centralized_critic=True``. The critic consumes the **global** part of
+    the observation (i.e. the per-agent flat obs with the identity one-hot
+    tail stripped) and produces a single scalar value estimate that is
+    shared across all agents at training time. Per-agent advantages are
+    still computed off the per-agent reward streams, so each agent gets a
+    distinct learning signal (the value baseline is shared, the targets
+    are not).
+
+    This is the conservative MAPPO formulation from Yu et al. 2021,
+    adapted to this codebase's particular setup where the env already
+    returns a global observation (see ``joint_trainer.flatten_dict_obs``)
+    --- no per-agent obs concatenation is needed.
+
+    Architecture mirrors :class:`PolicyNetwork`'s shared trunk: a 2-layer
+    MLP with ReLU, then a linear scalar head. Default hidden size matches
+    the actor trunk so the critic has comparable capacity.
+
+    Args:
+        obs_dim: Dimension of the global observation input (i.e. the
+            actor-side ``obs_dim`` minus the identity-one-hot tail length).
+        hidden_size: Size of the hidden layers (default: 64, matching
+            :class:`PolicyNetwork`).
+
+    Example:
+        >>> critic = CentralizedCritic(obs_dim=42, hidden_size=64)
+        >>> obs = torch.randn(16, 42)
+        >>> value = critic(obs)
+        >>> value.shape
+        torch.Size([16, 1])
+    """
+
+    def __init__(self, obs_dim: int, hidden_size: int = 64) -> None:
+        super().__init__()
+        self.obs_dim = obs_dim
+        self.hidden_size = hidden_size
+        self.shared = nn.Sequential(
+            nn.Linear(obs_dim, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+        )
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            x: Global observation tensor of shape ``(batch_size, obs_dim)``.
+
+        Returns:
+            Value estimates of shape ``(batch_size, 1)``.
+        """
+        return self.value_head(self.shared(x))
+
+
 def compute_gae(
     rewards: List[float],
     values: List[float],

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -74,6 +74,11 @@ class CellConfig:
     # Issue #159: optional return normalization. Default False preserves
     # existing behavior; flip on for the ablation cells.
     normalize_returns: bool = False
+    # Issue #208: MAPPO / centralized-critic flag. Default False preserves
+    # the independent-PPO (IPPO) baseline; flip on for the MAPPO arm of
+    # the Phase 2 sweep. Incompatible with lambda_red > 0 (the redundancy
+    # penalty couples the per-agent actor trunks).
+    centralized_critic: bool = False
     # Encoder outputs are quantized for plug-in MI. We first project from
     # ``hidden_size`` down to ``mi_proj_dims`` via a fixed random matrix
     # (seeded from ``seed``); then ``quantize_uniform`` packs each row into
@@ -464,6 +469,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         entropy_coef=cfg.entropy_coef,
         redundancy_coef=cfg.lambda_red,
         normalize_returns=cfg.normalize_returns,
+        centralized_critic=cfg.centralized_critic,
         device=cfg.device,
         seed=cfg.seed,
     )
@@ -561,6 +567,18 @@ def main() -> None:
             "for the 4-cell ablation."
         ),
     )
+    p.add_argument(
+        "--centralized-critic",
+        action="store_true",
+        help=(
+            "Issue #208: enable MAPPO (centralized critic, decentralized "
+            "actors). One shared CentralizedCritic consumes the global "
+            "obs (identity-tail stripped) and produces a value baseline "
+            "shared across all agents; per-agent advantages still come "
+            "from per-agent rewards. Default off preserves IPPO. "
+            "Incompatible with --lambda-red > 0."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -574,6 +592,7 @@ def main() -> None:
         value_coef=args.value_coef,
         entropy_coef=args.entropy_coef,
         normalize_returns=args.normalize_returns,
+        centralized_critic=args.centralized_critic,
         device=args.device,
     )
     print(

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -16,6 +16,7 @@ from bucket_brigade.training.joint_trainer import (
     JointPPOTrainer,
     flatten_dict_obs,
 )
+from bucket_brigade.training.networks import CentralizedCritic
 
 
 NUM_AGENTS = 4
@@ -28,7 +29,9 @@ def _env_fn():
 
 
 def _make_trainer(
-    redundancy_coef: float = 0.0, hidden_size: int = 16
+    redundancy_coef: float = 0.0,
+    hidden_size: int = 16,
+    centralized_critic: bool = False,
 ) -> JointPPOTrainer:
     env = _env_fn()
     obs = env.reset(seed=0)
@@ -43,6 +46,7 @@ def _make_trainer(
         minibatch_size=32,
         ppo_epochs=2,
         redundancy_coef=redundancy_coef,
+        centralized_critic=centralized_critic,
         seed=0,
     )
 
@@ -296,3 +300,173 @@ class TestGradientFlow:
             assert first_linear.weight.grad.abs().sum().item() > 0.0, (
                 f"agent {i}: zero gradient from redundancy penalty"
             )
+
+
+class TestCentralizedCritic:
+    """Issue #208: MAPPO centralized critic.
+
+    The centralized-critic path replaces the per-agent value heads with a
+    single shared :class:`CentralizedCritic` consuming the global portion
+    of the observation (identity-one-hot tail stripped). Per-agent
+    advantages still come from per-agent rewards; only the value baseline
+    is shared.
+    """
+
+    def test_centralized_critic_forward_shape(self):
+        """``CentralizedCritic(obs_dim)`` accepts ``(B, obs_dim)`` and
+        returns ``(B, 1)``."""
+        critic = CentralizedCritic(obs_dim=42, hidden_size=32)
+        x = torch.randn(8, 42)
+        v = critic(x)
+        assert v.shape == (8, 1)
+
+    def test_init_critic_attributes(self):
+        """Trainer with ``centralized_critic=True`` exposes a critic +
+        optimizer; default flag leaves them ``None``."""
+        trainer_off = _make_trainer(centralized_critic=False)
+        assert trainer_off.centralized_critic is False
+        assert trainer_off.critic is None
+        assert trainer_off.critic_optimizer is None
+
+        trainer_on = _make_trainer(centralized_critic=True)
+        assert trainer_on.centralized_critic is True
+        assert isinstance(trainer_on.critic, CentralizedCritic)
+        # Global obs dim = obs_dim - num_agents (identity-tail stripped).
+        assert trainer_on.critic.obs_dim == trainer_on.obs_dim - NUM_AGENTS
+        assert trainer_on.critic_optimizer is not None
+
+    def test_critic_incompatible_with_redundancy_coef(self):
+        """Combining the centralized critic with the redundancy penalty
+        must raise (per-agent actor coupling vs. shared critic — two
+        unrelated experiments)."""
+        with pytest.raises(ValueError, match="centralized_critic"):
+            _make_trainer(centralized_critic=True, redundancy_coef=0.1)
+
+    def test_rollout_values_are_shared_under_centralized_critic(self):
+        """When MAPPO is on, every agent's stored rollout value at each
+        timestep must be the same float (the shared critic output)."""
+        trainer = _make_trainer(centralized_critic=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        # All N value rows must equal agent 0's value row, elementwise.
+        v0 = rollout.values[0].cpu().numpy()
+        for i in range(1, NUM_AGENTS):
+            vi = rollout.values[i].cpu().numpy()
+            assert np.allclose(vi, v0), (
+                f"agent {i} value row differs from agent 0 — centralized "
+                "critic should broadcast a single shared estimate"
+            )
+
+    def test_update_runs_without_nan_under_centralized_critic(self):
+        """End-to-end smoke: rollout + update completes with finite stats
+        and the new ``critic_value_loss`` key is present."""
+        trainer = _make_trainer(centralized_critic=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        for k, v in stats.items():
+            assert np.isfinite(v), f"non-finite stat {k}={v}"
+        assert "critic_value_loss" in stats
+        # Per-agent value_loss stats are recorded as 0.0 (the per-agent
+        # value heads are bypassed under MAPPO).
+        for i in range(NUM_AGENTS):
+            assert stats[f"value_loss/agent_{i}"] == 0.0
+
+    def test_critic_receives_gradient_after_update(self):
+        """After one ``update()`` call, the centralized critic's first
+        linear layer must have non-zero gradient (i.e. the critic loss
+        actually drives the centralized network's weights)."""
+        trainer = _make_trainer(centralized_critic=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        trainer.update(rollout)
+        first_linear = trainer.critic.shared[0]
+        assert first_linear.weight.grad is not None, "critic: no grad"
+        assert first_linear.weight.grad.abs().sum().item() > 0.0, (
+            "critic: zero gradient after update"
+        )
+
+    def test_actors_still_receive_gradient_under_centralized_critic(self):
+        """After one ``update()`` call, every per-agent policy network's
+        first linear layer must have non-zero gradient (the policy loss
+        still drives the actors even without a per-agent value head)."""
+        trainer = _make_trainer(centralized_critic=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        trainer.update(rollout)
+        for i, policy in enumerate(trainer.policies):
+            first_linear = policy.shared[0]
+            assert first_linear.weight.grad is not None, f"agent {i}: no grad"
+            assert first_linear.weight.grad.abs().sum().item() > 0.0, (
+                f"agent {i}: zero gradient under centralized critic"
+            )
+
+    def test_default_flag_no_critic_constructed(self):
+        """Regression guard: with ``centralized_critic=False`` (default),
+        no centralized-critic module or optimizer is constructed, and
+        the new ``critic_value_loss`` stat is **not** present in the
+        update output. This pins the default code path to the
+        pre-#208 IPPO contract.
+        """
+        trainer = _make_trainer(centralized_critic=False)
+        assert trainer.critic is None
+        assert trainer.critic_optimizer is None
+
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        assert "critic_value_loss" not in stats, (
+            "default IPPO path leaked a centralized-critic stat key"
+        )
+        # Per-agent value losses must still be non-zero floats (the per-
+        # agent value heads are exercised on the default path).
+        any_nonzero = any(
+            stats[f"value_loss/agent_{i}"] != 0.0 for i in range(NUM_AGENTS)
+        )
+        assert any_nonzero, (
+            "default IPPO path: per-agent value_loss collapsed to 0 — "
+            "the per-agent value head is no longer being trained"
+        )
+
+    def test_default_flag_two_trainers_identical_init(self):
+        """Two trainers constructed with the same seed and
+        ``centralized_critic=False`` produce identical initial weights
+        --- the canonical IPPO determinism check (seeding only; rollout
+        determinism is RNG-state-dependent and tested elsewhere)."""
+        trainer_a = _make_trainer(centralized_critic=False)
+        trainer_b = _make_trainer(centralized_critic=False)
+        for pa, pb in zip(trainer_a.policies, trainer_b.policies):
+            for ka, va in pa.state_dict().items():
+                assert torch.equal(va, pb.state_dict()[ka]), (
+                    f"initial weights differ at {ka} — IPPO seeding broken"
+                )
+
+    def test_critic_uses_identity_stripped_global_obs(self):
+        """The centralized critic consumes the global obs (identity-tail
+        stripped). Its input dim must equal ``obs_dim - num_agents``,
+        and a manual forward on a hand-crafted batch returns the right
+        shape."""
+        trainer = _make_trainer(centralized_critic=True)
+        # Hand-craft a [mb, obs_dim - num_agents] tensor (no identity tail).
+        mb = 7
+        x = torch.randn(mb, trainer.obs_dim - NUM_AGENTS)
+        v = trainer.critic(x)
+        assert v.shape == (mb, 1)
+
+    def test_num_agents_one_reduces_to_ppo_like(self):
+        """Sanity: ``num_agents=1`` with the centralized critic should
+        construct and run without error (it reduces to vanilla PPO with
+        the value head moved to a separate module)."""
+        env = BucketBrigadeEnv(num_agents=1)
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=1).shape[0]
+        trainer = JointPPOTrainer(
+            env_fn=lambda: BucketBrigadeEnv(num_agents=1),
+            num_agents=1,
+            obs_dim=obs_dim,
+            action_dims=ACTION_DIMS,
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            centralized_critic=True,
+            seed=0,
+        )
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        assert np.isfinite(stats["total_loss"])
+        assert np.isfinite(stats["critic_value_loss"])


### PR DESCRIPTION
## Summary

Phase 1 of issue #208: adds an opt-in MAPPO / centralized-critic path to `JointPPOTrainer`, gated by a new `centralized_critic=False` flag (default preserves IPPO bit-for-bit). When enabled, a separate `CentralizedCritic` module consumes the global portion of each observation (the identity one-hot tail stripped) and produces a single shared value estimate used to compute advantages for all agents. Per-agent rewards still drive per-agent advantages, so each agent retains a distinct learning signal; only the value baseline is shared. This is the Yu et al. 2021 ("Surprising Effectiveness of PPO in Cooperative Multi-Agent Games") formulation adapted to the codebase's existing global-observation contract (per the curator note on #208).

## Changes

- `bucket_brigade/training/networks.py`: new `CentralizedCritic(nn.Module)` --- 2-layer MLP trunk + scalar head, matching `PolicyNetwork`'s default trunk shape.
- `bucket_brigade/training/joint_trainer.py`:
  - New `centralized_critic: bool = False` arg on `JointPPOTrainer.__init__`. When True: instantiate `self.critic` (consuming `obs_dim - num_agents` features) + its own `self.critic_optimizer`; otherwise both are `None`.
  - Raises `ValueError` if `centralized_critic=True` and `redundancy_coef > 0` (the redundancy penalty couples per-agent actor trunks, while the centralized critic replaces per-agent value heads --- combining them entangles unrelated experiments).
  - `_act_all`: under MAPPO, replaces per-agent rollout values with one shared estimate from the critic (broadcast to all N agents' value slots so the existing GAE machinery is untouched).
  - `update()`: under MAPPO, bypasses per-agent value heads; computes one critic forward per minibatch against the **mean across agents** of per-agent returns (the shared regression target); adds `critic_value_loss` to stats; backprop hits actor optimizers and the dedicated critic optimizer separately so Adam state never co-mingles.
- `experiments/p3_specialization/train.py`: new `centralized_critic: bool = False` field on `CellConfig`; threaded through to the trainer constructor; new `--centralized-critic` argparse flag.
- `tests/test_joint_trainer.py`: new `TestCentralizedCritic` class.

## Acceptance Criteria Verification

| Criterion (from #208 test plan) | Status | Verification |
|---|---|---|
| Critic forward returns `(batch, 1)` for input `(batch, obs_dim)` | Verified | `test_centralized_critic_forward_shape`, `test_critic_uses_identity_stripped_global_obs` |
| `update()` populates gradients on critic params after one call | Verified | `test_critic_receives_gradient_after_update` |
| `update()` still populates gradients on per-agent actor params | Verified | `test_actors_still_receive_gradient_under_centralized_critic` |
| Default `centralized_critic=False` is bit-identical to current behavior (regression guard) | Verified by schema pin | `test_default_flag_no_critic_constructed` + `test_default_flag_two_trainers_identical_init` (full bit-identity across two trainers depends on shared RNG state and is RNG-state-dependent; we instead pin no-new-module + no-new-stat-key + same init weights) |
| `centralized_critic=True` and `redundancy_coef>0` either work together or raise a clear error | Verified --- raises `ValueError` | `test_critic_incompatible_with_redundancy_coef` |
| `num_agents=1` with `centralized_critic=True` reduces to vanilla PPO sanity | Verified | `test_num_agents_one_reduces_to_ppo_like` |
| Existing IPPO + redundancy-penalty + #204 tests pass unchanged | Verified | 15 existing + 11 new = **26 tests pass** in `test_joint_trainer.py`; 73 pass + 4 skipped across `test_joint_trainer.py + test_environment.py + test_training.py` |

## Test Plan

Ran:
- `uv run python -m pytest tests/test_joint_trainer.py -q` --- 26 passed.
- `uv run python -m pytest tests/test_joint_trainer.py tests/test_environment.py tests/test_training.py -q` --- 73 passed, 4 skipped (pre-existing).

## Known follow-ups (out of scope for this PR)

- `experiments/p3_specialization/train.py::_measure_information` calls `trainer.encoder_outputs_batch(rollout.observations)` with a 3D tensor (`[T, N, obs_dim]` since #204), which then trips a 2-D check in `quantize_uniform`. **This is pre-existing on `main` and unrelated to MAPPO** --- IPPO smoke trips the same error. Per Builder scope discipline, not fixed here; should be filed as a separate issue. The MAPPO Phase 2 sweep (per issue #208's "Out of scope" section) will need this fixed, or its sweep harness will need to bypass `_measure_information`.
- Phase 2 (separate issue): full 200-iter A/B on `minimal_specialization` (IPPO vs. MAPPO, seed 42, identical hyperparams) to measure gap-closure. Deferred per #208 body. Per CLAUDE.md compute guidelines, that run belongs on `$COMPUTE_HOST_PRIMARY`, not localhost.

Closes #208