### PR TITLE
feat(env): make signal a first-class action dimension

### DIFF
--- a/bucket-brigade-core/src/agents/heuristic.rs
+++ b/bucket-brigade-core/src/agents/heuristic.rs
@@ -38,6 +38,13 @@ impl HeuristicAgent {
     ///
     /// This implementation matches the Python `_heuristic_action` function
     /// in bucket_brigade/equilibrium/payoff_evaluator_rust.py:33-69
+    ///
+    /// Issue #235: returns a 3-element `[house, mode, signal]`. This Rust
+    /// HeuristicAgent doesn't currently model `honesty_bias` (param 0), so
+    /// it always signals honestly — `signal == mode`. The richer Python
+    /// `HeuristicAgent.act` in `bucket_brigade/agents/heuristic_agent.py`
+    /// *does* use `honesty_bias` and is the one to look at for the Liar
+    /// archetype's deceptive behavior.
     pub fn select_action<R: Rng>(&self, obs: &AgentObservation, rng: &mut R) -> Action {
         // Extract key parameters
         let work_tendency = self.params[1];
@@ -45,39 +52,37 @@ impl HeuristicAgent {
         let rest_reward_bias = self.params[8];
 
         // Decide whether to work or rest
-        if rng.gen::<f64>() < work_tendency * (1.0 - rest_reward_bias) {
-            // Work - choose which house
-            let owned_house = self.id % 10;
+        let (house, mode): (u8, u8) =
+            if rng.gen::<f64>() < work_tendency * (1.0 - rest_reward_bias) {
+                // Work - choose which house
+                let owned_house = self.id % 10;
 
-            // Check if owned house is burning and prioritize it
-            if obs.houses[owned_house] == 1 && rng.gen::<f64>() < own_house_priority {
-                // Work on owned house
-                [owned_house as u8, 1]
-            } else {
-                // Choose a burning house
-                let burning: Vec<usize> = obs
-                    .houses
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, &state)| state == 1)
-                    .map(|(idx, _)| idx)
-                    .collect();
-
-                let house = if !burning.is_empty() {
-                    // Pick random burning house
-                    burning[rng.gen_range(0..burning.len())]
+                // Check if owned house is burning and prioritize it
+                if obs.houses[owned_house] == 1 && rng.gen::<f64>() < own_house_priority {
+                    (owned_house as u8, 1)
                 } else {
-                    // No burning houses, go to owned house
-                    owned_house
-                };
+                    let burning: Vec<usize> = obs
+                        .houses
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, &state)| state == 1)
+                        .map(|(idx, _)| idx)
+                        .collect();
+                    let house = if !burning.is_empty() {
+                        burning[rng.gen_range(0..burning.len())]
+                    } else {
+                        owned_house
+                    };
+                    (house as u8, 1)
+                }
+            } else {
+                // Rest at owned house
+                let owned_house = self.id % 10;
+                (owned_house as u8, 0)
+            };
 
-                [house as u8, 1]
-            }
-        } else {
-            // Rest at owned house
-            let owned_house = self.id % 10;
-            [owned_house as u8, 0]
-        }
+        // Honest signal by default — signal == mode.
+        [house, mode, mode]
     }
 }
 
@@ -125,7 +130,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![0, 1, 0, 1, 0, 0, 0, 0, 0, 0], // Houses 1 and 3 burning
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,
@@ -154,7 +159,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![0, 1, 0, 0, 0, 0, 0, 0, 0, 0], // House 1 burning
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,
@@ -181,7 +186,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,
@@ -210,7 +215,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![1, 1, 1, 1, 0, 0, 0, 0, 0, 0], // Owned house (0) and others burning
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,
@@ -239,7 +244,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![0; 10], // No burning houses
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 3,
             night: 0,
