### PR TITLE
exp(220): rerun obs-fix validation; verdict 5.9% gap (MAPPO still needed)

### DIFF
--- a/experiments/p3_specialization/diagnostics/pairwise_action_kl.py
+++ b/experiments/p3_specialization/diagnostics/pairwise_action_kl.py
@@ -29,9 +29,9 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from bucket_brigade.env import BucketBrigadeEnv
-from bucket_brigade.training import JointPPOTrainer, flatten_dict_obs
-from definitions import get_scenario_by_name
+from bucket_brigade.envs import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.training.joint_trainer import JointPPOTrainer, flatten_dict_obs
 
 
 def softmax_packed(logits_list: list[torch.Tensor]) -> torch.Tensor:

--- a/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.json
+++ b/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.json
@@ -1,0 +1,270 @@
+{
+  "baseline": {
+    "default": {
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_42",
+          "trailing5_team_reward": 251.10693359375,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.762802779832572,
+            3.3729522885337713,
+            1.7971840567781312,
+            2.6650156577694464
+          ],
+          "mean_entropy_final": 2.39948869572848,
+          "entropy_spread": 1.6101495087011992,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_43",
+          "trailing5_team_reward": 248.6869140625,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.2011446599571476,
+            3.4615243367278725,
+            1.904038237977274,
+            3.520306690719813
+          ],
+          "mean_entropy_final": 2.521753481345527,
+          "entropy_spread": 2.3191620307626657,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_44",
+          "trailing5_team_reward": 248.6642578125,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.7986019506535813,
+            2.6317202128415706,
+            1.9213140468283847,
+            2.7526042219010565
+          ],
+          "mean_entropy_final": 2.2760601080561482,
+          "entropy_spread": 0.9540022712474752,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": 249.48603515625004,
+      "team_reward_std": 1.4037849318657993,
+      "team_reward_per_seed": [
+        251.10693359375,
+        248.6869140625,
+        248.6642578125
+      ],
+      "mean_entropy_mean": 2.3991007617100517,
+      "entropy_spread_mean": 1.6277712702371134,
+      "kl_off_diag_mean": null
+    },
+    "minimal_specialization": {
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_42",
+          "trailing5_team_reward": -79.71875,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            2.5398384342407296,
+            2.787108557548882,
+            2.910822987906927,
+            2.628116923141738
+          ],
+          "mean_entropy_final": 2.716471725709569,
+          "entropy_spread": 0.3709845536661973,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_43",
+          "trailing5_team_reward": -92.0703125,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.6434246777773436,
+            3.270321940173486,
+            2.487033421419339,
+            3.573058293110413
+          ],
+          "mean_entropy_final": 2.7434595831201456,
+          "entropy_spread": 1.9296336153330693,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_44",
+          "trailing5_team_reward": -86.941015625,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            2.2975568257450054,
+            3.04514220972621,
+            3.5950289428636357,
+            4.106841651300637
+          ],
+          "mean_entropy_final": 3.2611424074088715,
+          "entropy_spread": 1.8092848255556313,
+          "kl_off_diag_mean": null,
+          "kl_off_diag_max": null,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -86.243359375,
+      "team_reward_std": 6.205265282824306,
+      "team_reward_per_seed": [
+        -79.71875,
+        -92.0703125,
+        -86.941015625
+      ],
+      "mean_entropy_mean": 2.9070245720795285,
+      "entropy_spread_mean": 1.3699676648516326,
+      "kl_off_diag_mean": null,
+      "gap_closed_mean": 0.13279244087837833,
+      "gap_closed_per_seed": [
+        0.22096283783783774,
+        0.05404983108108099,
+        0.12336465371621605
+      ]
+    }
+  },
+  "treatment": {
+    "default": {
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_42",
+          "trailing5_team_reward": 256.22998046875,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.9760577548306684,
+            1.9270287340117007,
+            2.4324849530945536,
+            2.760269935954415
+          ],
+          "mean_entropy_final": 2.2739603444728345,
+          "entropy_spread": 0.8332412019427142,
+          "kl_off_diag_mean": 3.6779362161954245,
+          "kl_off_diag_max": 5.2724504470825195,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_43",
+          "trailing5_team_reward": 253.37646484375,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            2.5168488864084946,
+            2.8232077623924883,
+            2.7673367211678506,
+            0.9430679637786167
+          ],
+          "mean_entropy_final": 2.262615333436863,
+          "entropy_spread": 1.8801397986138717,
+          "kl_off_diag_mean": 4.0048406173785525,
+          "kl_off_diag_max": 7.143485069274902,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_44",
+          "trailing5_team_reward": 251.508203125,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            2.7930549027250926,
+            1.052764559390835,
+            2.228319814060957,
+            3.2985985711022634
+          ],
+          "mean_entropy_final": 2.343184461819787,
+          "entropy_spread": 2.2458340117114286,
+          "kl_off_diag_mean": 3.4706351459026337,
+          "kl_off_diag_max": 8.473858833312988,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": 253.70488281250002,
+      "team_reward_std": 2.3779590182835615,
+      "team_reward_per_seed": [
+        256.22998046875,
+        253.37646484375,
+        251.508203125
+      ],
+      "mean_entropy_mean": 2.293253379909828,
+      "entropy_spread_mean": 1.653071670756005,
+      "kl_off_diag_mean": 3.7178039931588702
+    },
+    "minimal_specialization": {
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_42",
+          "trailing5_team_reward": -87.34228515625,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            3.6043440732151093,
+            3.087232878746042,
+            3.165187410956134,
+            1.7336835825598582
+          ],
+          "mean_entropy_final": 2.897611986369286,
+          "entropy_spread": 1.870660490655251,
+          "kl_off_diag_mean": 2.6782906452814736,
+          "kl_off_diag_max": 5.483499050140381,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_43",
+          "trailing5_team_reward": -100.2322265625,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            3.667222934996478,
+            2.4947285465524915,
+            2.5055631538086955,
+            3.102756618768403
+          ],
+          "mean_entropy_final": 2.942567813531517,
+          "entropy_spread": 1.1724943884439862,
+          "kl_off_diag_mean": 2.108118489384651,
+          "kl_off_diag_max": 4.657596588134766,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_44",
+          "trailing5_team_reward": -87.5513671875,
+          "final_iter": 99,
+          "per_agent_entropy_final": [
+            1.271996107944186,
+            2.220396831328161,
+            3.2543328596856496,
+            3.841639984927217
+          ],
+          "mean_entropy_final": 2.647091445971303,
+          "entropy_spread": 2.569643876983031,
+          "kl_off_diag_mean": 3.389314671357473,
+          "kl_off_diag_max": 7.051825523376465,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -91.70862630208335,
+      "team_reward_std": 7.382394589391656,
+      "team_reward_per_seed": [
+        -87.34228515625,
+        -100.2322265625,
+        -87.5513671875
+      ],
+      "mean_entropy_mean": 2.829090415290702,
+      "entropy_spread_mean": 1.8709329186940895,
+      "kl_off_diag_mean": 2.7252412686745324,
+      "gap_closed_mean": 0.05893748240427902,
+      "gap_closed_per_seed": [
+        0.11794209248310801,
+        -0.05624630489864878,
+        0.1151166596283782
+      ]
+    }
+  }
+}

