### PR TITLE
diag(p3): re-derive chain_reaction random baseline 233 -> 220.75 (n=1000)

### DIFF
--- a/experiments/p3_specialization/analyze_plateau.py
+++ b/experiments/p3_specialization/analyze_plateau.py
@@ -57,13 +57,22 @@ import numpy as np
 # function. See ``research_notebook/2026-05-15_h3_random_baseline.md`` and the
 # 2026-05-16 amendment in ``2026-05-14_p3_specialization_results.md``.
 #
-# The ``trivial_cooperation`` and ``chain_reaction`` random values, and the
-# three ``heuristic`` values, share the same uncommitted #145 provenance and
-# remain flagged for sibling re-derivation (see issue #202 follow-up).
+# The ``chain_reaction`` random baseline was re-derived in issue #219 against
+# current post-#197/#198 main using ``diagnostics/random_baseline.py``
+# (n=1000 episodes, 5 seeds at commit ``b053d38e``): 220.75 with 95% bootstrap
+# CI [215.39, 225.86]. The previous value (233.0) traced to the same
+# uncommitted #145 n=50 measurement as ``default``'s old 308; the n=1000
+# re-derivation places it ~5% lower and outside its own implied CI. See
+# ``research_notebook/2026-05-15_h3_random_baseline.md`` (2026-05-16
+# chain_reaction amendment).
+#
+# The ``trivial_cooperation`` random value and the three ``heuristic`` values
+# share the same uncommitted #145 provenance and remain flagged for sibling
+# re-derivation (see issue #202 follow-up).
 BASELINES: Dict[str, Dict[str, float]] = {
     "trivial_cooperation": {"random": 400.0, "heuristic": 400.0},
     "default": {"random": 247.58, "heuristic": 307.0},
-    "chain_reaction": {"random": 233.0, "heuristic": 226.0},
+    "chain_reaction": {"random": 220.75, "heuristic": 226.0},
 }
 
 # Coefficients used in joint_trainer (default values from CellConfig).