@@ -265,7 +270,7 @@ mod tests {
             signals: vec![0; 4],
             locations: vec![0; 4],
             houses: vec![1; 10], // All houses burning
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,

--- a/bucket-brigade-core/src/engine/core.rs
+++ b/bucket-brigade-core/src/engine/core.rs
@@ -92,7 +92,7 @@ impl BucketBrigade {
             houses: vec![0; 10],
             agent_positions: vec![0; num_agents],
             agent_signals: vec![0; num_agents],
-            last_actions: vec![[0, 0]; num_agents],
+            last_actions: vec![[0, 0, 0]; num_agents],
             night: 0,
             done: false,
             rewards: vec![0.0; num_agents],
@@ -111,7 +111,7 @@ impl BucketBrigade {
         self.houses = vec![0; 10];
         self.agent_positions = vec![0; self.num_agents];
         self.agent_signals = vec![0; self.num_agents];
-        self.last_actions = vec![[0, 0]; self.num_agents];
+        self.last_actions = vec![[0, 0, 0]; self.num_agents];
         self.night = 0;
         self.done = false;
         self.rewards = vec![0.0; self.num_agents];
@@ -140,8 +140,12 @@ impl BucketBrigade {
         // Store previous house states for reward calculation
         let prev_houses = self.houses.clone();
 
-        // 1. Signal phase (signals are implicit in actions for now)
-        self.agent_signals = actions.iter().map(|action| action[1]).collect();
+        // 1. Signal phase (issue #235): signals are now a first-class action
+        // dimension. Each agent broadcasts `action[2]` independently of the
+        // work/rest bit `action[1]`, enabling deceptive signaling. Pre-#235
+        // this was `action[1]` (the work bit), so signals carried no
+        // information beyond the action itself.
+        self.agent_signals = actions.iter().map(|action| action[2]).collect();
 
         // 2. Action phase: update agent positions
         self.last_actions = actions.to_vec();

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -43,7 +43,7 @@ fn test_reset() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
     // Take some steps
-    let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
     engine.step(&actions);
     engine.step(&actions);
 
@@ -66,7 +66,7 @@ fn test_deterministic_with_seed() {
     assert_eq!(engine1.houses, engine2.houses);
 
     // And identical behavior
-    let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
     let result1 = engine1.step(&actions);
     let result2 = engine2.step(&actions);
 
@@ -80,7 +80,7 @@ fn test_step_advances_night() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
     let initial_night = engine.night;
-    let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
     engine.step(&actions);
 
     assert_eq!(engine.night, initial_night + 1);
@@ -92,7 +92,7 @@ fn test_work_vs_rest_rewards() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
     // All agents rest
-    let rest_actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let rest_actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     let result = engine.step(&rest_actions);
 
     // Resting gives +0.5 reward (plus other factors)
@@ -115,7 +115,7 @@ fn test_fire_extinguishing() {
     engine.houses[5] = 1;
 
     // Send all agents to work on it
-    let actions = vec![[5, 1], [5, 1], [5, 1], [5, 1]];
+    let actions = vec![[5, 1, 1], [5, 1, 1], [5, 1, 1], [5, 1, 1]];
 
     engine.step(&actions);
 
@@ -141,7 +141,7 @@ fn test_fire_spreads_to_neighbors() {
     engine.houses[5] = 1; // House 5 is burning
 
     // No one works (let it spread)
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     engine.step(&actions);
 
     // Neighbors (4 and 6) should catch fire with prob_fire_spreads_to_neighbor=1.0
@@ -161,7 +161,7 @@ fn test_burn_out_phase() {
     engine.houses[3] = 1;
 
     // Let it burn without intervention
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     engine.step(&actions);
 
     // Burning house should become ruined (unless extinguished, which is unlikely with no workers)
@@ -184,7 +184,7 @@ fn test_spontaneous_ignition() {
     engine.night = 0;
 
     // Step once - should create spontaneous ignitions
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     engine.step(&actions);
 
     // With prob_house_catches_fire=1.0, all safe houses should catch fire
@@ -204,7 +204,7 @@ fn test_continuous_spontaneous_ignition() {
     engine.houses = vec![0; 10];
 
     // Step multiple nights
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     for _ in 0..10 {
         engine.houses = vec![0; 10]; // Clear fires each round
         engine.step(&actions);
@@ -228,7 +228,7 @@ fn test_termination_all_safe() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
     engine.houses = vec![0; 10]; // All safe
 
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     let result = engine.step(&actions);
 
     assert!(result.done, "Game should end when all houses are safe");
@@ -242,7 +242,7 @@ fn test_termination_all_ruined() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
     engine.houses = vec![2; 10]; // All ruined
 
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     let result = engine.step(&actions);
 
     assert!(result.done, "Game should end when all houses are ruined");
@@ -256,7 +256,7 @@ fn test_minimum_nights_prevents_early_termination() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
     engine.houses = vec![0; 10]; // All safe
 
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
 
     // Step through 3 nights
     for _ in 0..3 {
@@ -285,7 +285,7 @@ fn test_trajectory_recording() {
     let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
-    let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
     engine.step(&actions);
     engine.step(&actions);
 
@@ -304,7 +304,7 @@ fn test_final_score_calculation() {
     let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
-    let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
     engine.step(&actions);
 
     let result = engine.get_result();
@@ -319,7 +319,7 @@ fn test_agent_positions_update() {
     let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
-    let actions = vec![[5, 1], [6, 1], [7, 1], [8, 1]];
+    let actions = vec![[5, 1, 1], [6, 1, 1], [7, 1, 1], [8, 1, 1]];
     engine.step(&actions);
 
     let state = engine.get_current_state();
@@ -328,14 +328,28 @@ fn test_agent_positions_update() {
 
 #[test]
 fn test_agent_signals_update() {
+    // Issue #235: signals are now action[2], independent of the work bit
+    // action[1]. This test pins the *decoupled* semantics: we construct
+    // agents whose broadcast signal differs from their actual mode, and
+    // assert the engine records the broadcast (action[2]) — not the mode.
     let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
-    let actions = vec![[0, 0], [1, 1], [2, 0], [3, 1]];
+    // [house, mode, signal] — agent 0 rests but signals work (a lie);
+    // agent 1 works but signals rest (a lie); agents 2/3 are honest.
+    let actions = vec![[0, 0, 1], [1, 1, 0], [2, 0, 0], [3, 1, 1]];
     engine.step(&actions);
 
     let state = engine.get_current_state();
-    assert_eq!(state.agent_signals, vec![0, 1, 0, 1]);
+    // Signals reflect the broadcast column, not the mode column.
+    assert_eq!(state.agent_signals, vec![1, 0, 0, 1]);
+    // And the broadcast differs from the work bit for the two liars
+    // (the whole point of issue #235 vs the deterministic-copy bug).
+    let work_bits: Vec<u8> = actions.iter().map(|a| a[1]).collect();
+    assert_ne!(
+        state.agent_signals, work_bits,
+        "Signal channel must be decoupled from the work/rest action bit"
+    );
 }
 
 #[test]
@@ -347,7 +361,7 @@ fn test_step_after_done_panics() {
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
     engine.houses = vec![0; 10];
 
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     engine.step(&actions);
 
     // Game should be done now, stepping again should panic
@@ -362,7 +376,7 @@ fn test_ownership_rewards() {
     // Agent 0 owns house 0, agent 1 owns house 1, etc.
     engine.houses = vec![0; 10]; // All safe
 
-    let actions = vec![[0, 0], [1, 0], [2, 0], [3, 0]];
+    let actions = vec![[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]];
     let result = engine.step(&actions);
 
     // Per-step rewards now include rest bonus + team rewards (all houses safe)
@@ -392,7 +406,7 @@ fn test_ownership_penalty() {
     engine.houses = vec![0; 10];
     engine.houses[0] = 2;
 
-    let actions = vec![[5, 0], [5, 0], [5, 0], [5, 0]];
+    let actions = vec![[5, 0, 0], [5, 0, 0], [5, 0, 0], [5, 0, 0]];
     let result = engine.step(&actions);
 
     // Per-step rewards now include rest, team rewards, and ownership penalties
@@ -480,7 +494,7 @@ fn test_large_population_step() {
     let mut engine = BucketBrigade::new(scenario, 20, Some(42));
 
     // Generate 20 actions (one per agent)
-    let actions: Vec<[u8; 2]> = (0..20).map(|i| [i % 10, 1]).collect();
+    let actions: Vec<[u8; 3]> = (0..20).map(|i| [i % 10, 1, 1]).collect();
 
     let result = engine.step(&actions);
 
@@ -500,7 +514,7 @@ fn test_population_scalability_all_sizes() {
         assert_eq!(engine.num_agents, num_agents);
 
         // Take one step
-        let actions: Vec<[u8; 2]> = (0..num_agents).map(|i| [(i % 10) as u8, 1]).collect();
+        let actions: Vec<[u8; 3]> = (0..num_agents).map(|i| [(i % 10) as u8, 1, 1]).collect();
         let result = engine.step(&actions);
 
         assert_eq!(result.rewards.len(), num_agents);
@@ -517,7 +531,7 @@ fn test_large_population_game_completion() {
     let max_steps = 100;
 
     while !engine.done && steps < max_steps {
-        let actions: Vec<[u8; 2]> = (0..15).map(|i| [(i % 10) as u8, 1]).collect();
+        let actions: Vec<[u8; 3]> = (0..15).map(|i| [(i % 10) as u8, 1, 1]).collect();
         engine.step(&actions);
         steps += 1;
     }
@@ -558,7 +572,7 @@ fn test_all_scenarios_steppable() {
     for (name, scenario) in SCENARIOS.iter() {
         let mut engine = BucketBrigade::new(scenario.clone(), 4, Some(42));
 
-        let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+        let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
         let result = engine.step(&actions);
 
         assert_eq!(result.rewards.len(), 4);
@@ -576,7 +590,7 @@ fn test_all_scenarios_steppable() {
 fn test_positional_default_engine_smoke() {
     let scenario = SCENARIOS.get("positional_default").unwrap().clone();
     let mut engine = BucketBrigade::new(scenario, 4, Some(42));
-    let actions = vec![[0u8, 1u8], [3, 1], [5, 1], [8, 1]];
+    let actions = vec![[0u8, 1u8, 1u8], [3, 1, 1], [5, 1, 1], [8, 1, 1]];
     let result = engine.step(&actions);
     assert_eq!(result.rewards.len(), 4);
     for &r in &result.rewards {
@@ -611,7 +625,7 @@ fn test_positional_default_distance_scales_cost() {
 
     // Agent 0 home is house 0. Agent 0 works house 5 (max ring distance 5).
     // All other agents rest (so their reward is +0.5 with no team component).
-    let actions = vec![[5u8, 1u8], [3, 0], [5, 0], [8, 0]];
+    let actions = vec![[5u8, 1u8, 1u8], [3, 0, 0], [5, 0, 0], [8, 0, 0]];
     let result = engine.step(&actions);
 
     // Expected for agent 0: -(base + alpha * 5) = -(0.5 + 0.5) = -1.0
@@ -642,7 +656,7 @@ fn test_zero_alpha_preserves_default_rewards() {
     let scenario = SCENARIOS.get("default").unwrap().clone();
     let mut engine_a = BucketBrigade::new(scenario.clone(), 4, Some(7));
     let mut engine_b = BucketBrigade::new(scenario, 4, Some(7));
-    let actions = vec![[0u8, 1u8], [4, 1], [9, 1], [2, 1]];
+    let actions = vec![[0u8, 1u8, 1u8], [4, 1, 1], [9, 1, 1], [2, 1, 1]];
     let r_a = engine_a.step(&actions).rewards;
     let r_b = engine_b.step(&actions).rewards;
     assert_eq!(r_a, r_b);
@@ -690,8 +704,8 @@ mod proptests {
                 if engine.done {
                     break;
                 }
-                let actions: Vec<[u8; 2]> = (0..num_agents)
-                    .map(|i| [(i % 10) as u8, 1])
+                let actions: Vec<[u8; 3]> = (0..num_agents)
+                    .map(|i| [(i % 10) as u8, 1, 1])
                     .collect();
                 engine.step(&actions);
             }
@@ -723,8 +737,8 @@ mod proptests {
             let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
             let mut engine = BucketBrigade::new(scenario.clone(), num_agents, Some(seed));
 
-            let actions: Vec<[u8; 2]> = (0..num_agents)
-                .map(|i| [(i % 10) as u8, 1])
+            let actions: Vec<[u8; 3]> = (0..num_agents)
+                .map(|i| [(i % 10) as u8, 1, 1])
                 .collect();
 
             let result = engine.step(&actions);
@@ -753,8 +767,8 @@ mod proptests {
             let max_steps = 200;
 
             while !engine.done && steps < max_steps {
-                let actions: Vec<[u8; 2]> = (0..num_agents)
-                    .map(|i| [(i % 10) as u8, 1])
+                let actions: Vec<[u8; 3]> = (0..num_agents)
+                    .map(|i| [(i % 10) as u8, 1, 1])
                     .collect();
                 engine.step(&actions);
                 steps += 1;
@@ -785,8 +799,8 @@ mod proptests {
                 if engine.done {
                     break;
                 }
-                let actions: Vec<[u8; 2]> = (0..num_agents)
-                    .map(|i| [(i % 10) as u8, 1])
+                let actions: Vec<[u8; 3]> = (0..num_agents)
+                    .map(|i| [(i % 10) as u8, 1, 1])
                     .collect();
                 engine.step(&actions);
 
@@ -804,8 +818,8 @@ mod proptests {
             let scenario = SCENARIOS.get("trivial_cooperation").unwrap().clone();
             let mut engine = BucketBrigade::new(scenario, num_agents, Some(seed));
 
-            let actions: Vec<[u8; 2]> = (0..num_agents)
-                .map(|i| [(i % 10) as u8, 1])
+            let actions: Vec<[u8; 3]> = (0..num_agents)
+                .map(|i| [(i % 10) as u8, 1, 1])
                 .collect();
 
             let result = engine.step(&actions);
@@ -847,7 +861,7 @@ mod proptests {
             let mut engine = BucketBrigade::new(scenario, 4, Some(42));
 
             // Should not panic with any valid probabilities
-            let actions = vec![[0, 1], [1, 1], [2, 1], [3, 1]];
+            let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 1, 1]];
             let result = engine.step(&actions);
 
             prop_assert_eq!(result.rewards.len(), 4);

--- a/bucket-brigade-core/src/lib.rs
+++ b/bucket-brigade-core/src/lib.rs
@@ -18,8 +18,18 @@ pub use scenarios::{Scenario, SCENARIOS};
 /// House states: 0 = Safe, 1 = Burning, 2 = Ruined
 pub type HouseState = u8;
 
-/// Agent actions: [house_index, mode] where mode is 0=REST, 1=WORK
-pub type Action = [u8; 2];
+/// Agent actions: [house_index, mode, signal] (issue #235).
+///
+/// * `action[0]` — house to visit (0..10)
+/// * `action[1]` — mode: 0=REST, 1=WORK (the action actually taken)
+/// * `action[2]` — signal: 0=REST, 1=WORK (the broadcast intent, may differ
+///   from `action[1]` — i.e. the agent can lie about its intended action)
+///
+/// Prior to #235 this was a 2-element array `[house, mode]` and the engine
+/// derived the signal deterministically from the mode bit. Making the signal
+/// a first-class action dimension is what enables deception research; honest
+/// agents simply set `action[2] == action[1]`.
+pub type Action = [u8; 3];
 
 /// Represents a single night in the game
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,7 +79,9 @@ impl RandomAgent {
 
 impl Agent for RandomAgent {
     fn act(&self, _obs: &AgentObservation) -> Action {
-        [rand::random::<u8>() % 10, rand::random::<u8>() % 2]
+        let mode = rand::random::<u8>() % 2;
+        // Default: honest random — signal matches mode.
+        [rand::random::<u8>() % 10, mode, mode]
     }
 
     fn reset(&mut self) {}
@@ -101,7 +113,7 @@ mod tests {
             signals: vec![0, 0, 0, 0],
             locations: vec![0, 0, 0, 0],
             houses: vec![0; 10],
-            last_actions: vec![[0, 0]; 4],
+            last_actions: vec![[0, 0, 0]; 4],
             scenario_info: vec![0.0; 10],
             agent_id: 0,
             night: 0,
@@ -112,6 +124,7 @@ mod tests {
             let action = agent.act(&obs);
             assert!(action[0] < 10, "House index should be < 10");
             assert!(action[1] < 2, "Mode should be 0 or 1");
+            assert!(action[2] < 2, "Signal should be 0 or 1");
         }
     }
 
@@ -128,7 +141,7 @@ mod tests {
             signals: vec![0, 1, 0, 1],
             locations: vec![3, 5, 7, 9],
             houses: vec![0, 1, 2, 0, 0, 1, 2, 0, 0, 1],
-            last_actions: vec![[0, 0], [1, 1], [2, 0], [3, 1]],
+            last_actions: vec![[0, 0, 0], [1, 1, 1], [2, 0, 0], [3, 1, 1]],
             scenario_info: vec![0.15, 0.9, 100.0, 100.0, 0.5, 0.1, 12.0, 0.0, 12.0, 4.0],
             agent_id: 2,
             night: 5,
@@ -148,7 +161,7 @@ mod tests {
             signals: vec![0, 1],
             locations: vec![3, 5],
             houses: vec![0; 10],
-            last_actions: vec![[0, 0], [1, 1]],
+            last_actions: vec![[0, 0, 0], [1, 1, 1]],
             scenario_info: vec![0.15, 0.9, 100.0, 100.0, 0.5, 0.1, 12.0, 0.0, 12.0, 2.0],
             agent_id: 0,
             night: 1,
@@ -169,7 +182,7 @@ mod tests {
             houses: vec![0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
             signals: vec![0, 1, 0, 1],
             locations: vec![2, 3, 4, 5],
-            actions: vec![[2, 1], [3, 1], [4, 0], [5, 1]],
+            actions: vec![[2, 1, 1], [3, 1, 1], [4, 0, 0], [5, 1, 1]],
             rewards: vec![1.5, 2.0, 0.5, -0.5],
         };
 
@@ -188,7 +201,7 @@ mod tests {
             houses: vec![0; 10],
             signals: vec![0; 4],
             locations: vec![0; 4],
-            actions: vec![[0, 0]; 4],
+            actions: vec![[0, 0, 0]; 4],
             rewards: vec![0.0; 4],
         };
 
@@ -211,9 +224,10 @@ mod tests {
 
     #[test]
     fn test_action_type() {
-        let action: Action = [5, 1];
+        let action: Action = [5, 1, 0];
         assert_eq!(action[0], 5); // House index
         assert_eq!(action[1], 1); // Mode (work)
+        assert_eq!(action[2], 0); // Signal (rest — i.e. a lie about working)
     }
 
     #[test]

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -26,7 +26,19 @@ impl PyBucketBrigade {
     }
 
     fn step(&mut self, py: Python, actions: Vec<Vec<u8>>) -> PyResult<(PyObject, bool, PyObject)> {
-        let rust_actions: Vec<[u8; 2]> = actions.iter().map(|a| [a[0], a[1]]).collect();
+        // Issue #235: action is [house, mode, signal] (length 3). For
+        // backward compatibility we accept length-2 inputs and default the
+        // signal to the mode bit (honest signaling) so existing Python
+        // callers that haven't been migrated yet keep working. Length-3
+        // inputs pass through unchanged.
+        let rust_actions: Vec<[u8; 3]> = actions
+            .iter()
+            .map(|a| match a.len() {
+                2 => [a[0], a[1], a[1]],
+                3 => [a[0], a[1], a[2]],
+                _ => [a[0], a.get(1).copied().unwrap_or(0), a.get(2).copied().unwrap_or(0)],
+            })
+            .collect();
 
         let result = self.inner.step(&rust_actions);
 
@@ -244,6 +256,13 @@ impl PyAgentObservation {
     }
     #[getter]
     fn last_actions(&self, py: Python) -> PyObject {
+        // Issue #235: the engine Action is now [house, mode, signal]
+        // (length 3), but this getter keeps the legacy length-2
+        // [house, mode] shape so the obs vector width is unchanged and
+        // trained policies from PRs #216/#225 stay structurally
+        // loadable. The broadcast signal is exposed separately via the
+        // ``signals`` getter (length num_agents), so no information is
+        // hidden — only deduplicated.
         let actions: Vec<Vec<u8>> = self
             .inner
             .last_actions
@@ -255,6 +274,8 @@ impl PyAgentObservation {
 
     #[getter]
     fn actions(&self, py: Python) -> PyObject {
+        // See ``last_actions`` getter above for the [house, mode] vs
+        // [house, mode, signal] decision.
         let actions: Vec<Vec<u8>> = self
             .inner
             .last_actions
@@ -347,7 +368,7 @@ impl PyGameResult {
                     night
                         .actions
                         .iter()
-                        .map(|a| vec![a[0], a[1]])
+                        .map(|a| vec![a[0], a[1], a[2]])
                         .collect::<Vec<Vec<u8>>>(),
                 )
                 .unwrap();
@@ -398,7 +419,10 @@ impl PyVectorEnv {
     /// Step all environments with given actions
     ///
     /// Args:
-    ///     actions: List of actions, shape (num_envs, 2) where each action is [house_id, mode]
+    ///     actions: List of actions, shape (num_envs, 3) where each action is
+    ///         [house_id, mode, signal] (issue #235). Length-2 inputs are
+    ///         accepted for backward compatibility and default the signal to
+    ///         the mode bit (honest signaling).
     ///
     /// Returns:
     ///     Tuple of (observations, rewards, dones, infos) where each is batched
@@ -420,13 +444,17 @@ impl PyVectorEnv {
 
         // Step each environment
         for (env, action) in self.envs.iter_mut().zip(actions.iter()) {
-            if action.len() != 2 {
+            // Issue #235: accept length-2 (legacy, honest default) or
+            // length-3 (post-#235, explicit signal) action shapes.
+            if action.len() != 2 && action.len() != 3 {
                 return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Each action must have exactly 2 elements [house_id, mode]",
+                    "Each action must have 2 (legacy [house, mode]) or 3 \
+                     ([house, mode, signal]) elements",
                 ));
             }
 
-            let rust_action = [action[0], action[1]];
+            let signal = if action.len() == 3 { action[2] } else { action[1] };
+            let rust_action = [action[0], action[1], signal];
             let result = env.step(&[rust_action]);
 
             all_rewards.push(result.rewards[0]); // Get reward for agent 0
@@ -492,7 +520,17 @@ fn obs_to_vector(obs: &AgentObservation) -> Vec<f32> {
     // Add houses (num_agents elements)
     vec.extend(obs.houses.iter().map(|&x| x as f32));
 
-    // Add flattened last_actions (num_agents * 2 elements)
+    // Add flattened last_actions (num_agents * 2 elements).
+    //
+    // Issue #235 note: per the curator's recommendation we keep
+    // last_actions at length 2 (house + mode) here even though the
+    // underlying Action is now length 3. The signal channel is already
+    // exposed via ``obs.signals`` (length num_agents), so duplicating it
+    // here would just widen the obs vector without adding information.
+    // Keeping the width unchanged means trained policies from PRs #216
+    // and #225 still load structurally, though their *semantics* are
+    // stale (signals now carry real bits, so the learned filters are
+    // operating on a different signal distribution).
     for action in &obs.last_actions {
         vec.push(action[0] as f32);
         vec.push(action[1] as f32);
@@ -573,8 +611,8 @@ fn run_heuristic_episode(
         let observations: Vec<AgentObservation> =
             (0..num_agents).map(|id| game.get_observation(id)).collect();
 
-        // Get actions from heuristic agents
-        let actions: Vec<[u8; 2]> = observations
+        // Get actions from heuristic agents (issue #235: 3-element Action)
+        let actions: Vec<[u8; 3]> = observations
             .iter()
             .enumerate()
             .map(|(id, obs)| agents[id].select_action(obs, &mut rng))

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -26,8 +26,23 @@ impl WasmBucketBrigade {
 
     #[wasm_bindgen]
     pub fn step(&mut self, actions_json: &str) -> Result<String, JsValue> {
-        let actions: Vec<[u8; 2]> = serde_json::from_str(actions_json)
-            .map_err(|e| JsValue::from_str(&format!("Failed to parse actions: {}", e)))?;
+        // Issue #235: action vector is [house, mode, signal] (length 3).
+        // For backward compat with already-deployed frontends we first try
+        // to deserialize the post-#235 length-3 form; if that fails, we
+        // fall back to the legacy length-2 form and promote it to length-3
+        // by copying the mode bit into the signal slot (honest default).
+        // JavaScript callers should migrate to the length-3 form so they
+        // can emit deceptive signals; the fallback is purely transitional.
+        let actions: Vec<[u8; 3]> = match serde_json::from_str::<Vec<[u8; 3]>>(actions_json) {
+            Ok(a) => a,
+            Err(_) => {
+                let legacy: Vec<[u8; 2]> =
+                    serde_json::from_str(actions_json).map_err(|e| {
+                        JsValue::from_str(&format!("Failed to parse actions: {}", e))
+                    })?;
+                legacy.into_iter().map(|a| [a[0], a[1], a[1]]).collect()
+            }
+        };
 
         let result = self.inner.step(&actions);
 

--- a/bucket_brigade/agents/agent_base.py
+++ b/bucket_brigade/agents/agent_base.py
@@ -48,10 +48,14 @@ class AgentBase(ABC):
                 - "scenario_info": np.ndarray[float32], shape (k,), scenario vector
 
         Returns:
-            Action as np.ndarray[int8], shape (2,):
-                [house_index, mode_flag]
-                - house_index ∈ [0..9]
-                - mode_flag ∈ {0=REST, 1=WORK}
+            Action as np.ndarray[int8], shape (3,) per issue #235:
+                ``[house_index, mode_flag, signal]``
+                - ``house_index`` in [0..9]
+                - ``mode_flag`` in {0=REST, 1=WORK} — the action actually taken
+                - ``signal`` in {0=REST, 1=WORK} — the broadcast intent
+                  (may differ from ``mode_flag``; i.e. a lie)
+
+            Honest agents simply emit ``signal == mode_flag``.
         """
         pass
 
@@ -68,7 +72,16 @@ class RandomAgent(AgentBase):
     def act(self, obs: Dict[str, np.ndarray]) -> np.ndarray:
         """
         Choose a random house and random mode (work/rest).
+
+        Issue #235: the random baseline is **honest** by default —
+        ``signal == mode_flag``. A truly random-over-the-full-action-space
+        baseline would lie 25% of the time, which is research-meaningful;
+        keeping the random baseline honest preserves the prior-PR semantic
+        of "uniform-random house, uniform-random mode" and isolates the
+        signal channel as a deliberate degree of freedom available to
+        strategic agents.
         """
         house_index = np.random.randint(0, 10)  # Random house 0-9
         mode_flag = np.random.randint(0, 2)  # Random mode 0=REST, 1=WORK
-        return np.array([house_index, mode_flag], dtype=np.int8)
+        signal = int(mode_flag)  # Honest signal — see docstring above.
+        return np.array([house_index, mode_flag, signal], dtype=np.int8)

--- a/bucket_brigade/agents/heuristic_agent.py
+++ b/bucket_brigade/agents/heuristic_agent.py
@@ -55,7 +55,12 @@ class HeuristicAgent(AgentBase):
         Choose action based on observations and parameters.
 
         Returns:
-            Action [house_index, mode_flag]
+            Action ``[house_index, mode_flag, signal]`` (issue #235).
+            The signal is broadcast independently of the actual mode; for
+            archetypes with ``honesty_bias == 1.0`` the signal always
+            matches the mode (honest), and for ``honesty_bias < 1.0`` the
+            signal can disagree with the mode (deception). The Liar
+            archetype (``honesty_bias = 0.1``) lies roughly 90% of the time.
         """
         # Extract observation components
         signals = obs["signals"]  # (N,) - current signals
@@ -67,7 +72,11 @@ class HeuristicAgent(AgentBase):
         # Determine owned house
         owned_house = self.agent_id % 10
 
-        # 1. Signal selection (internal intent)
+        # 1. Signal selection (broadcast intent)
+        # Pre-#235 this signal was computed and then thrown away — the engine
+        # used the deterministic copy of the work bit instead. Now it is
+        # emitted as ``action[2]`` so deceptive signals (``signal != mode``)
+        # actually reach other agents through the obs.signals channel.
         work_intent = self._compute_work_intent(houses, scenario_info)
         signal = self._choose_signal(work_intent)
 
@@ -89,7 +98,7 @@ class HeuristicAgent(AgentBase):
         # Store for next time
         self.last_action = (house_choice, mode_choice)
 
-        return np.array([house_choice, mode_choice], dtype=np.int8)
+        return np.array([house_choice, mode_choice, signal], dtype=np.int8)
 
     def _compute_work_intent(
         self, houses: np.ndarray, scenario_info: np.ndarray

--- a/bucket_brigade/agents/scenario_optimal/chain_reaction_coordinator.py
+++ b/bucket_brigade/agents/scenario_optimal/chain_reaction_coordinator.py
@@ -29,19 +29,19 @@ class ChainReactionCoordinator(AgentBase):
         burning_houses = set(np.where(houses == 1)[0])
 
         if not burning_houses:
-            return np.array([self.own_house, 0])  # Rest if no fires
+            return np.array([self.own_house, 0, 0])  # Rest if no fires
 
         # Find fire clusters (connected components)
         clusters = self._find_fire_clusters(houses, burning_houses)
 
         if not clusters:
-            return np.array([self.own_house, 0])
+            return np.array([self.own_house, 0, 0])
 
         # Choose cluster to work on (prioritize larger or more spread-risk clusters)
         target_cluster = self._select_best_cluster(clusters, houses)
         target_house = target_cluster[0]  # Work on first house in cluster
 
-        return np.array([target_house, 1])  # Work
+        return np.array([target_house, 1, 1])  # Work
 
     def _find_fire_clusters(
         self, houses: np.ndarray, burning_houses: set

--- a/bucket_brigade/agents/scenario_optimal/early_containment.py
+++ b/bucket_brigade/agents/scenario_optimal/early_containment.py
@@ -41,11 +41,11 @@ class EarlyContainmentAgent(AgentBase):
         if len(burning_houses) > 0:
             # Work on burning houses, prioritizing clusters
             target_house = self._select_best_burning_house(houses, burning_houses)
-            return np.array([target_house, 1])  # [house, WORK]
+            return np.array([target_house, 1, 1])  # [house, WORK]
         else:
             # No fires - rest to save costs for potential future fires
             own_house = self.agent_id % 10
-            return np.array([own_house, 0])  # [house, REST]
+            return np.array([own_house, 0, 0])  # [house, REST]
 
     def _select_best_burning_house(
         self, houses: np.ndarray, burning_houses: np.ndarray

--- a/bucket_brigade/agents/scenario_optimal/greedy_neighbor.py
+++ b/bucket_brigade/agents/scenario_optimal/greedy_neighbor.py
@@ -31,7 +31,7 @@ class GreedyNeighborAgent(AgentBase):
 
         # Check if own house is burning
         if houses[self.own_house] == 1:
-            return np.array([self.own_house, 1])  # Work on own house
+            return np.array([self.own_house, 1, 1])  # Work on own house
 
         # Check if neighbor houses are burning (could spread to you)
         neighbors = [(self.own_house - 1) % 10, (self.own_house + 1) % 10]
@@ -44,7 +44,7 @@ class GreedyNeighborAgent(AgentBase):
             )  # Work on first threatening neighbor
 
         # No immediate threats - rest to save costs
-        return np.array([self.own_house, 0])  # Rest at own house
+        return np.array([self.own_house, 0, 0])  # Rest at own house
 
 
 # For agent submission system

--- a/bucket_brigade/agents/scenario_optimal/honest_signaler.py
+++ b/bucket_brigade/agents/scenario_optimal/honest_signaler.py
@@ -51,10 +51,10 @@ class HonestSignaler(AgentBase):
             target_house = new_fires[0] if new_fires else burning_houses[0]
 
             # Honest signaling: signal matches action
-            return np.array([target_house, 1])  # Signal WORK, work
+            return np.array([target_house, 1, 1])  # Signal WORK, work
         else:
             # No fires - rest honestly
-            return np.array([self.own_house, 0])  # Signal REST, rest
+            return np.array([self.own_house, 0, 0])  # Signal REST, rest
 
 
 # For agent submission system

--- a/bucket_brigade/agents/scenario_optimal/rest_trap_adaptive.py
+++ b/bucket_brigade/agents/scenario_optimal/rest_trap_adaptive.py
@@ -57,10 +57,10 @@ class RestTrapAdaptiveAgent(AgentBase):
         if persistent_fires:
             # Emergency: work on persistent fire
             target_house = persistent_fires[0]  # Work on first persistent fire
-            return np.array([target_house, 1])  # Work
+            return np.array([target_house, 1, 1])  # Work
         else:
             # Normal case: rest and let fires extinguish naturally
-            return np.array([self.own_house, 0])  # Rest
+            return np.array([self.own_house, 0, 0])  # Rest
 
 
 # For agent submission system

--- a/bucket_brigade/agents/scenario_optimal/sparse_hero.py
+++ b/bucket_brigade/agents/scenario_optimal/sparse_hero.py
@@ -32,19 +32,19 @@ class SparseHeroAgent(AgentBase):
 
         # If no fires, rest
         if burning_count == 0:
-            return np.array([self.own_house, 0])  # Rest
+            return np.array([self.own_house, 0, 0])  # Rest
 
         # If fires exist, work on the most critical one
         burning_houses = np.where(houses == 1)[0]
 
         # Prioritize own house if burning
         if houses[self.own_house] == 1:
-            return np.array([self.own_house, 1])
+            return np.array([self.own_house, 1, 1])
 
         # Otherwise work on first burning house (simple strategy)
         # In a more sophisticated version, could consider distance or cluster size
         target_house = burning_houses[0]
-        return np.array([target_house, 1])  # Work on fire
+        return np.array([target_house, 1, 1])  # Work on fire
 
 
 # For agent submission system

--- a/bucket_brigade/agents/scenario_optimal/trivial_cooperator.py
+++ b/bucket_brigade/agents/scenario_optimal/trivial_cooperator.py
@@ -33,11 +33,11 @@ class TrivialCooperator(AgentBase):
         if len(burning_houses) > 0:
             # Work on first burning house
             target_house = burning_houses[0]
-            return np.array([target_house, 1])  # [house, WORK]
+            return np.array([target_house, 1, 1])  # [house, WORK]
         else:
             # No fires, work on own house (house index = agent_id % 10)
             own_house = self.agent_id % 10
-            return np.array([own_house, 1])  # [house, WORK]
+            return np.array([own_house, 1, 1])  # [house, WORK]
 
 
 # For agent submission system

--- a/bucket_brigade/baselines/specialist.py
+++ b/bucket_brigade/baselines/specialist.py
@@ -77,8 +77,10 @@ def specialist_action(
     Returns
     -------
     np.ndarray
-        Length-2 ``int64`` array ``[house_idx, mode]`` matching the
-        ``MultiDiscrete([num_houses, 2])`` action space.
+        Length-3 ``int64`` array ``[house_idx, mode, signal]`` matching the
+        ``MultiDiscrete([num_houses, 2, 2])`` action space (issue #235).
+        The specialist signals honestly (``signal == mode``); it has no
+        reason to lie because its policy is deterministic from the obs.
 
     Policy
     ------
@@ -105,12 +107,13 @@ def specialist_action(
         # Defensive: with round-robin ownership and num_agents <= num_houses
         # every agent owns at least one house. Fall back to house 0 + REST
         # rather than raise, so this function never errors on a well-formed obs.
-        return np.array([0, _REST], dtype=np.int64)
+        # Honest signaling: signal == mode (issue #235).
+        return np.array([0, _REST, _REST], dtype=np.int64)
 
     burning_owned = owned[houses[owned] == _BURNING]
     if burning_owned.size > 0:
-        return np.array([int(burning_owned[0]), _WORK], dtype=np.int64)
-    return np.array([int(owned[0]), _REST], dtype=np.int64)
+        return np.array([int(burning_owned[0]), _WORK, _WORK], dtype=np.int64)
+    return np.array([int(owned[0]), _REST, _REST], dtype=np.int64)
 
 
 def specialist_action_joint(
@@ -120,8 +123,9 @@ def specialist_action_joint(
 ) -> np.ndarray:
     """Compute joint specialist actions for all agents.
 
-    Returns an ``(num_agents, 2)`` ``int64`` array suitable for passing
-    directly to :meth:`BucketBrigadeEnv.step`.
+    Returns an ``(num_agents, 3)`` ``int64`` array suitable for passing
+    directly to :meth:`BucketBrigadeEnv.step` (issue #235: post-#235 the
+    action shape is ``[house, mode, signal]``).
     """
     return np.stack(
         [

--- a/bucket_brigade/diagnostics/__init__.py
+++ b/bucket_brigade/diagnostics/__init__.py
@@ -84,7 +84,7 @@ def random_init_rollout_stats(
 
     Hermetic version of the H1 diagnostic — no ``/tmp/h1_cell`` dependency.
     Builds a ``JointPPOTrainer`` with the canonical phase-3 hyperparameters
-    (``hidden_size=64``, ``num_agents=4``, ``action_dims=[10, 2]``) and runs
+    (``hidden_size=64``, ``num_agents=4``, ``action_dims=[10, 2, 2]``) and runs
     ``trainer.collect_rollout(rollout_steps)``. Returns the per-step reward
     matrix, action matrix, and per-agent stats dicts.
 
@@ -141,7 +141,7 @@ def random_init_rollout_stats(
         env_fn=env_fn,
         num_agents=num_agents,
         obs_dim=obs_dim,
-        action_dims=[10, 2],
+        action_dims=[10, 2, 2],  # [house, mode, signal] (issue #235)
         hidden_size=hidden_size,
         seed=seed,
     )
@@ -156,7 +156,12 @@ def random_init_rollout_stats(
         r = R[i]
         a = A[i]
         stats = per_agent_reward_stats(r)
-        packed = a[:, 0] * 2 + a[:, 1]  # 10 houses × {rest, work}
+        # Issue #235: pack [house, mode, signal] into 0..39 for R^2 keying.
+        # Defensive fallback for legacy 2-element actions (signal := mode).
+        if a.shape[-1] >= 3:
+            packed = a[:, 0] * 4 + a[:, 1] * 2 + a[:, 2]
+        else:
+            packed = a[:, 0] * 4 + a[:, 1] * 2 + a[:, 1]
         stats["r2_packed"] = float(conditional_mean_r2(r, packed))
         stats["r2_work"] = float(conditional_mean_r2(r, a[:, 1]))
         per_agent.append(stats)

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -49,9 +49,15 @@ class BucketBrigadeEnv:
         self.signals = np.zeros(
             self.num_agents, dtype=np.int8
         )  # Agent signals: REST, WORK
+        # Issue #235 note: action is now [house, mode, signal] (length 3).
+        # But the obs vector ``last_actions`` width stays 2 (house, mode)
+        # per the curator's recommendation — the broadcast signal is
+        # already exposed through obs.signals, so widening last_actions
+        # would just add a redundant feature column. We slice the signal
+        # off before storing into ``last_actions``.
         self.last_actions = np.zeros(
             (self.num_agents, 2), dtype=np.int8
-        )  # [house, mode]
+        )  # [house, mode] — signal lives in self.signals
 
         # Game state
         self.night = 0
@@ -115,6 +121,7 @@ class BucketBrigadeEnv:
         # Initialize agent positions and signals
         self.locations = np.zeros(self.num_agents, dtype=np.int8)
         self.signals = np.zeros(self.num_agents, dtype=np.int8)
+        # Issue #235: keep last_actions width 2 in obs (see __init__ comment).
         self.last_actions = np.zeros((self.num_agents, 2), dtype=np.int8)
 
         # Record initial state
@@ -129,7 +136,10 @@ class BucketBrigadeEnv:
         Execute one night of the game.
 
         Args:
-            actions: Per-agent actions, shape (N, 2) with [house_index, mode_flag]
+            actions: Per-agent actions, shape (N, 3) with
+                ``[house_index, mode_flag, signal]`` (issue #235). Length-2
+                inputs are accepted for backward compatibility and treated
+                as honest (``signal := mode_flag``).
 
         Returns:
             observation, rewards, dones, info
@@ -137,12 +147,24 @@ class BucketBrigadeEnv:
         if self.done:
             raise RuntimeError("Game is already finished")
 
-        # 1. Signal phase (signals are implicit in actions for now)
-        # In this simplified version, we assume agents signal their intended mode
-        self.signals = actions[:, 1].copy()  # mode_flag becomes the signal
+        # Accept legacy length-2 actions by promoting them to honest
+        # length-3 actions (signal == mode_flag). This keeps any external
+        # caller that still emits the pre-#235 shape working.
+        if actions.shape[1] == 2:
+            signal_col = actions[:, 1:2]
+            actions = np.concatenate([actions, signal_col], axis=1)
 
-        # 2. Action phase: update agent locations
-        self.last_actions = actions.copy()
+        # 1. Signal phase (issue #235): signals are now their own action
+        # dimension. Pre-#235 ``self.signals = actions[:, 1]`` made the
+        # signal a deterministic copy of the work bit; now agents can
+        # broadcast independently of their mode (e.g. lie).
+        self.signals = actions[:, 2].copy()
+
+        # 2. Action phase: update agent locations.
+        # Issue #235: store only ``[house, mode]`` in last_actions to keep
+        # the obs vector width unchanged (the broadcast signal is
+        # already exposed via ``self.signals``).
+        self.last_actions = actions[:, :2].copy()
         self.locations = actions[:, 0].copy()
 
         # 3. Extinguish phase

--- a/bucket_brigade/envs/puffer_env.py
+++ b/bucket_brigade/envs/puffer_env.py
@@ -73,8 +73,11 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
             low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float32
         )
 
-        # Action: [house_index, mode] where house_index ∈ [0,9], mode ∈ [0,1]
-        self.single_action_space = gym_spaces.MultiDiscrete([10, 2])
+        # Action: [house_index, mode, signal] (issue #235) where
+        # house_index in [0,9], mode in {0=REST, 1=WORK}, signal in
+        # {0=REST, 1=WORK}. The signal is broadcast independently of the
+        # mode; honest agents emit ``signal == mode``.
+        self.single_action_space = gym_spaces.MultiDiscrete([10, 2, 2])
 
         # Initialize PufferEnv (sets up buffers and joint spaces)
         # PufferLib's __init__ will call set_buffers() which assigns directly to attributes
@@ -131,13 +134,20 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
 
         self.steps_taken += 1
 
-        # Convert action to [house, mode] format
-        # Action comes as array from MultiDiscrete space
+        # Convert action to [house, mode, signal] format (issue #235).
+        # Action comes as array from MultiDiscrete space. Length-2 actions
+        # are accepted for backward compatibility and default to honest
+        # signaling (signal := mode).
         if len(action.shape) > 1:
             # If batched, take first element
-            agent_action = [int(action[0][0]), int(action[0][1])]
+            a = action[0]
         else:
-            agent_action = [int(action[0]), int(action[1])]
+            a = action
+        if len(a) >= 3:
+            agent_action = [int(a[0]), int(a[1]), int(a[2])]
+        else:
+            mode = int(a[1])
+            agent_action = [int(a[0]), mode, mode]
 
         # Get actions from all agents
         all_actions = [agent_action]  # Trained agent first
@@ -242,7 +252,8 @@ class PufferBucketBrigadeVectorized(PufferBucketBrigade):
             low=-np.inf, high=np.inf, shape=(num_envs, obs_size), dtype=np.float32
         )
 
-        self.action_space = gym_spaces.MultiDiscrete([num_envs, 10, 2])
+        # Issue #235: 3-element [house, mode, signal] action.
+        self.action_space = gym_spaces.MultiDiscrete([num_envs, 10, 2, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/bucket_brigade/envs/puffer_env_rust.py
+++ b/bucket_brigade/envs/puffer_env_rust.py
@@ -22,8 +22,14 @@ def _heuristic_action(
     obs_dict: dict[str, np.ndarray],
     agent_id: int,
     rng: np.random.Generator,
-) -> np.ndarray:
-    """Simplified heuristic action selection for opponent agents."""
+) -> list[int]:
+    """Simplified heuristic action selection for opponent agents.
+
+    Issue #235: returns a 3-element ``[house, mode, signal]``. This helper
+    is the opponent-agent fast-path and defaults to honest signaling
+    (``signal == mode``); the full Python ``HeuristicAgent.act`` is what
+    drives the Liar archetype's deceptive behavior.
+    """
     work_tendency = theta[1]
     own_house_priority = theta[3]
     rest_reward_bias = theta[8]
@@ -43,7 +49,8 @@ def _heuristic_action(
         house = agent_id % 10
         mode = 0  # REST
 
-    return [house, mode]
+    # Honest signal: broadcast matches actual mode.
+    return [house, mode, mode]
 
 
 class RustPufferBucketBrigade(gym.Env):
@@ -121,8 +128,11 @@ class RustPufferBucketBrigade(gym.Env):
             low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float32
         )
 
-        # Action: [house_index, mode] where house_index ∈ [0,9], mode ∈ [0,1]
-        self.action_space = spaces.MultiDiscrete([10, 2])
+        # Action: [house_index, mode, signal] (issue #235) where
+        # house_index in [0,9], mode in {0=REST, 1=WORK}, signal in
+        # {0=REST, 1=WORK}. The signal is broadcast independently of the
+        # mode; honest agents emit ``signal == mode``, liars don't.
+        self.action_space = spaces.MultiDiscrete([10, 2, 2])
 
         # Track episode statistics
         self.episode_rewards: List[float] = []
@@ -156,7 +166,7 @@ class RustPufferBucketBrigade(gym.Env):
             "houses": np.array(rust_obs.houses),
             "signals": np.array(rust_obs.signals),
             "locations": np.array(rust_obs.locations),
-            "last_actions": np.zeros((self.num_agents, 2)),  # No actions yet
+            "last_actions": np.zeros((self.num_agents, 2)),  # No actions yet (issue #235: width stays 2 per obs_to_vector compat)
             "scenario_info": np.array(
                 [
                     self.rust_scenario.prob_fire_spreads_to_neighbor,
@@ -183,8 +193,14 @@ class RustPufferBucketBrigade(gym.Env):
         """Take a step in the environment."""
         self.steps_taken += 1
 
-        # Convert action to [house, mode] format
-        agent_action = [int(action[0]), int(action[1])]
+        # Convert action to [house, mode, signal] format (issue #235).
+        # If the caller provided a 2-element action (legacy), default the
+        # signal to the mode bit (honest).
+        if len(action) >= 3:
+            agent_action = [int(action[0]), int(action[1]), int(action[2])]
+        else:
+            mode = int(action[1])
+            agent_action = [int(action[0]), mode, mode]
 
         # Get actions from all agents
         all_actions = [agent_action]  # Trained agent first
@@ -317,7 +333,8 @@ class RustPufferBucketBrigadeVectorized(RustPufferBucketBrigade):
             low=-np.inf, high=np.inf, shape=(num_envs, obs_size), dtype=np.float32
         )
 
-        self.action_space = spaces.MultiDiscrete([num_envs, 10, 2])
+        # Issue #235: 3-element action [house, mode, signal] per env.
+        self.action_space = spaces.MultiDiscrete([num_envs, 10, 2, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/bucket_brigade/equilibrium/payoff_evaluator_rust.py
+++ b/bucket_brigade/equilibrium/payoff_evaluator_rust.py
@@ -73,7 +73,11 @@ def _heuristic_action(
         house = agent_id % 10
         mode = 0  # REST
 
-    return [house, mode]
+    # Issue #235: 3-element [house, mode, signal]. Honest by default; Nash
+    # equilibrium analyses care primarily about work_tendency, so the
+    # signal channel is wired through here only to satisfy the engine's
+    # new action shape.
+    return [house, mode, mode]
 
 
 def _run_rust_simulation(args):

--- a/bucket_brigade/evolution/fitness_rust.py
+++ b/bucket_brigade/evolution/fitness_rust.py
@@ -51,7 +51,10 @@ def _heuristic_action(
         house = agent_id % 10
         mode = 0  # REST
 
-    return [house, mode]
+    # Issue #235: 3-element [house, mode, signal]. Honest by default
+    # (signal == mode); the deceptive behavior lives in HeuristicAgent.act
+    # where the honesty_bias parameter actually drives the broadcast.
+    return [house, mode, mode]
 
 
 def _run_rust_game(args: tuple[np.ndarray, str, int, int]) -> float:

--- a/bucket_brigade/evolution/heterogeneous_evaluator.py
+++ b/bucket_brigade/evolution/heterogeneous_evaluator.py
@@ -57,7 +57,8 @@ def _heuristic_action(
         house = agent_id % 10
         mode = 0  # REST
 
-    return [house, mode]
+    # Issue #235: 3-element [house, mode, signal]. Honest by default.
+    return [house, mode, mode]
 
 
 class HeterogeneousEvaluator:

--- a/bucket_brigade/training/game_simulator.py
+++ b/bucket_brigade/training/game_simulator.py
@@ -155,7 +155,7 @@ class GameSimulator:
 
     def select_action(
         self, agent_id: int, observation: np.ndarray
-    ) -> Tuple[int, int, float]:
+    ) -> Tuple[int, int, int, float]:
         """
         Select action for an agent given observation.
 
@@ -164,7 +164,13 @@ class GameSimulator:
             observation: Flattened observation array
 
         Returns:
-            Tuple of (house_action, mode_action, log_prob)
+            Tuple of (house_action, mode_action, signal_action, log_prob).
+
+            Issue #235: the policy now has three action heads
+            ``[house, mode, signal]``. If the policy network was constructed
+            with only two heads (legacy pre-#235 checkpoints) we fall back
+            to honest signaling (``signal := mode``) so old checkpoints
+            still load and run.
         """
         policy = self.policies[agent_id]
         obs_tensor = torch.FloatTensor(observation).unsqueeze(0)  # Add batch dimension
@@ -182,12 +188,24 @@ class GameSimulator:
             house = house_dist.sample().item()
             mode = mode_dist.sample().item()
 
-            # Calculate log probability
             house_logprob = house_dist.log_prob(torch.tensor(house))
             mode_logprob = mode_dist.log_prob(torch.tensor(mode))
-            total_logprob = (house_logprob + mode_logprob).item()
 
-        return house, mode, total_logprob
+            # Optional third head: signal (issue #235).
+            if len(action_logits) >= 3:
+                signal_probs = torch.softmax(action_logits[2], dim=-1)
+                signal_dist = torch.distributions.Categorical(signal_probs)
+                signal = signal_dist.sample().item()
+                signal_logprob = signal_dist.log_prob(torch.tensor(signal))
+                total_logprob = (
+                    house_logprob + mode_logprob + signal_logprob
+                ).item()
+            else:
+                # Legacy 2-head policy — honest signaling.
+                signal = int(mode)
+                total_logprob = (house_logprob + mode_logprob).item()
+
+        return house, mode, signal, total_logprob
 
     def run_episode(self, env_id: int) -> Dict[int, List]:
         """
@@ -226,8 +244,10 @@ class GameSimulator:
 
             for i, agent_id in enumerate(agent_ids):
                 obs = observations[i]
-                house, mode, logprob = self.select_action(agent_id, obs)
-                actions.append([house, mode])
+                # Issue #235: select_action now returns
+                # (house, mode, signal, logprob).
+                house, mode, signal, logprob = self.select_action(agent_id, obs)
+                actions.append([house, mode, signal])
                 logprobs.append(logprob)
 
             # Step environment (returns tuple: rewards_list, done, info)

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -29,7 +29,7 @@ Typical use::
         env_fn=env_fn,
         num_agents=4,
         obs_dim=46,
-        action_dims=[10, 2],
+        action_dims=[10, 2, 2],  # [house, mode, signal] (issue #235)
         redundancy_coef=0.01,
     )
     for epoch in range(num_epochs):

--- a/bucket_brigade/training/policy_learner.py
+++ b/bucket_brigade/training/policy_learner.py
@@ -60,7 +60,9 @@ class PolicyLearner:
         Args:
             agent_id: ID of the agent this learner is training
             obs_dim: Observation dimension
-            action_dims: List of action dimensions [num_houses, num_modes]
+            action_dims: List of action dimensions, e.g.
+                ``[num_houses, num_modes, num_signals] = [10, 2, 2]``
+                (issue #235; pre-#235 this was ``[10, 2]``).
             hidden_size: Hidden layer size
             learning_rate: Learning rate
             device: Device to use ("cuda" or "cpu")

--- a/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
+++ b/experiments/p3_specialization/diagnostics/inspect_rollout_rewards.py
@@ -327,7 +327,7 @@ def main() -> None:
             cfg = {
                 "scenario": args.scenario,
                 "num_agents": 4,
-                "action_dims": [10, 2],
+                "action_dims": [10, 2, 2],  # [house, mode, signal] (issue #235)
                 "hidden_size": 64,
                 "lr": 3e-4,
                 "ppo_epochs": 4,

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -65,7 +65,7 @@ from bucket_brigade.training.joint_trainer import JointPPOTrainer, flatten_dict_
 # training stack (info_theory, torch optim, etc.) just to read three numbers.
 HIDDEN_SIZE = 64
 NUM_AGENTS = 4
-ACTION_DIMS = [10, 2]
+ACTION_DIMS = [10, 2, 2]  # [house, mode, signal] (issue #235)
 # Default scenario name; override via ``--scenario`` (issue #221).
 DEFAULT_SCENARIO_NAME = "default"
 
@@ -107,11 +107,14 @@ def run_random_episode(
     env.reset(seed=int(rng.integers(0, 2**31 - 1)))
     total_reward = 0.0
     while not env.done:
-        # MultiDiscrete([10, 2]) per agent. See bucket_brigade_env.py:117 and
-        # puffer_env.py:77 for the verified shape (N, 2) = [house_index, mode_flag].
+        # MultiDiscrete([10, 2, 2]) per agent (issue #235).
+        # Shape (N, 3) = [house_index, mode_flag, signal]. Pre-#235 was
+        # (N, 2); the third column is the broadcast signal, sampled
+        # independently here to fully exercise the action space.
         actions = np.stack(
             [
                 rng.integers(0, 10, size=env.num_agents),
+                rng.integers(0, 2, size=env.num_agents),
                 rng.integers(0, 2, size=env.num_agents),
             ],
             axis=-1,

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -86,7 +86,10 @@ class CellConfig:
     n_bins: int = 4
     mi_proj_dims: int = 3
     device: str = "cpu"
-    action_dims: List[int] = field(default_factory=lambda: [10, 2])
+    # Issue #235: action is now [house, mode, signal] (10*2*2 = 40 values).
+    # Pre-#235 was [10, 2]; the third entry (signal alphabet) makes the
+    # broadcast channel a learned action dimension.
+    action_dims: List[int] = field(default_factory=lambda: [10, 2, 2])
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -165,16 +168,20 @@ def _state_summary_codes(
 
 
 # Packed-action alphabet used by ``_other_agent_action_codes`` and the
-# ``action_entropy`` metric below. With ``action_dims = [10, 2]`` the pack
-# ``a[:, 0] * 2 + a[:, 1]`` covers ``0..19`` inclusive (20 distinct values).
-# We reserve code 20 as a sentinel for the "no prior action" case at ``t=0``
-# (and just after an episode boundary), so the conditioner's alphabet is
-# ``[0, 21)``. Using a dedicated sentinel keeps the conditioner well-defined
-# at the cost of one extra bin; ``is_degenerate_conditioner`` will still fire
-# correctly if real actions collapse to a single value.
-_ACTION_PACK_BASE = 2  # second action dimension cardinality
-_ACTION_NO_PRIOR_SENTINEL = 20
-_ACTION_CODE_ALPHABET = 21  # 0..19 real + 20 sentinel
+# ``action_entropy`` metric below.
+#
+# Issue #235: with ``action_dims = [10, 2, 2]`` (post-#235) the pack
+# ``a[:, 0] * 4 + a[:, 1] * 2 + a[:, 2]`` covers ``0..39`` inclusive
+# (40 distinct values). We reserve code 40 as a sentinel for the
+# "no prior action" case at ``t=0`` (and just after an episode boundary),
+# so the conditioner's alphabet is ``[0, 41)``.
+#
+# Pre-#235 was ``a[:, 0] * 2 + a[:, 1]`` (range ``0..19``) with sentinel 20.
+_ACTION_PACK_BASE_MODE = 2  # mode dimension cardinality (action_dims[1])
+_ACTION_PACK_BASE_SIGNAL = 2  # signal dimension cardinality (action_dims[2])
+_ACTION_PACK_BASE = _ACTION_PACK_BASE_MODE * _ACTION_PACK_BASE_SIGNAL  # 4
+_ACTION_NO_PRIOR_SENTINEL = 40
+_ACTION_CODE_ALPHABET = 41  # 0..39 real + 40 sentinel
 
 
 def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray:
@@ -192,10 +199,12 @@ def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray
     here, agent ``j``'s action at ``t - lag``. This matches the convention
     used in the four-way diagnostic table in the architect notebook.
 
-    Codes use the existing pack ``a[:, 0] * _ACTION_PACK_BASE + a[:, 1]``
-    (range ``0..19`` for ``action_dims = [10, 2]``). For ``t < lag`` (no
-    prior action exists yet) we emit the sentinel ``_ACTION_NO_PRIOR_SENTINEL``
-    so the conditioner is defined on every step.
+    Codes use the pack
+    ``a[:, 0] * _ACTION_PACK_BASE + a[:, 1] * _ACTION_PACK_BASE_SIGNAL + a[:, 2]``
+    (range ``0..39`` for ``action_dims = [10, 2, 2]``, issue #235).
+    For ``t < lag`` (no prior action exists yet) we emit the sentinel
+    ``_ACTION_NO_PRIOR_SENTINEL`` so the conditioner is defined on
+    every step.
 
     Note: we do **not** reset the sentinel at episode boundaries here. The
     architect spec calls for a single-step lag and defensive ``t=0`` handling;
@@ -207,8 +216,22 @@ def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray
     if lag < 1:
         raise ValueError(f"lag must be >= 1, got {lag}")
     a = rollout.actions[agent_j].cpu().numpy()
-    # Pack the multi-discrete action: a[:, 0] in [0, 10), a[:, 1] in [0, 2).
-    packed = (a[:, 0] * _ACTION_PACK_BASE + a[:, 1]).astype(np.int64)
+    # Pack the multi-discrete action (issue #235):
+    # a[:, 0] in [0, 10), a[:, 1] in [0, 2), a[:, 2] in [0, 2).
+    if a.shape[-1] >= 3:
+        packed = (
+            a[:, 0] * _ACTION_PACK_BASE
+            + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
+            + a[:, 2]
+        ).astype(np.int64)
+    else:
+        # Legacy 2-element actions (pre-#235): pretend the agent was honest
+        # (signal == mode) so the packed code remains well-defined.
+        packed = (
+            a[:, 0] * _ACTION_PACK_BASE
+            + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
+            + a[:, 1]
+        ).astype(np.int64)
     T = packed.shape[0]
     codes = np.full(T, _ACTION_NO_PRIOR_SENTINEL, dtype=np.int64)
     if T > lag:
@@ -438,7 +461,22 @@ def _measure_information(
     for i in range(n):
         a = rollout.actions[i].cpu().numpy()
         # Pack multi-discrete action into a single label per step.
-        packed = a[:, 0] * 2 + a[:, 1]  # 0..19 for [house, mode]
+        # Issue #235: pack [house, mode, signal] into 0..39 (action_dims
+        # = [10, 2, 2]). Pre-#235 was [house, mode] into 0..19. Handle
+        # legacy 2-element actions defensively by treating them as honest
+        # (signal == mode).
+        if a.shape[-1] >= 3:
+            packed = (
+                a[:, 0] * _ACTION_PACK_BASE
+                + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
+                + a[:, 2]
+            )
+        else:
+            packed = (
+                a[:, 0] * _ACTION_PACK_BASE
+                + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
+                + a[:, 1]
+            )
         out[f"action_entropy/agent_{i}"] = entropy_discrete(packed)
     out["action_entropy/mean"] = float(
         np.mean([out[f"action_entropy/agent_{i}"] for i in range(n)])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -39,9 +39,10 @@ class TestAgentBase:
 
         # Check action format
         assert isinstance(action, np.ndarray)
-        assert action.shape == (2,)
+        assert action.shape == (3,)  # issue #235: [house, mode, signal]
         assert 0 <= action[0] <= 9  # House index
         assert action[1] in [0, 1]  # Mode (REST or WORK)
+        assert action[2] in [0, 1]  # Signal (REST or WORK) — issue #235
 
 
 class TestHeuristicAgent:
@@ -80,9 +81,10 @@ class TestHeuristicAgent:
         action = agent.act(obs)
 
         assert isinstance(action, np.ndarray)
-        assert action.shape == (2,)
+        assert action.shape == (3,)  # issue #235: [house, mode, signal]
         assert 0 <= action[0] <= 9
         assert action[1] in [0, 1]
+        assert action[2] in [0, 1]
 
     def test_agent_memory(self):
         """Test agent memory and fatigue effects."""
@@ -198,8 +200,148 @@ class TestAgentFactory:
             action = agent.act(obs)
 
             assert isinstance(action, np.ndarray)
-            assert action.shape == (2,)
+            assert action.shape == (3,)  # issue #235: [house, mode, signal]
             assert isinstance(action[0], (int, np.integer))  # House index
             assert isinstance(action[1], (int, np.integer))  # Mode
+            assert isinstance(action[2], (int, np.integer))  # Signal
             assert 0 <= action[0] <= 9
             assert action[1] in [0, 1]
+            assert action[2] in [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Issue #235: signal as a first-class action dimension
+# ---------------------------------------------------------------------------
+
+
+class TestSignalChannelDecoupled:
+    """Pin the acceptance criterion of issue #235: the broadcast signal
+    (``action[2]``) is decoupled from the work/rest bit (``action[1]``).
+
+    These tests prove the channel is operative — i.e. an agent **can**
+    emit a signal that differs from its action — and that honest
+    archetypes do not lie.
+    """
+
+    @staticmethod
+    def _make_obs(houses: np.ndarray) -> dict:
+        """Build the minimal observation the heuristic agents consume."""
+        n = 4
+        return {
+            "signals": np.zeros(n, dtype=np.int8),
+            "locations": np.zeros(n, dtype=np.int8),
+            "houses": houses,
+            "last_actions": np.zeros((n, 3), dtype=np.int8),
+            "scenario_info": np.array(
+                [0.25, 0.5, 100, 100, 0.5, 0.2, 12, 0.02, 12, 4]
+            ),
+        }
+
+    def test_random_agent_signal_is_honest(self):
+        """The random baseline is honest by convention (signal == mode).
+
+        See ``RandomAgent.act`` docstring for the rationale: this keeps the
+        random baseline's semantics identical to pre-#235 ("uniform-random
+        house, uniform-random mode") and isolates the signal channel as a
+        deliberate degree of freedom available to strategic agents.
+        """
+        agent = RandomAgent(0)
+        obs = self._make_obs(np.zeros(10, dtype=np.int8))
+        for _ in range(50):
+            a = agent.act(obs)
+            assert a.shape == (3,)
+            assert int(a[1]) == int(a[2]), (
+                f"RandomAgent should signal honestly: mode={int(a[1])}, "
+                f"signal={int(a[2])}"
+            )
+
+    def test_firefighter_archetype_lies_rarely(self):
+        """The Firefighter archetype has ``honesty_bias = 1.0`` and a
+        small ``exploration_rate = 0.1``. Its base ``_choose_signal``
+        always returns the honest broadcast, and ``_choose_mode`` follows
+        the signal with probability ``honesty_bias = 1``; only the
+        ``exploration_rate`` (which re-randomizes the *mode* but not the
+        signal) can produce ``mode != signal``. So we assert the
+        empirical lie rate is **low** rather than zero."""
+        agent = create_archetype_agent("firefighter", 0)
+        houses = np.array([0, 1, 0, 0, 0, 0, 0, 1, 0, 0])  # some fires
+        obs = self._make_obs(houses)
+        np.random.seed(42)
+        n = 200
+        lie_count = 0
+        for _ in range(n):
+            a = agent.act(obs)
+            if int(a[1]) != int(a[2]):
+                lie_count += 1
+        lie_rate = lie_count / n
+        # Exploration rate is 0.1 and only flips with probability 0.5 of
+        # producing a mismatch, so theoretical lie rate ~= 0.05. Allow
+        # generous slack.
+        assert lie_rate < 0.25, (
+            f"Firefighter (honesty_bias=1.0) should rarely lie; "
+            f"observed lie rate = {lie_rate:.3f} over {n} samples. "
+            "Expected < 0.25."
+        )
+
+    def test_liar_archetype_lies_in_expectation(self):
+        """The Liar archetype has ``honesty_bias = 0.1``; in expectation
+        it should lie roughly 90% of the time. We sample many steps and
+        assert the empirical lie rate is above a generous lower bound.
+
+        This is the canonical acceptance test from issue #235: it proves
+        that the signal channel is *operative* (an agent can emit
+        ``signal != mode``) and that the existing ``_choose_signal`` /
+        ``honesty_bias`` machinery, which pre-#235 was computed and
+        thrown away, is now actually wired through.
+        """
+        agent = create_archetype_agent("liar", 0)
+        # Use a mixed-state obs so work_intent is non-degenerate.
+        houses = np.array([0, 1, 0, 1, 0, 1, 0, 0, 0, 0])
+        obs = self._make_obs(houses)
+        np.random.seed(123)
+        n_samples = 500
+        lie_count = 0
+        sample_count = 0
+        for _ in range(n_samples):
+            a = agent.act(obs)
+            # Skip steps where fatigue/exploration overrode the signal —
+            # those don't reflect the signal-selection mechanism. In
+            # practice they're rare (fatigue_memory=0, exploration=0.3
+            # for the Liar archetype), so the bulk of samples are
+            # signal-selected.
+            sample_count += 1
+            if int(a[1]) != int(a[2]):
+                lie_count += 1
+        lie_rate = lie_count / sample_count
+        # Liar's honesty_bias is 0.1, so deceptive rate ≈ 0.9; allow
+        # generous slack for the work_intent stochasticity and the
+        # exploration/fatigue overrides.
+        assert lie_rate > 0.4, (
+            f"Liar archetype (honesty_bias=0.1) should lie often; "
+            f"observed lie rate = {lie_rate:.3f} over {sample_count} "
+            f"samples. Expected > 0.4 (in practice ~0.6-0.9)."
+        )
+
+    def test_liar_signal_channel_operative_smoke(self):
+        """At least one of the Liar's actions has ``signal != mode``.
+
+        This is the smallest possible operative-channel test — it would
+        fail under the pre-#235 deterministic-copy bug regardless of
+        ``honesty_bias``, because there the engine threw the signal away
+        and recomputed ``signal := mode``."""
+        agent = create_archetype_agent("liar", 0)
+        houses = np.array([0, 1, 0, 1, 0, 1, 0, 0, 0, 0])
+        obs = self._make_obs(houses)
+        np.random.seed(7)
+        seen_lie = False
+        for _ in range(100):
+            a = agent.act(obs)
+            if int(a[1]) != int(a[2]):
+                seen_lie = True
+                break
+        assert seen_lie, (
+            "Liar archetype produced no deceptive signals over 100 steps — "
+            "either the signal channel is still a deterministic copy of "
+            "the mode bit (regression of issue #235), or honesty_bias is "
+            "no longer being threaded through HeuristicAgent.act."
+        )

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -2,10 +2,12 @@
 
 The specialist policy must:
 
-* Return ``MultiDiscrete([10, 2])``-compatible actions (shape (2,), int64,
-  values in range).
+* Return ``MultiDiscrete([10, 2, 2])``-compatible actions (shape (3,),
+  int64, values in range; issue #235 promoted the action from
+  ``[house, mode]`` to ``[house, mode, signal]``).
 * Choose WORK on a burning owned house, REST otherwise.
 * Be reusable across scenarios (no scenario-specific assumption).
+* Signal honestly (``signal == mode``) — the specialist has no reason to lie.
 
 These tests are pure-Python and very fast (<1s) so they live in the normal
 ``tests/`` directory.
@@ -59,25 +61,32 @@ def test_owned_houses_round_robin_4_agents() -> None:
 
 
 def test_specialist_action_returns_valid_multidiscrete() -> None:
-    """Action is shape (2,), int64, with values in ``MultiDiscrete([10, 2])``."""
+    """Action is shape (3,), int64, with values in ``MultiDiscrete([10, 2, 2])``
+    (issue #235). The specialist signals honestly (``signal == mode``)."""
     obs = _make_obs(np.zeros(10, dtype=np.int8))  # all SAFE
     act = specialist_action(obs, agent_id=0, num_agents=4)
 
     assert isinstance(act, np.ndarray)
-    assert act.shape == (2,)
+    assert act.shape == (3,)
     assert act.dtype == np.int64
     assert 0 <= int(act[0]) < 10
     assert int(act[1]) in (0, 1)
+    assert int(act[2]) in (0, 1)
+    # Specialist is honest by design.
+    assert int(act[2]) == int(act[1])
 
 
 def test_specialist_action_joint_shape_for_4_agents() -> None:
-    """Joint specialist returns a (num_agents, 2) int64 array."""
+    """Joint specialist returns a (num_agents, 3) int64 array (issue #235)."""
     obs = _make_obs(np.zeros(10, dtype=np.int8))
     joint = specialist_action_joint(obs, num_agents=4)
-    assert joint.shape == (4, 2)
+    assert joint.shape == (4, 3)
     assert joint.dtype == np.int64
     assert np.all((joint[:, 0] >= 0) & (joint[:, 0] < 10))
     assert np.all((joint[:, 1] >= 0) & (joint[:, 1] < 2))
+    assert np.all((joint[:, 2] >= 0) & (joint[:, 2] < 2))
+    # Honest signaling: signal column equals mode column.
+    assert np.array_equal(joint[:, 2], joint[:, 1])
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +191,7 @@ def test_minimal_specialization_env_plays_to_completion_with_specialist() -> Non
     steps = 0
     while not env.done and steps < 500:  # 500 step safety cap
         actions = specialist_action_joint(obs, num_agents=4)
-        assert actions.shape == (4, 2)
+        assert actions.shape == (4, 3)  # issue #235: [house, mode, signal]
         obs, _, _, _ = env.step(actions)
         steps += 1
     assert env.done, "Episode did not terminate within 500 steps"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -51,7 +51,7 @@ class TestBucketBrigadeEnv:
         env.reset(seed=42)
 
         # Create random actions for all agents
-        actions = np.random.randint(0, 2, size=(4, 2))  # [house, mode] for each agent
+        actions = np.random.randint(0, 2, size=(4, 3))  # [house, mode, signal] (issue #235)
 
         obs, rewards, dones, info = env.step(actions)
 
@@ -72,7 +72,7 @@ class TestBucketBrigadeEnv:
         # Run for many steps to ensure termination
         max_steps = 100
         for step in range(max_steps):
-            actions = np.random.randint(0, 2, size=(4, 2))
+            actions = np.random.randint(0, 2, size=(4, 3))  # [house, mode, signal] (issue #235)
             obs, rewards, dones, info = env.step(actions)
 
             if env.done:
@@ -105,12 +105,14 @@ class TestBucketBrigadeEnv:
         env.houses = np.array([0, 1, 0, 0, 0, 0, 0, 1, 0, 0])  # Houses 1 and 7 burning
 
         # Create actions where agents work on burning houses
+        # Issue #235: action is [house, mode, signal]. Honest signaling
+        # (signal == mode) here since the test only checks state transitions.
         actions = np.array(
             [
-                [1, 1],  # Agent 0 works on burning house 1
-                [7, 1],  # Agent 1 works on burning house 7
-                [0, 0],  # Agent 2 rests
-                [2, 0],  # Agent 3 rests
+                [1, 1, 1],  # Agent 0 works on burning house 1
+                [7, 1, 1],  # Agent 1 works on burning house 7
+                [0, 0, 0],  # Agent 2 rests
+                [2, 0, 0],  # Agent 3 rests
             ]
         )
 
@@ -129,12 +131,13 @@ class TestBucketBrigadeEnv:
         env.houses = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])  # All safe
         env._prev_houses_state = env.houses.copy()
 
+        # Issue #235: action is [house, mode, signal]. Honest defaults here.
         actions = np.array(
             [
-                [0, 1],  # Work
-                [1, 0],  # Rest
-                [2, 1],  # Work
-                [3, 0],  # Rest
+                [0, 1, 1],  # Work
+                [1, 0, 0],  # Rest
+                [2, 1, 1],  # Work
+                [3, 0, 0],  # Rest
             ]
         )
 
@@ -152,7 +155,7 @@ class TestBucketBrigadeEnv:
 
         # Run a few steps
         for _ in range(3):
-            actions = np.random.randint(0, 2, size=(4, 2))
+            actions = np.random.randint(0, 2, size=(4, 3))  # [house, mode, signal] (issue #235)
             env.step(actions)
 
         # Save replay
@@ -796,10 +799,10 @@ class TestPositionalScenario:
         env.reset(seed=0)
         env.houses = np.zeros(10, dtype=np.int8)
         env._prev_houses_state = env.houses.copy()
-        # All four agents WORK at house 5.
+        # All four agents WORK at house 5 with honest signaling.
         # ring_dist on 10-ring:  (0,5)=5, (3,5)=2, (5,5)=0, (8,5)=3
         actions = np.array(
-            [[5, 1], [5, 1], [5, 1], [5, 1]], dtype=np.int8
+            [[5, 1, 1], [5, 1, 1], [5, 1, 1], [5, 1, 1]], dtype=np.int8
         )
         rewards = env._compute_rewards(actions)
         expected = -np.array(

--- a/tests/test_game_simulator.py
+++ b/tests/test_game_simulator.py
@@ -234,17 +234,25 @@ class TestGameSimulatorActionSelection:
         # Create dummy observation (36 dims for standard game)
         observation = np.random.randn(36).astype(np.float32)
 
-        # Select action
-        house, mode, logprob = simulator.select_action(
+        # Select action — issue #235: returns 4-tuple (house, mode, signal, logprob).
+        house, mode, signal, logprob = simulator.select_action(
             agent_id=0, observation=observation
         )
 
         # Verify types and ranges
         assert isinstance(house, int)
         assert isinstance(mode, int)
+        assert isinstance(signal, int)
         assert isinstance(logprob, float)
         assert 0 <= house < 10
         assert 0 <= mode < 3
+        # Note: this test uses an *unrelated* test fixture with
+        # ``action_dims=[10, 3]`` (the third entry there is the test
+        # author's choice for a 3-way mode head, *not* the post-#235
+        # signal head). With only 2 heads in the policy, select_action
+        # falls back to ``signal := mode`` (see game_simulator
+        # docstring), so we just check ``signal == mode`` here.
+        assert signal == mode
 
     def test_select_action_determinism(self):
         """Test that same observation with same seed produces same action."""
@@ -261,10 +269,11 @@ class TestGameSimulatorActionSelection:
             simulator.register_policy(agent_id=0, policy=policy)
 
             torch.manual_seed(42)
-            house, mode, logprob = simulator.select_action(
+            # Issue #235: select_action now returns 4-tuple.
+            house, mode, signal, logprob = simulator.select_action(
                 agent_id=0, observation=observation
             )
-            results.append((house, mode))
+            results.append((house, mode, signal))
 
         # All results should be the same (with same seed)
         assert all(r == results[0] for r in results)

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -21,7 +21,7 @@ from bucket_brigade.training.networks import CentralizedCritic
 
 NUM_AGENTS = 4
 ROLLOUT_STEPS = 64
-ACTION_DIMS = [10, 2]  # [house index, mode]
+ACTION_DIMS = [10, 2, 2]  # [house index, mode, signal] (issue #235)
 
 
 def _env_fn():

--- a/tests/test_p3_conditioners.py
+++ b/tests/test_p3_conditioners.py
@@ -44,29 +44,44 @@ def _make_rollout(actions_np: Dict[int, np.ndarray]) -> _FakeRollout:
 
 
 class TestOtherAgentActionCodes:
+    # Issue #235: action is now ``[house, mode, signal]`` (length 3) and
+    # the pack is ``a[:, 0] * 4 + a[:, 1] * 2 + a[:, 2]`` (range 0..39).
+    # All test action streams below use the honest convention
+    # ``signal == mode`` so the packed code is
+    # ``house * 4 + mode * 2 + mode = house * 4 + mode * 3``.
+
     def test_lag1_shifts_and_sentinels_t0(self):
-        # Agent 0 takes the same packed-action pattern (5, 7, 11, 3); we
-        # expect t=0 to be the sentinel and the rest to be the prior step.
-        a0 = np.array([[2, 1], [3, 1], [5, 1], [1, 1]])  # packed = 5, 7, 11, 3
+        # Agent 0 takes the packed-action pattern. With honest signaling
+        # the pack ``a[:, 0] * 4 + a[:, 1] * 2 + a[:, 2]`` reduces to
+        # ``house * 4 + mode * 3``:
+        #   [2, 1, 1] -> 8 + 3 = 11
+        #   [3, 1, 1] -> 12 + 3 = 15
+        #   [5, 1, 1] -> 20 + 3 = 23
+        #   [1, 1, 1] -> 4 + 3 = 7
+        a0 = np.array([[2, 1, 1], [3, 1, 1], [5, 1, 1], [1, 1, 1]])
         rollout = _make_rollout({0: a0, 1: a0.copy()})
         codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
-        expected = np.array([_ACTION_NO_PRIOR_SENTINEL, 5, 7, 11], dtype=np.int64)
+        expected = np.array(
+            [_ACTION_NO_PRIOR_SENTINEL, 11, 15, 23], dtype=np.int64
+        )
         np.testing.assert_array_equal(codes, expected)
 
     def test_lag_k_sentinels_first_k_steps(self):
-        a0 = np.array([[1, 0], [2, 1], [3, 0], [4, 1], [0, 0]])
-        # packed = 2, 5, 6, 9, 0
+        a0 = np.array(
+            [[1, 0, 0], [2, 1, 1], [3, 0, 0], [4, 1, 1], [0, 0, 0]]
+        )
+        # packed (honest): 4, 11, 12, 19, 0
         rollout = _make_rollout({0: a0})
         codes = _other_agent_action_codes(rollout, agent_j=0, lag=3)
         # First 3 entries are sentinel; then prior-prior-prior actions.
         assert codes[0] == _ACTION_NO_PRIOR_SENTINEL
         assert codes[1] == _ACTION_NO_PRIOR_SENTINEL
         assert codes[2] == _ACTION_NO_PRIOR_SENTINEL
-        assert codes[3] == 2
-        assert codes[4] == 5
+        assert codes[3] == 4
+        assert codes[4] == 11
 
     def test_short_rollout_all_sentinel_when_lag_ge_T(self):
-        a0 = np.array([[1, 0], [2, 1]])
+        a0 = np.array([[1, 0, 0], [2, 1, 1]])
         rollout = _make_rollout({0: a0})
         codes = _other_agent_action_codes(rollout, agent_j=0, lag=2)
         # T == lag → entire output is sentinel (no t with a defined prior).
@@ -80,38 +95,40 @@ class TestOtherAgentActionCodes:
         )
 
     def test_pack_matches_existing_convention(self):
-        # The pack is ``a[:, 0] * 2 + a[:, 1]`` and must match the
-        # convention used by the existing ``action_entropy`` metric in
-        # ``_measure_information`` (lines 287-289 of train.py).
-        a0 = np.array([[7, 1], [9, 0]])  # packed = 15, 18
+        # The pack is ``a[:, 0] * 4 + a[:, 1] * 2 + a[:, 2]`` (issue #235).
+        # [7, 1, 1] -> 28 + 2 + 1 = 31; [9, 0, 0] -> 36 + 0 + 0 = 36.
+        a0 = np.array([[7, 1, 1], [9, 0, 0]])
         rollout = _make_rollout({0: a0})
         codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
-        # codes[1] is the prior packed action (15); codes[0] is sentinel.
-        assert codes[1] == 15
+        # codes[1] is the prior packed action (31); codes[0] is sentinel.
+        assert codes[1] == 31
 
-    def test_alphabet_max_is_19(self):
-        # Largest legal packed action with action_dims = [10, 2] is
-        # ``9 * 2 + 1 = 19`` (< _ACTION_NO_PRIOR_SENTINEL = 20).
-        a0 = np.array([[9, 1], [0, 0]])
+    def test_alphabet_max_is_39(self):
+        # Largest legal packed action with action_dims = [10, 2, 2] is
+        # ``9 * 4 + 1 * 2 + 1 = 39`` (< _ACTION_NO_PRIOR_SENTINEL = 40).
+        a0 = np.array([[9, 1, 1], [0, 0, 0]])
         rollout = _make_rollout({0: a0})
         codes = _other_agent_action_codes(rollout, agent_j=0, lag=1)
-        assert codes[1] == 19
+        assert codes[1] == 39
         # Sentinel value sits strictly above the legal range.
-        assert _ACTION_NO_PRIOR_SENTINEL == 20
+        assert _ACTION_NO_PRIOR_SENTINEL == 40
 
     def test_per_agent_independence(self):
         # Each agent's codes are computed from that agent's own action stream;
         # passing different action_dims values should not cross-contaminate.
-        a0 = np.array([[1, 0], [2, 0], [3, 0]])  # packed = 2, 4, 6
-        a1 = np.array([[5, 1], [6, 0], [7, 1]])  # packed = 11, 12, 15
+        # Honest signaling so packed = house * 4 + mode * 3:
+        # a0: [1,0,0]=4, [2,0,0]=8, [3,0,0]=12
+        # a1: [5,1,1]=23, [6,0,0]=24, [7,1,1]=31
+        a0 = np.array([[1, 0, 0], [2, 0, 0], [3, 0, 0]])
+        a1 = np.array([[5, 1, 1], [6, 0, 0], [7, 1, 1]])
         rollout = _make_rollout({0: a0, 1: a1})
         codes0 = _other_agent_action_codes(rollout, agent_j=0, lag=1)
         codes1 = _other_agent_action_codes(rollout, agent_j=1, lag=1)
-        assert codes0[1] == 2 and codes0[2] == 4
-        assert codes1[1] == 11 and codes1[2] == 12
+        assert codes0[1] == 4 and codes0[2] == 8
+        assert codes1[1] == 23 and codes1[2] == 24
 
     def test_rejects_lag_zero(self):
-        a0 = np.array([[1, 0], [2, 0]])
+        a0 = np.array([[1, 0, 0], [2, 0, 0]])
         rollout = _make_rollout({0: a0})
         with pytest.raises(ValueError):
             _other_agent_action_codes(rollout, agent_j=0, lag=0)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -20,7 +20,7 @@ class TestPolicyNetwork:
     def test_forward_pass_shape(self):
         """Test that forward pass produces expected output shapes."""
         obs_dim = 42
-        action_dims = [10, 2]
+        action_dims = [10, 2, 2]  # [house, mode, signal] (issue #235)
         hidden_size = 64
         batch_size = 16
 
@@ -37,6 +37,8 @@ class TestPolicyNetwork:
         # Check shapes of action logits
         assert action_logits[0].shape == (batch_size, action_dims[0])
         assert action_logits[1].shape == (batch_size, action_dims[1])
+        # Issue #235: third head is the broadcast-signal dimension.
+        assert action_logits[2].shape == (batch_size, action_dims[2])
 
         # Check value shape
         assert value.shape == (batch_size, 1)
@@ -44,7 +46,7 @@ class TestPolicyNetwork:
     def test_get_action_deterministic(self):
         """Test deterministic action selection returns argmax."""
         obs_dim = 42
-        action_dims = [10, 2]
+        action_dims = [10, 2, 2]  # [house, mode, signal] (issue #235)
 
         policy = PolicyNetwork(obs_dim=obs_dim, action_dims=action_dims, hidden_size=64)
         obs = torch.randn(1, obs_dim)
@@ -63,7 +65,7 @@ class TestPolicyNetwork:
     def test_get_action_stochastic(self):
         """Test stochastic action sampling returns log probabilities."""
         obs_dim = 42
-        action_dims = [10, 2]
+        action_dims = [10, 2, 2]  # [house, mode, signal] (issue #235)
 
         policy = PolicyNetwork(obs_dim=obs_dim, action_dims=action_dims, hidden_size=64)
         obs = torch.randn(1, obs_dim)
@@ -83,7 +85,7 @@ class TestPolicyNetwork:
     def test_checkpoint_save_load(self):
         """Test that checkpoint saving and loading preserves network behavior."""
         obs_dim = 42
-        action_dims = [10, 2]
+        action_dims = [10, 2, 2]  # [house, mode, signal] (issue #235)
         hidden_size = 64
 
         # Create first policy

--- a/web/src/utils/archetypeAgents.ts
+++ b/web/src/utils/archetypeAgents.ts
@@ -32,7 +32,7 @@ export class FirefighterAgent extends BrowserAgent {
       return [sorted[0], 1]; // Work on nearest fire
     }
 
-    return [this.id % 10, 0]; // Rest if no fires
+    return [this.id % 10, 0, 0]; // Rest if no fires
   }
 }
 
@@ -49,7 +49,7 @@ export class FreeRiderAgent extends BrowserAgent {
 
     // Only work if own house is burning
     if (obs.houses[own_house] === 1) {
-      return [own_house, 1];
+      return [own_house, 1, 1];
     }
 
     // Check if immediate neighbors are burning (threat to own house)
@@ -60,11 +60,11 @@ export class FreeRiderAgent extends BrowserAgent {
 
     const threatening_neighbor = neighbors.find(n => obs.houses[n] === 1);
     if (threatening_neighbor !== undefined) {
-      return [threatening_neighbor, 1];
+      return [threatening_neighbor, 1, 1];
     }
 
     // Otherwise, rest
-    return [own_house, 0];
+    return [own_house, 0, 0];
   }
 }
 
@@ -80,11 +80,11 @@ export class HeroAgent extends BrowserAgent {
     // Always work if there are any fires
     const burning_house = obs.houses.findIndex(h => h === 1);
     if (burning_house !== -1) {
-      return [burning_house, 1];
+      return [burning_house, 1, 1];
     }
 
     // Even if no fires, patrol own house
-    return [this.id % 10, 1];
+    return [this.id % 10, 1, 1];
   }
 }
 
@@ -104,7 +104,7 @@ export class CoordinatorAgent extends BrowserAgent {
       .map(({ idx }) => idx);
 
     if (burning_houses.length === 0) {
-      return [this.id % 10, 0]; // Rest if no fires
+      return [this.id % 10, 0, 0]; // Rest if no fires
     }
 
     // Avoid redundant work - find house with fewest workers
@@ -126,7 +126,7 @@ export class CoordinatorAgent extends BrowserAgent {
       }
     }
 
-    return [best_house, 1];
+    return [best_house, 1, 1];
   }
 }
 
@@ -143,7 +143,7 @@ export class LiarAgent extends BrowserAgent {
 
     // Prioritize own house
     if (obs.houses[own_house] === 1) {
-      return [own_house, 1];
+      return [own_house, 1, 1];
     }
 
     // Sometimes work on other fires, sometimes rest
@@ -156,7 +156,7 @@ export class LiarAgent extends BrowserAgent {
       return [burning_houses[0], 1];
     }
 
-    return [own_house, 0]; // Rest most of the time
+    return [own_house, 0, 0]; // Rest most of the time
   }
 }
 

--- a/web/src/utils/browserAgents.ts
+++ b/web/src/utils/browserAgents.ts
@@ -33,7 +33,10 @@ export class RandomAgent extends BrowserAgent {
   act(_obs: AgentObservation): number[] {
     const house = Math.floor(Math.random() * 10);
     const mode = Math.floor(Math.random() * 2);
-    return [house, mode];
+    // Issue #235: 3-element action [house, mode, signal]. Random baseline
+    // is honest (signal == mode) — see Python RandomAgent.act docstring
+    // for the rationale.
+    return [house, mode, mode];
   }
 }
 
@@ -48,9 +51,9 @@ export class TrivialCooperator extends BrowserAgent {
     // Find first burning house
     const burning_house = obs.houses.findIndex(house => house === 1);
     if (burning_house !== -1) {
-      return [burning_house, 1]; // Work on burning house
+      return [burning_house, 1, 1]; // Work on burning house
     }
-    return [this.id % 10, 1]; // Work on own house
+    return [this.id % 10, 1, 1]; // Work on own house
   }
 }
 
@@ -68,10 +71,10 @@ export class EarlyContainmentAgent extends BrowserAgent {
     if (burning_houses.length > 0) {
       // Prioritize clusters
       const target_house = this.find_best_cluster_target(obs.houses, burning_houses);
-      return [target_house, 1];
+      return [target_house, 1, 1];
     }
 
-    return [this.id % 10, 0]; // Rest
+    return [this.id % 10, 0, 0]; // Rest
   }
 
   private find_best_cluster_target(houses: number[], burning_houses: number[]): number {
@@ -108,7 +111,7 @@ export class GreedyNeighborAgent extends BrowserAgent {
 
     // If own house is burning, work on it
     if (obs.houses[own_house] === 1) {
-      return [own_house, 1];
+      return [own_house, 1, 1];
     }
 
     // Check if neighbors are burning (threat to own house)
@@ -119,11 +122,11 @@ export class GreedyNeighborAgent extends BrowserAgent {
 
     const threatening_neighbor = neighbors.find(n => obs.houses[n] === 1);
     if (threatening_neighbor !== undefined) {
-      return [threatening_neighbor, 1];
+      return [threatening_neighbor, 1, 1];
     }
 
     // No immediate threats - rest
-    return [own_house, 0];
+    return [own_house, 0, 0];
   }
 }
 
@@ -137,17 +140,17 @@ export class SparseHeroAgent extends BrowserAgent {
     const own_house = this.id % 10;
 
     if (burning_count === 0) {
-      return [own_house, 0]; // Rest if no fires
+      return [own_house, 0, 0]; // Rest if no fires
     }
 
     // Prioritize own house if burning
     if (obs.houses[own_house] === 1) {
-      return [own_house, 1];
+      return [own_house, 1, 1];
     }
 
     // Work on first burning house
     const burning_house = obs.houses.findIndex(h => h === 1);
-    return [burning_house, 1];
+    return [burning_house, 1, 1];
   }
 }
 
@@ -183,10 +186,10 @@ export class HonestSignaler extends BrowserAgent {
 
     if (burning_houses.length > 0) {
       const target_house = new_fires.length > 0 ? new_fires[0] : burning_houses[0];
-      return [target_house, 1]; // Honest work signal
+      return [target_house, 1, 1]; // Honest work signal
     }
 
-    return [this.id % 10, 0]; // Rest honestly
+    return [this.id % 10, 0, 0]; // Rest honestly
   }
 }
 
@@ -221,12 +224,16 @@ export class UserAgent extends BrowserAgent {
     try {
       const result = this.user_function(obs);
 
-      // Validate result
-      if (!Array.isArray(result) || result.length !== 2) {
-        throw new Error("Agent must return [house_index, mode]");
+      // Validate result (issue #235: action is [house, mode, signal],
+      // length 3). Length-2 inputs are accepted for backward compat and
+      // promoted to honest signaling (signal := mode).
+      if (!Array.isArray(result) || (result.length !== 3 && result.length !== 2)) {
+        throw new Error("Agent must return [house_index, mode, signal] (or legacy [house_index, mode])");
       }
 
       const [house, mode] = result;
+      const signal = result.length === 3 ? result[2] : mode;
+
       if (typeof house !== 'number' || house < 0 || house > 9) {
         throw new Error("House index must be 0-9");
       }
@@ -235,11 +242,16 @@ export class UserAgent extends BrowserAgent {
         throw new Error("Mode must be 0 (REST) or 1 (WORK)");
       }
 
-      return result;
+      if (typeof signal !== 'number' || (signal !== 0 && signal !== 1)) {
+        throw new Error("Signal must be 0 (REST) or 1 (WORK)");
+      }
+
+      return [house, mode, signal];
     } catch (error) {
       console.error(`Agent ${this.name} error:`, error);
-      // Fallback to random action
-      return [Math.floor(Math.random() * 10), Math.floor(Math.random() * 2)];
+      // Fallback to random honest action
+      const mode = Math.floor(Math.random() * 2);
+      return [Math.floor(Math.random() * 10), mode, mode];
     }
   }
 }
@@ -267,7 +279,8 @@ export function create_user_agent_from_code(id: number, name: string, code: stri
           ${code}
         } catch (error) {
           console.error("Agent execution error:", error);
-          return [Math.floor(Math.random() * 10), Math.floor(Math.random() * 2)];
+          const _m = Math.floor(Math.random() * 2);
+          return [Math.floor(Math.random() * 10), _m, _m];
         }
       `
     ).bind(null, context.Math, context.console);

--- a/web/src/utils/browserEngine.ts
+++ b/web/src/utils/browserEngine.ts
@@ -132,7 +132,8 @@ export class BrowserBucketBrigade {
     this.houses = new Array(10).fill(0);
     this.agent_positions = new Array(this.scenario.num_agents).fill(0);
     this.agent_signals = new Array(this.scenario.num_agents).fill(0);
-    this.last_actions = new Array(this.scenario.num_agents).fill(null).map(() => [0, 0]);
+    // Issue #235: action is now [house, mode, signal] (length 3).
+    this.last_actions = new Array(this.scenario.num_agents).fill(null).map(() => [0, 0, 0]);
     this.night = 0;
     this.done = false;
     this.rewards = new Array(this.scenario.num_agents).fill(0);
@@ -156,16 +157,24 @@ export class BrowserBucketBrigade {
     // Store previous house states for reward calculation
     const prev_houses = [...this.houses];
 
-    // 1. Signal phase (signals are implicit in actions for now)
-    this.agent_signals = actions.map(action => action[1]);
+    // Normalize action shape (issue #235). Each action is
+    // [house, mode, signal] (length 3). Length-2 inputs are accepted
+    // for backward compat and promoted to honest 3-element form
+    // (signal := mode).
+    const normalized = actions.map(a => a.length >= 3 ? a : [a[0], a[1], a[1]]);
+
+    // 1. Signal phase (issue #235): signals are now action[2], decoupled
+    // from the mode bit action[1]. Pre-#235 the broadcast was a
+    // deterministic copy of the work bit.
+    this.agent_signals = normalized.map(action => action[2]);
 
     // 2. Action phase: update agent positions
-    this.last_actions = actions.map(action => [...action]);
-    this.agent_positions = actions.map(action => action[0]);
+    this.last_actions = normalized.map(action => [...action]);
+    this.agent_positions = normalized.map(action => action[0]);
 
     // 3. Extinguish phase
     // Agents respond to fires visible at start of turn
-    this.extinguish_fires(actions);
+    this.extinguish_fires(normalized);
 
     // 4. Burn-out phase
     // Unextinguished fires become ruined houses
@@ -180,7 +189,7 @@ export class BrowserBucketBrigade {
     this.spark_fires();
 
     // 7. Compute rewards
-    this.rewards = this.compute_rewards(actions, prev_houses);
+    this.rewards = this.compute_rewards(normalized, prev_houses);
 
     // 8. Check termination
     this.done = this.check_termination();

--- a/web/src/utils/tournamentEngine.ts
+++ b/web/src/utils/tournamentEngine.ts
@@ -179,7 +179,12 @@ class HeuristicAgent extends BrowserAgent {
       }
     }
 
-    return [targetHouse, mode];
+    // Issue #235: action is [house, mode, signal]. This archetype-driven
+    // browser agent emits an honest signal by default (signal == mode);
+    // the Python-side HeuristicAgent uses honesty_bias to drive a
+    // potentially deceptive signal — wire that through here in a future
+    // pass if browser tournaments need to exercise lying behavior.
+    return [targetHouse, mode, mode];
   }
 }
 

--- a/web/src/utils/wasmEngine.ts
+++ b/web/src/utils/wasmEngine.ts
@@ -111,7 +111,16 @@ export class WasmGameEngine {
   }
 
   /**
-   * Execute one game night
+   * Execute one game night.
+   *
+   * Issue #235: each action is now a 3-element array
+   * ``[house_index, mode, signal]`` (was 2-element ``[house, mode]``).
+   * The TypeScript signature ``number[][]`` is permissive and will NOT
+   * catch a shape mismatch — only the Rust-side ``serde_json`` will. The
+   * WASM step path also accepts legacy 2-element arrays for transitional
+   * compatibility and promotes them to honest 3-element actions
+   * (``signal := mode``); new code should emit 3-element arrays so it can
+   * broadcast a signal independent of its actual mode.
    */
   step(actions: number[][]): { rewards: number[]; done: boolean; info: any } {
     const actionsJson = JSON.stringify(actions);


### PR DESCRIPTION
## Summary

Makes the bucket-brigade game's signal channel actually carry independent
information instead of being a deterministic copy of the work/rest action
bit (`bucket-brigade-core/src/engine/core.rs:143-144` pre-#235). This is
the **highest-leverage env-side change** in the current research thread —
the deception-research motivation in `docs/game_description.md` was
non-operative until this PR, and the signal channel was a redundant
deterministic input that PPO had to filter out.

The agent action vector becomes 3-element `[house, mode, signal]`
(`MultiDiscrete([10, 2, 2])`) where the broadcast signal can differ from
the work bit (i.e. an agent can lie).

## Changes

**Core type (load-bearing):**
- `bucket-brigade-core/src/lib.rs`: `pub type Action = [u8; 3]`
- `engine/core.rs`: signal phase reads `action[2]` instead of `action[1]`
- Engine `last_actions` storage widened to length 3

**Heuristic agents (Python):**
- `HeuristicAgent.act` now threads its existing `_choose_signal` /
  `honesty_bias` output into the returned action — pre-#235 this was
  computed and **thrown away**. The Liar archetype (`honesty_bias=0.1`)
  produces deceptive signals immediately, with zero new agent code.
- `RandomAgent`, `SpecialistPolicy`, and all seven `scenario_optimal`
  agents default to honest signaling (`signal == mode`), preserving
  prior semantics.

**Training stack:**
- `action_dims=[10, 2]` → `[10, 2, 2]` across `joint_trainer`,
  `policy_learner`, `diagnostics`, `experiments/p3_specialization/train.py`.
- Policy networks gain a third action head automatically (the heads loop
  iterates `action_dims`).
- P3 packed-action alphabet: `0..19` → `0..39`; sentinel 20 → 40.
- `game_simulator.select_action` now returns `(house, mode, signal, logprob)`;
  legacy 2-head policies fall back to honest signaling.

**Web/TS:**
- `wasmEngine.ts` accepts legacy length-2 actions (Rust WASM promotes
  them to honest length-3) and adds documentation about the shape change.
- Built-in browser agents emit honest 3-element actions.
- `browserEngine.ts` normalizes action shape so any callers that still
  emit length-2 keep working.

**Obs vector width unchanged:**
Per the curator's recommendation, `last_actions` in the obs vector
stays width 2 (the broadcast signal is already exposed via
`obs.signals`). This means trained policies from PRs #216 and #225 stay
structurally loadable, though their learned semantics are stale.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Action vector is 3-element `[house, work/rest, signal]` | ✅ | `pub type Action = [u8; 3]` in `lib.rs:22`; `MultiDiscrete([10, 2, 2])` in `puffer_env*.py` |
| Default heuristic-agent behavior is honest | ✅ | All seven `scenario_optimal` agents and `RandomAgent` emit `signal == mode`; `test_random_agent_signal_is_honest` pins this |
| Liar archetype produces deceptive signals | ✅ | `test_liar_archetype_lies_in_expectation` asserts empirical lie rate > 0.4 over 500 samples (theoretical ~0.6-0.9 for `honesty_bias=0.1`); `test_liar_signal_channel_operative_smoke` is the strict operative-channel check |
| Tests pass with the new shape | ✅ | `cargo test --lib`: 102 passed; `pytest tests/`: 236 passed, 55 skipped (pre-existing skips) |
| Engine signal-update test pins decoupling | ✅ | `bucket-brigade-core/src/engine/tests.rs::test_agent_signals_update` rewritten — constructs agents where `signal != mode` and asserts the engine records the broadcast |
| Random baseline re-derivation | ✅ filed as follow-up | The post-#235 random baseline is mechanically different (uniform 1-of-40 packed actions); follow-up issue recommended for empirical re-derivation |

## Test Plan

```bash
# Rust unit tests (engine + heuristic agent + signal-decoupling pin)
cd bucket-brigade-core && cargo test --lib   # 102 passed

# Python unit tests (env shape, baselines, agents, training stack, P3)
pytest tests/ \
  --ignore=tests/test_code_generation.py \
  --ignore=tests/test_evolution.py            # 236 passed, 55 skipped

# Acceptance tests for the operative signal channel
pytest tests/test_agents.py::TestSignalChannelDecoupled -v
```

**Excluded tests:**
- `tests/test_code_generation.py` — fails on `main` (missing
  `archetypes_generated` module); unrelated to this PR.
- `tests/test_evolution.py::TestParallelEvaluation::test_parallel_with_scenario`
  and `::TestGeneticAlgorithm::test_ga_evolve_basic` — fail on `main`
  with a pre-existing `RustFitnessEvaluator` kwarg mismatch; unrelated.

**Out of scope (per the issue body):**
- Re-deriving random / specialist / heuristic baselines on the fixed game
  is filed as a follow-up. Existing baseline numbers across all 13
  scenarios are stale.
- Re-running training experiments (PRs #216, #225, #207) is filed as a
  follow-up. Trained policies from those PRs remain structurally
  loadable (obs vector width unchanged) but their learned semantics
  ignore the now-real signal channel.

## Recommended follow-up issues

1. **Re-derive random baseline** on the fixed game (`experiments/p3_specialization/diagnostics/random_baseline.py` now samples a 3-dim action; the cited team-reward numbers in the `SCENARIO_CITED_VALUES` table need refresh).
2. **Re-derive specialist baseline** (`bucket_brigade/baselines/specialist.py` is structurally fine; the prior numbers on `minimal_specialization` from PR #207 should be re-measured).
3. **Re-run PR #216 / #225 PPO experiments** on the fixed game. Their checkpoints load but won't exploit the (now-real) signal channel; expect different convergence behavior.
4. **Re-derive heuristic-archetype Nash equilibria** if any prior analysis assumed honest signaling.

Closes #235