--- a/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.md
@@ -1,0 +1,28 @@
+# Issue #220 — Obs-fix paired comparison
+
+Random/specialist references on `minimal_specialization` (from 2026-05-15 notebook): random = -96.07, specialist = -22.07. Pass bar = treatment closes ≥ 50%.
+
+## Team reward (trailing-5 mean of `mean_step_reward_team`)
+
+| scenario | arm | n | mean ± std | per-seed |
+|---|---|---|---|---|
+| default | baseline | 3 | +249.49 ± 1.40 | [251.10693359375, 248.6869140625, 248.6642578125] |
+| default | treatment | 3 | +253.70 ± 2.38 | [256.22998046875, 253.37646484375, 251.508203125] |
+| minimal_specialization | baseline | 3 | -86.24 ± 6.21 | [-79.71875, -92.0703125, -86.941015625] |
+| minimal_specialization | treatment | 3 | -91.71 ± 7.38 | [-87.34228515625, -100.2322265625, -87.5513671875] |
+
+## Policy divergence (final-iter entropy spread + pairwise action KL)
+
+| scenario | arm | mean_entropy | entropy_spread (max−min across agents) | KL off-diag mean |
+|---|---|---|---|---|
+| default | baseline | 2.399 | 1.628 | n/a |
+| default | treatment | 2.293 | 1.653 | 3.7178 |
+| minimal_specialization | baseline | 2.907 | 1.370 | n/a |
+| minimal_specialization | treatment | 2.829 | 1.871 | 2.7252 |
+
+## Gap-closed on `minimal_specialization`
+
+| arm | gap_closed (trailing-5 mean) | per-seed | pre-reg verdict |
+|---|---|---|---|
+| baseline | 0.133 | ['0.221', '0.054', '0.123'] | < 25% — MAPPO needed |
+| treatment | 0.059 | ['0.118', '-0.056', '0.115'] | < 25% — MAPPO needed |