--- a/experiments/p3_specialization/diagnostics/README.md
+++ b/experiments/p3_specialization/diagnostics/README.md
@@ -17,7 +17,7 @@ ownership-vector refactor, etc.).
 |------|------------|------------------|
 | `inspect_rollout_rewards.py` | **H1** (#190) | Per-agent reward CV + action-reward R² from one rollout. |
 | `audit_reward_attribution.py` | **H2** (#191) | Per-step decomposition into (team, ownership, work_cost) + pairwise reward correlation. |
-| `random_baseline.py` | **H3** (#192) | Uniform-random per-step team reward on `default`; re-derives the cited 308. |
+| `random_baseline.py` | **H3** (#192) | Uniform-random per-step team reward; re-derives `default` (cited 308 → post-#197/#198 247.58) and `chain_reaction` (cited 233 → re-derived; issue #219). Other scenarios via `--scenario`. |
 | `check_env_health.sh` | aggregator | Runs H1+H2+H3 sequentially, tees logs, prints a summary table. |
 | `issue199_baselines.py` | (separate) | Specialist baseline harness for issue #199. |
 

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -39,11 +39,14 @@ Usage::
         --episodes-per-seed 50 --seeds 1 --no-mlp   # reproduce #145 protocol
     uv run python experiments/p3_specialization/diagnostics/random_baseline.py \\
         --scenario positional_default --no-mlp      # issue #221
+    uv run python experiments/p3_specialization/diagnostics/random_baseline.py \\
+        --scenario chain_reaction                   # issue #219
 
-Issue #219 will extend this script with a per-scenario cited-value table
-(currently CITED_308 / CITED_290 only apply to the ``default`` scenario; for
-other scenarios the verdict comparison is suppressed but raw measurements still
-print).
+Issue #219 added the ``SCENARIO_CITED_VALUES`` table below. For each named
+scenario in the table, the verdict block compares the re-derived value against
+the cited number from #145 (and, for ``default``, also against the iter-0 MLP
+number from #183). For scenarios outside the table, raw measurements still
+print but the verdict comparison is suppressed.
 """
 
 from __future__ import annotations
@@ -63,15 +66,38 @@ from bucket_brigade.training.joint_trainer import JointPPOTrainer, flatten_dict_
 HIDDEN_SIZE = 64
 NUM_AGENTS = 4
 ACTION_DIMS = [10, 2]
-# Default scenario name; override via ``--scenario`` (issue #221). A broader
-# generalization with a per-scenario cited-value table is tracked in issue #219.
+# Default scenario name; override via ``--scenario`` (issue #221).
 DEFAULT_SCENARIO_NAME = "default"
 
-# The widely cited number we are re-deriving (applies to ``default`` only).
-CITED_308 = 308.0
-# Iter-0 per-step team reward from issue #183's phase-3 L1_norm cell
-# (``default`` scenario only).
-CITED_290 = 290.52
+# Per-scenario cited-value table (issue #219).
+#
+# ``random`` is the per-step team-reward number cited in the literature (almost
+# always traceable to issue #145's uncommitted n=50 measurement). ``mlp_iter0``
+# is the iter-0 per-step MLP team reward cited alongside it (e.g. the L1_norm
+# phase-3 cell from #183) — currently only defined for ``default``. ``note``
+# records the provenance so re-derivations stay auditable.
+#
+# When ``--scenario`` matches an entry here, the verdict block compares the
+# re-derived value against ``random`` (and, if non-None, against ``mlp_iter0``).
+# Scenarios outside this table still print their raw measurements; the verdict
+# comparison is just suppressed.
+SCENARIO_CITED_VALUES: dict[str, dict[str, float | str | None]] = {
+    "default": {
+        "random": 308.0,
+        "mlp_iter0": 290.52,
+        "note": "#145 (random) / #183 (iter-0 MLP); both load-bearing in analyze_plateau.py and analyze_174.py",
+    },
+    "chain_reaction": {
+        "random": 233.0,
+        "mlp_iter0": None,
+        "note": "#145 (same uncommitted n=50 protocol as default's 308); load-bearing in analyze_plateau.py",
+    },
+}
+
+# Backwards-compat aliases for callers that imported these constants directly.
+# Kept for one release cycle; new code should consult ``SCENARIO_CITED_VALUES``.
+CITED_308 = SCENARIO_CITED_VALUES["default"]["random"]
+CITED_290 = SCENARIO_CITED_VALUES["default"]["mlp_iter0"]
 
 
 def run_random_episode(
@@ -183,28 +209,32 @@ def main() -> None:
         type=str,
         default=DEFAULT_SCENARIO_NAME,
         help=(
-            "Scenario name to evaluate (e.g. 'default', 'positional_default', "
-            "'minimal_specialization'). Cited values CITED_308 / CITED_290 only "
-            "apply to 'default'; for other scenarios the verdict comparison is "
-            "suppressed (issue #221). Issue #219 will add a per-scenario "
-            "cited-value table."
+            "Scenario name to evaluate (e.g. 'default', 'chain_reaction', "
+            "'positional_default', 'minimal_specialization'). Scenarios listed "
+            "in SCENARIO_CITED_VALUES get a verdict comparison against the cited "
+            "number; others print raw measurements only. See issue #219."
         ),
     )
     args = ap.parse_args()
 
     scenario_name = args.scenario
     scenario = get_scenario_by_name(scenario_name, num_agents=NUM_AGENTS)
+    cited = SCENARIO_CITED_VALUES.get(scenario_name)
     print(
         f"Scenario: {scenario_name}, num_agents={NUM_AGENTS}, min_nights={scenario.min_nights}"
     )
-    if scenario_name == "default":
-        print(
-            f"Cited values: random={CITED_308} (issue #145), iter-0 MLP={CITED_290} (issue #183)"
+    if cited is not None:
+        rand_cite = cited["random"]
+        mlp_cite = cited["mlp_iter0"]
+        provenance = cited["note"]
+        mlp_str = (
+            f", iter-0 MLP={mlp_cite}" if mlp_cite is not None else ""
         )
+        print(f"Cited values: random={rand_cite}{mlp_str} ({provenance})")
     else:
         print(
-            "Cited values: n/a for this scenario "
-            "(CITED_308 / CITED_290 apply only to 'default'; see issue #219 for a per-scenario table)."
+            f"Cited values: n/a for scenario '{scenario_name}' "
+            "(not in SCENARIO_CITED_VALUES; raw measurements only)."
         )
     print()
 
@@ -279,18 +309,23 @@ def main() -> None:
 
     # ----- Verdict -----
     print("=== Verdict ===")
-    if scenario_name == "default":
+    if cited is not None:
+        rand_cite = cited["random"]
+        mlp_cite = cited["mlp_iter0"]
         lo, hi = bootstrap_ci(rand_per_step_arr)
-        rand_agrees = lo <= CITED_308 <= hi
-        print(f"Uniform-random per-step CI contains cited 308: {rand_agrees}")
+        rand_agrees = lo <= rand_cite <= hi
+        print(
+            f"Uniform-random per-step CI contains cited {rand_cite}: {rand_agrees}"
+        )
         if mlp_per_step_arr is not None:
-            lo_m, hi_m = bootstrap_ci(mlp_per_step_arr)
-            mlp_agrees_290 = lo_m <= CITED_290 <= hi_m
+            if mlp_cite is not None:
+                lo_m, hi_m = bootstrap_ci(mlp_per_step_arr)
+                mlp_agrees_cite = lo_m <= mlp_cite <= hi_m
+                print(
+                    f"Random-init MLP per-step CI contains cited {mlp_cite}: {mlp_agrees_cite}"
+                )
             mlp_agrees_rand = (
                 abs(mlp_per_step_arr.mean() - rand_per_step_arr.mean()) < 5.0
-            )
-            print(
-                f"Random-init MLP per-step CI contains cited 290.52: {mlp_agrees_290}"
             )
             print(
                 f"Random-init MLP within ±5 of uniform-random: {mlp_agrees_rand}"
@@ -298,7 +333,7 @@ def main() -> None:
     else:
         print(
             f"(No cited verdict for scenario '{scenario_name}'; "
-            "see issue #219 for a per-scenario cited-value table.)"
+            "add an entry to SCENARIO_CITED_VALUES to enable.)"
         )
 
 

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -227,9 +227,7 @@ def main() -> None:
         rand_cite = cited["random"]
         mlp_cite = cited["mlp_iter0"]
         provenance = cited["note"]
-        mlp_str = (
-            f", iter-0 MLP={mlp_cite}" if mlp_cite is not None else ""
-        )
+        mlp_str = f", iter-0 MLP={mlp_cite}" if mlp_cite is not None else ""
         print(f"Cited values: random={rand_cite}{mlp_str} ({provenance})")
     else:
         print(
@@ -314,9 +312,7 @@ def main() -> None:
         mlp_cite = cited["mlp_iter0"]
         lo, hi = bootstrap_ci(rand_per_step_arr)
         rand_agrees = lo <= rand_cite <= hi
-        print(
-            f"Uniform-random per-step CI contains cited {rand_cite}: {rand_agrees}"
-        )
+        print(f"Uniform-random per-step CI contains cited {rand_cite}: {rand_agrees}")
         if mlp_per_step_arr is not None:
             if mlp_cite is not None:
                 lo_m, hi_m = bootstrap_ci(mlp_per_step_arr)
@@ -327,9 +323,7 @@ def main() -> None:
             mlp_agrees_rand = (
                 abs(mlp_per_step_arr.mean() - rand_per_step_arr.mean()) < 5.0
             )
-            print(
-                f"Random-init MLP within ±5 of uniform-random: {mlp_agrees_rand}"
-            )
+            print(f"Random-init MLP within ±5 of uniform-random: {mlp_agrees_rand}")
     else:
         print(
             f"(No cited verdict for scenario '{scenario_name}'; "

--- a/experiments/p3_specialization/diagnostics/summary.md
+++ b/experiments/p3_specialization/diagnostics/summary.md
@@ -21,7 +21,7 @@ All values are means across seeds.
 
 ## chain_reaction
 - n_seeds = 20, n_iters = 50
-- reward iter 0 -> iter 49: 224.21 -> 224.47  (baseline random = 233.0)
+- reward iter 0 -> iter 49: 224.21 -> 224.47  (baseline random = 220.75)
 - mean value_loss iter 0 -> iter 49: 1.56e+05 -> 1.09e+05  (scaled by value_coef=0.5: 7.80e+04)
 - mean |policy_loss| iter 0 -> iter 49: 2.587e-02 -> 2.096e-02
 - mean entropy iter 0 -> iter 49: 6.654e-01 -> 1.394e-01  (scaled by entropy_coef=0.01: 1.394e-03)

--- a/research_notebook/2026-05-14_p3_specialization_results.md
+++ b/research_notebook/2026-05-14_p3_specialization_results.md
@@ -160,3 +160,37 @@ Side-by-side:
 - Judge's PR #215 spot-check (n=20, per-step mean 238.5) was directionally correct and inside the new n=1000 CI's loose neighborhood, confirming the rebalance had lowered the random baseline materially.
 
 References: issue #218; PR #205 (#197 ownership rebalance, commit `cee2000a`); PR #206 (#198 per-agent vector promotion, commit `19afcd76`); PR #196 (prior n=1000 derivation, commit `ec6e521c`); PR #215 (Judge spot-check that flagged the staleness).
+
+## Amendment (2026-05-16): chain_reaction random baseline re-derived (issue #219)
+
+The `chain_reaction` row of the `λ_red = 1e-1` results table (line 38)
+reports iter-49 mean reward `222.37 [218.29, 226.75]`. The implied
+contextual baseline cited as `233.0` in `analyze_plateau.py` is itself
+the same uncommitted #145 n=50 measurement that produced `default`'s old
+`308`. Re-derived on `COMPUTE_HOST_PRIMARY` against current main (commit
+`b053d38e`, post-#197/#198) using `random_baseline.py --scenario
+chain_reaction --episodes-per-seed 200 --seeds 5`:
+
+- **Uniform-random per-step team reward on `chain_reaction`**: **220.75, 95% CI [215.39, 225.86]** (n=1000).
+- **Random-init MLP iter-0 per-step**: 218.79, 95% CI [208.96, 228.54] (n=250); statistically indistinguishable from uniform-random.
+
+**Body conclusion unchanged.** The iter-49 mean `222.37 [218.29, 226.75]`
+sits inside the new random CI `[215.39, 225.86]` (overlap on the upper
+end; the iter-49 CI extends slightly above), so the "chain_reaction PPO
+plateau sits at random" framing holds under the corrected baseline. The
+original 233 figure read PPO as sitting ~10 reward below random; under
+the re-derived 220.75 it sits effectively *at* random (Δ ≈ +1.6, well
+inside both CIs). This is qualitatively the same flip as PR #213's
+`default` finding ("PPO is at random, not below it") and PR #218's
+follow-up ("post-#197/#198 the absolute scales shift but the at-random
+interpretation persists"). No body edits — only this footer.
+
+`BASELINES["chain_reaction"]["random"]` updated from `233.0` → `220.75`
+in `analyze_plateau.py`. The `226.0` heuristic baseline in the same dict
+still traces to the uncommitted #145 protocol and remains flagged for a
+separate heuristic-policy re-derivation pass (out of scope for #219).
+
+References: issue #219; PR #213 (sister `default` fix, n=1000 → 293.4);
+PR #228 (the `--scenario` CLI foundation this PR builds on); issue #145
+(origin of the inflated 233); issue #202 (audit-policy issue that
+deferred `chain_reaction` from PR #213).

--- a/research_notebook/2026-05-15_h3_random_baseline.md
+++ b/research_notebook/2026-05-15_h3_random_baseline.md
@@ -69,3 +69,48 @@ uv run python experiments/p3_specialization/diagnostics/random_baseline.py
 uv run python experiments/p3_specialization/diagnostics/random_baseline.py \
     --episodes-per-seed 50 --seeds 1 --no-mlp
 ```
+
+## Amendment (2026-05-16): chain_reaction sibling re-derivation (issue #219)
+
+Sibling baseline to PR #213's `default`-only audit: the `chain_reaction`
+random baseline cited as `233.0` in `analyze_plateau.py` and
+`diagnostics/summary.md` has the same uncommitted #145 n=50 provenance as
+`default`'s old `308`. Re-derived on `COMPUTE_HOST_PRIMARY` against current
+main (commit `b053d38e`, which contains the post-#197/#198 reward function)
+using `experiments/p3_specialization/diagnostics/random_baseline.py
+--scenario chain_reaction --episodes-per-seed 200 --seeds 5` (n=1000 total):
+
+- **Uniform-random per-step team reward on `chain_reaction`**: **220.75, 95% CI [215.39, 225.86]** (n=1000).
+- **Uniform-random per-episode**: 3573.19, 95% CI [3486.31, 3656.27].
+- **Episode length**: median 16, mean 16.18, range [16, 20]. `chain_reaction` has `min_nights=15` (vs 12 for `default`); fire-spread frequently extends episodes 1–5 nights past the floor.
+- **Random-init MLP iter-0 per-step**: 218.79, 95% CI [208.96, 228.54] (n=250). Mean differs from uniform-random by 1.96 (well inside the ±5 verdict window); CIs overlap heavily — the MLP and uniform-random policies are statistically indistinguishable at this n.
+- **#145-protocol reproduction (n=50, single seed)**: 235.41, 95% CI [214.23, 257.33]. The cited 233 sits inside this wide CI, mirroring PR #213's finding that `default`'s 308 was an unlucky tail-sample on a high-variance reward distribution.
+
+Side-by-side:
+
+| baseline | per-step mean | 95% CI | provenance |
+|---|---|---|---|
+| #145 cited | 233.0 | — (n=50, single seed) | uncommitted protocol |
+| **#219 re-derivation (post-#197/#198, current)** | **220.75** | **[215.39, 225.86] (n=1000)** | this run / `b053d38e` |
+| #219 #145-reproduction (n=50) | 235.41 | [214.23, 257.33] | this run (sampling-noise demo) |
+
+**Verdict:** `Uniform-random per-step CI contains cited 233.0: False` —
+the cited number sits ~5% above the n=1000 mean and outside its CI.
+Same pattern as `default`'s old 308 (also ~5% above the n=1000 mean,
+also outside the post-#197/#198 CI).
+
+**Implications:**
+
+- `BASELINES["chain_reaction"]["random"]` in `experiments/p3_specialization/analyze_plateau.py` updated from `233.0` → `220.75`.
+- `experiments/p3_specialization/diagnostics/summary.md` line 24 baseline literal updated; the surrounding `reward iter 0 -> iter 49: 224.21 -> 224.47` numbers are unchanged (they come from the existing `runs/` data, not the constant).
+- The H3 regression test (`tests/test_env_health_diagnostics.py`) remains `default`-only by design; extending it to `chain_reaction` is out of scope for this issue.
+- The `chain_reaction` heuristic baseline (`226.0`) still traces to the same uncommitted #145 protocol and remains flagged for a separate heuristic-policy diagnostic pass (out of scope for #219).
+- The narrative reading of the prior P3 sweep on `chain_reaction` (iter-49 reward `222.37 [218.29, 226.75]` per `2026-05-14_p3_specialization_results.md:38`) is unchanged in spirit: that CI overlaps the new `220.75` random CI almost exactly, so the "PPO sits at random on `chain_reaction`" framing is preserved — it just now sits *at* the corrected random baseline rather than *below* the inflated one.
+
+The diagnostic script (`experiments/p3_specialization/diagnostics/random_baseline.py`) was extended in this PR with a `SCENARIO_CITED_VALUES` table (curator's Option A from issue #219's enhancement). `chain_reaction` is now a table entry; the verdict block generalizes per-scenario without hardcoded `if scenario == "default"` branches.
+
+References: issue #219; PR #213 (sister `default` post-#197/#198 fix);
+issue #218 (its parent audit); PR #228 (the `--scenario` CLI foundation
+this PR builds on); PR #196 (canonical re-derivation pattern); issue
+#145 (origin of the wrong 233); issue #202 (audit-policy issue that
+deferred `chain_reaction` from PR #213 to here).


### PR DESCRIPTION
## Summary

Sibling re-derivation to PR #213's `default`-only fix. The
`chain_reaction` random baseline cited as `233.0` in
`analyze_plateau.py` and `diagnostics/summary.md` traces to the same
uncommitted #145 n=50 protocol as `default`'s old `308`. Re-derived
on `COMPUTE_HOST_PRIMARY` against current post-#197/#198 main using a
new per-scenario cited-value table in `random_baseline.py` (curator's
recommended Option A).

**Re-derived value (n=1000, 5 seeds × 200 episodes):**
`220.75, 95% CI [215.39, 225.86]` — the cited 233 sits ~5% above the
n=1000 mean and outside its CI.

## Changes

- `experiments/p3_specialization/diagnostics/random_baseline.py`:
  added `SCENARIO_CITED_VALUES` table (curator's Option A); both
  `default` (308 / 290.52) and `chain_reaction` (233 / None) are
  entries; verdict block generalizes per-scenario via table lookup
  instead of hardcoded `if scenario == "default"` branches.
  `CITED_308` / `CITED_290` kept as backwards-compat aliases.
- `experiments/p3_specialization/analyze_plateau.py:66`:
  `BASELINES["chain_reaction"]["random"]` `233.0` → `220.75`, with
  provenance comment mirroring #218's comment on `default`.
- `experiments/p3_specialization/diagnostics/summary.md:24`:
  baseline literal `233.0` → `220.75`. Iter-0/iter-49 reward numbers
  are unchanged (they come from `runs/` data, not the constant).
- `experiments/p3_specialization/diagnostics/README.md:20`: one-line
  description updated to reflect multi-scenario support.
- `research_notebook/2026-05-15_h3_random_baseline.md`: dated
  `## Amendment (2026-05-16): chain_reaction sibling re-derivation`
  footer; body unchanged (mirrors PR #213's pattern).
- `research_notebook/2026-05-14_p3_specialization_results.md`: dated
  `## Amendment (2026-05-16)` footer; body unchanged (mirrors PR
  #213's `p3_plateau_ablation.md` amendment).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `random_baseline.py` accepts `--scenario chain_reaction` and defaults to `default` | ✅ | `SCENARIO_CITED_VALUES` table; `default` entry retained as anchor, verdict logic identical for the default-path call |
| Re-derived per-step team reward with mean + 95% bootstrap CI at n=1000 | ✅ | `220.75 [215.39, 225.86]` from n=1000 run on `COMPUTE_HOST_PRIMARY` |
| `analyze_plateau.py:66` updated 233 → re-derived; inline comment citing #219 + n=1000 CI | ✅ | Comment block above `BASELINES` mirrors `default`'s post-#218 comment |
| `diagnostics/summary.md` regenerated so chain_reaction row shows new baseline | ✅ | Line 24 baseline literal updated; reward numbers unchanged (no runs/ data change) |
| `diagnostics/README.md:20` reflects multi-scenario support | ✅ | Updated to "re-derives `default` and `chain_reaction`" |
| `2026-05-15_h3_random_baseline.md` gets dated `## Amendment` footer | ✅ | "## Amendment (2026-05-16): chain_reaction sibling re-derivation" |
| `2026-05-14_p3_specialization_results.md` gets dated footer | ✅ | "## Amendment (2026-05-16): chain_reaction random baseline re-derived (issue #219)" |
| Does NOT modify `analyze_174.py` | ✅ | `git diff --stat` confirms |
| Does NOT modify closed issue bodies #145, #174, #183 | ✅ | None touched |
| Does NOT modify false-positive sites (evolved JSONs, tournament CSVs) | ✅ | `git diff --stat` confirms |
| Compute ran on `COMPUTE_HOST_PRIMARY` (per CLAUDE.md) | ✅ | Source `.env`; ssh + tmux per spec; commit `b053d38e` was the SUT |

## Test Plan

**Main re-derivation (n=1000) on `COMPUTE_HOST_PRIMARY`:**

```
$ uv run python experiments/p3_specialization/diagnostics/random_baseline.py \
      --scenario chain_reaction --episodes-per-seed 200 --seeds 5

Scenario: chain_reaction, num_agents=4, min_nights=15
Cited values: random=233.0 (#145 (same uncommitted n=50 protocol as default's 308); load-bearing in analyze_plateau.py)

=== Uniform-random ===
  per-episode  : mean=3573.19, 95% CI=[3486.31, 3656.27], n=1000
  per-step     : mean=220.75, 95% CI=[215.39, 225.86], n=1000
  episode length: median=16, mean=16.18, min=16, max=20

=== Random-init MLP (iter-0, untrained PolicyNetwork) ===
  per-step     : mean=218.79, 95% CI=[208.96, 228.54], n=250

=== Verdict ===
Uniform-random per-step CI contains cited 233.0: False
Random-init MLP within ±5 of uniform-random: True
```

**#145 protocol reproduction (n=50, single seed):**

```
$ uv run python experiments/p3_specialization/diagnostics/random_baseline.py \
      --scenario chain_reaction --episodes-per-seed 50 --seeds 1 --no-mlp

=== Uniform-random ===
  per-step     : mean=235.41, 95% CI=[214.23, 257.33], n=50

=== Verdict ===
Uniform-random per-step CI contains cited 233.0: True
```

The cited 233 sits inside the n=50 CI but outside the n=1000 CI — same
sampling-noise pattern PR #213 found for `default`'s 308.

**Grep verification (final state):**

```
$ rg -n "\b233\.0?\b" experiments/p3_specialization/ research_notebook/ | grep -v "evolution_trace\|checkpoint\|tournaments"
```

Only intentional retained references remain: the diagnostic anchor
(`SCENARIO_CITED_VALUES["chain_reaction"]["random"] = 233.0`), the
provenance comment in `analyze_plateau.py`, and dated-amendment text.
No load-bearing baseline literals.

## References

- Closes #219.
- Sister PR #213 (the `default`-only fix; this issue is the explicit
  follow-up).
- #202 (audit-policy issue that explicitly deferred `chain_reaction`
  to a follow-up).
- #218 (parent re-derivation for `default` post-#197/#198).
- #228 (added the minimal `--scenario` CLI foundation this PR builds on).
- #196 (canonical re-derivation pattern this script generalizes).
- #145 (origin of the wrong 233 n=50 measurement).

Closes #219