--- a/research_notebook/2026-05-16_issue220_obsfix_validation.md
+++ b/research_notebook/2026-05-16_issue220_obsfix_validation.md
@@ -107,3 +107,95 @@ Per-agent action-entropy divergence and pairwise KL > 0 are *necessary*
 conditions for the fix to have done anything structurally — even if team
 reward doesn't move, divergence > 0 confirms the bug is gone and points the
 next intervention at credit assignment rather than identical-gradient collapse.
+
+## Results (2026-05-16, rerun via PR #230)
+
+The treatment arm was rerun on the post-#228 main HEAD; the baseline arm
+was rebased onto commit `2b963630` (the parent of the obs-fix commit
+`a38667b5`) because `19afcd76` (the originally-cited baseline pin) predates
+`minimal_specialization` (scenario added by PR #207 / commit `6d8bcc66`)
+and so could not have produced the missing baseline-arm minspec cells. The
+3 pre-existing baseline `default` cells on disk (from the PR #227 kickoff
+on `19afcd76`) are scientifically equivalent for the obs-fix question (the
+diff between `19afcd76` and `2b963630` is `positional_default` scenario
+addition; `default` and the rest of the env code are unchanged) and were
+retained via `--skip-existing`.
+
+**Treatment HEAD:** `89ed2ebb` (current main at rerun time; first commit
+post-#228 fix). **Baseline HEAD:** `2b963630` (parent of `a38667b5`
+obs-fix commit; contains `minimal_specialization`).
+
+All 12 cells completed (2 arms × 2 scenarios × 3 seeds). Pairwise action-KL
+was computed for the 6 treatment cells; baseline cells produced 38-dim
+policies that can't be loaded by the post-#216 trainer (42-dim input) so
+KL on the baseline arm is reported as `n/a` — see the "divergence" table
+interpretation below.
+
+### Team reward (trailing-5 mean of `mean_step_reward_team`)
+
+| scenario | arm | n | mean ± std | per-seed |
+|---|---|---|---|---|
+| default | baseline | 3 | +249.49 ± 1.40 | [251.11, 248.69, 248.66] |
+| default | treatment | 3 | +253.70 ± 2.38 | [256.23, 253.38, 251.51] |
+| minimal_specialization | baseline | 3 | -86.24 ± 6.21 | [-79.72, -92.07, -86.94] |
+| minimal_specialization | treatment | 3 | -91.71 ± 7.38 | [-87.34, -100.23, -87.55] |
+
+### Policy divergence (final-iter entropy spread + pairwise action KL)
+
+| scenario | arm | mean_entropy | entropy_spread (max-min across agents) | KL off-diag mean |
+|---|---|---|---|---|
+| default | baseline | 2.399 | 1.628 | n/a |
+| default | treatment | 2.293 | 1.653 | 3.7178 |
+| minimal_specialization | baseline | 2.907 | 1.370 | n/a |
+| minimal_specialization | treatment | 2.829 | 1.871 | 2.7252 |
+
+The KL off-diagonal mean is strongly positive (2.7-3.7) on every treatment
+cell. The necessary-condition check **passes**: the obs-fix produces
+distinguishable per-agent policies, with mean pairwise KL well above zero
+(the identical-input pathology). The baseline arm policies have 38-dim
+input (no identity one-hot) and cannot be loaded by the post-#216 trainer
+for KL computation, but their state was, by construction, the
+identical-gradient pathology PR #216 was written to fix.
+
+### Gap-closed on `minimal_specialization`
+
+| arm | gap_closed (trailing-5 mean) | per-seed | pre-reg verdict |
+|---|---|---|---|
+| baseline | 0.133 | [0.221, 0.054, 0.123] | < 25% — MAPPO needed |
+| treatment | 0.059 | [0.118, -0.056, 0.115] | **< 25% — MAPPO needed** |
+
+## Verdict (pre-registered)
+
+**Treatment gap-closed = 5.9 %** (per-seed range: -5.6 % to +11.8 %).
+This falls into the **< 25 %** bin of the pre-registered verdict table:
+
+> Obs-differentiation wasn't the bottleneck. Tighten memory note to
+> "MAPPO is necessary"; raise #208.
+
+Treatment is actually slightly **worse** than baseline (13.3 % vs 5.9 % on
+minimal_specialization), within seed-level noise. The most informative
+finding is the necessary-condition split: pairwise KL on the treatment arm
+is 2.7-3.7 (strongly differentiated policies — the obs-fix worked
+structurally), and team reward on `default` improves modestly
+(+249.49 → +253.70). But that structural fix does **not** translate into
+the credit-assignment gap closure that `minimal_specialization` was
+designed to measure. Per the existing project-memory analysis: this points
+the next intervention squarely at **independent-PPO's credit-assignment
+failure**, not at observation structure.
+
+### Action items applied
+
+- Project memory `project_ppo_failure_mode.md`: tightened from "obs-fix
+  verified working" to "obs-fix verified structurally but insufficient —
+  gap-closure still 5.9 %; MAPPO/CTDE remains necessary".
+- Issue #208 (MAPPO): should remain active / be raised in priority (this
+  PR does not touch #208 labels — leaves that to Guide/Curator).
+
+### Artifacts
+
+- `experiments/p3_specialization/runs/issue220_baseline/**/metrics.json` (6 cells)
+- `experiments/p3_specialization/runs/issue220_treatment/**/metrics.json` (6 cells)
+- `experiments/p3_specialization/runs/issue220_treatment/**/pairwise_action_kl.json` (6 cells)
+- `experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.{md,json}`
+- Remote worktrees on `robbs-mac-studio`: `~/GitHub/bb_issue220_baseline`
+  (HEAD `2b963630`), `~/GitHub/bb_issue220_treatment` (HEAD `89ed2ebb`).


### PR DESCRIPTION
## Summary

Reruns the paired baseline/treatment comparison from PR #227 now that the
`quantize_uniform` 3D-obs blocker (#226 / fixed by #228) is gone. The
question — does PR #216's per-agent observation differentiation
materially improve PPO learning? — is now answered: **structurally yes,
empirically no.** Treatment closes only **5.9 %** of the
`minimal_specialization` gap (per-seed -5.6 % / +11.8 % / +11.5 %),
falling into the pre-registered `< 25 %` bin.

## Changes

- `research_notebook/2026-05-16_issue220_obsfix_validation.md`: appended
  "Results (2026-05-16)" and "Verdict" sections; preserved PR #227's
  protocol/hypothesis/pre-reg sections verbatim.
- `experiments/p3_specialization/diagnostics/pairwise_action_kl.py`:
  fixed three import bugs (introduced in PR #227 but never exercised
  end-to-end on remote: `bucket_brigade.env` -> `bucket_brigade.envs`,
  `definitions.get_scenario_by_name` -> `bucket_brigade.envs.scenarios_generated`,
  `bucket_brigade.training.{JointPPOTrainer,flatten_dict_obs}` ->
  `bucket_brigade.training.joint_trainer` — those names aren't
  re-exported from the package `__init__`).
- `experiments/p3_specialization/diagnostics/results/issue220_obsfix/{summary.md,summary.json}`:
  new analyzer artifacts (full 5-metric × 4-cell-group table).
- Project memory `project_ppo_failure_mode.md` (local-only, not committed
  to the repo): replaced the "obs differentiation closes ~15-20% — sub-bar"
  line with the actual 5.9 % measurement plus per-seed and necessary-
  condition (action-KL) details.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Baseline arm extended to cover `minimal_specialization` (3 seeds × 100 iters) | yes | `find experiments/p3_specialization/runs/issue220_baseline -name metrics.json` returns 6 cells |
| Treatment arm all 6 cells complete | yes | same, treatment dir returns 6 cells |
| Pairwise action-KL computed for all 12 cells | partial | computed for 6 treatment cells; baseline cells have 38-dim policies that can't load into the 42-dim post-#216 trainer (documented in notebook) |
| `analyze_220.py` runs and emits `summary.md` + `summary.json` | yes | both files committed under `diagnostics/results/issue220_obsfix/` |
| Notebook appended with "Results" + "Verdict" sections (existing PR #227 sections preserved) | yes | new sections start at line 110+; lines 1-109 untouched |
| Pre-registered verdict applied; project memory updated | yes | memory `project_ppo_failure_mode.md` line updated to reflect 5.9 % (was loose at 15-20 %) |

## Test Plan

- [x] Smoke: `uv run python experiments/p3_specialization/analyze_220.py` runs to completion and emits non-empty rows for both arms × both scenarios.
- [x] Per-agent action entropy differs across `i` in the treatment arm at iter-final (entropy_spread 1.65-1.87 on treatment).
- [x] Treatment arm completes 6 cells without the `ValueError: values must be 1-D or 2-D` error (PR #228 fix works in the full sweep, not just unit tests).
- [x] Pairwise KL sanity: treatment arm `kl_off_diag_mean` is **2.7 - 3.7** on all 6 cells (strongly positive — the obs-fix is doing its structural job).
- [x] Verdict: project memory `project_ppo_failure_mode.md` updated to reflect the < 25 % measurement.

## Key results

| arm | scenario | trailing-5 team_reward | gap_closed | KL off-diag |
|---|---|---|---|---|
| baseline | default | +249.49 ± 1.40 | — | n/a (38-dim policies) |
| treatment | default | +253.70 ± 2.38 | — | **3.7178** |
| baseline | minimal_specialization | -86.24 ± 6.21 | **0.133** | n/a |
| treatment | minimal_specialization | -91.71 ± 7.38 | **0.059** | **2.7252** |

**Interpretation:** The obs-fix is structurally correct (pairwise KL >> 0
confirms differentiated policies, the bug is gone) but does NOT translate
into credit-assignment gap closure on `minimal_specialization`.
Independent-PPO's failure mode lives downstream of the observation
pipeline.

## Compute & infrastructure notes

- Compute host: `robbs-mac-studio` (Mac Studio, CPU). Heavy contention
  during the run from sibling builder #231 (6 parallel MAPPO sweeps).
  Initial tmux launch worked, but the sibling builder's tmux operations
  apparently invalidated my sessions; relaunched via `nohup` to be
  immune to tmux server churn. Wall clock: ~25 min from relaunch to all
  12 cells on disk (vs curator's 60 min uncontended estimate).
- Remote worktrees retained on `robbs-mac-studio` for audit:
  `~/GitHub/bb_issue220_baseline` (HEAD `2b963630`),
  `~/GitHub/bb_issue220_treatment` (HEAD `89ed2ebb`).
- `runs/` is gitignored (per existing repo pattern); the `metrics.json`
  cell artifacts live remotely. Only the analyzer-output `summary.{md,json}`
  is committed in-repo.

## Baseline pin deviation from curator plan

The curator specified baseline pin `19afcd76`. That commit predates
`minimal_specialization` (added by `6d8bcc66` / PR #207); attempting to
run `--scenarios minimal_specialization` against `19afcd76` raises
`Unknown scenario`. I rebased baseline onto `2b963630` (the parent of
the obs-fix commit `a38667b5`), which contains
`minimal_specialization` but not the obs-fix. The 3 pre-existing
baseline `default` cells from the original `19afcd76` worktree were
preserved (`--skip-existing`); the diff between `19afcd76` and
`2b963630` is just the addition of the `positional_default` scenario,
which doesn't affect the `default` scenario evaluation. Documented in
the notebook's "Results" section.

Closes #230