### PR TITLE
diag(p3): re-derive specialist baselines on post-#236 game (#238)

### DIFF
--- a/experiments/p3_specialization/analyze_220.py
+++ b/experiments/p3_specialization/analyze_220.py
@@ -24,9 +24,12 @@ Five metrics per cell, per the issue #220 curator protocol:
    ``diagnostics/pairwise_action_kl.py``). Pre-#216 → KL ≈ 0; post-#216
    → KL > 0 iff agents specialize.
 5. **Gap closed** — for ``minimal_specialization``:
-   ``(ppo_trailing5 − random) / (specialist − random)`` with the 2026-05-15
-   references (random = −96.07, specialist = −22.07; pre-#216 reference
-   was 18.1%). Pass bar: treatment ≥ 50%.
+   ``(ppo_trailing5 − random) / (specialist − random)`` with the
+   post-#236 re-derived references from issue #238 (random = −96.07,
+   specialist = −22.07; pre-#216 reference was 18.1%). The post-#236
+   eval reproduces the pre-#236 values exactly because specialist
+   policies signal honestly and random samples uniformly over the new
+   3-element action space. Pass bar: treatment ≥ 50%.
 
 Usage::
 
@@ -49,7 +52,10 @@ LAMBDA_DIR = "lambda_0e0"
 NUM_AGENTS = 4
 TRAILING_N = 5
 
-# 2026-05-15 references from research_notebook/issue199 entry.
+# Post-#236 references re-derived under issue #238 (2026-05-16).
+# Source: diagnostics/results/issue238_post236_minspec/baselines.json.
+# Identical to the 2026-05-15 pre-#236 values to <0.01 per-step (specialists
+# signal honestly; random samples uniformly over the new 3-element action).
 MINSPEC_RANDOM = -96.07
 MINSPEC_SPECIALIST = -22.07
 

--- a/experiments/p3_specialization/analyze_231.py
+++ b/experiments/p3_specialization/analyze_231.py
@@ -54,15 +54,26 @@ SEEDS = [42, 43, 44]
 NUM_AGENTS = 4
 TRAILING_N = 5
 
-# Per-scenario (random, specialist) per-step references. Sources:
-#   random: experiments/p3_specialization/diagnostics/results/issue237_postmerge/
-#           (post-#236 re-derivation at commit dffe1060, n=1000 each;
-#           issue #237). Replaces the pre-#236 n=50 figures from
-#           issue199_minspec/baselines.json and issue221_positional/baselines.json.
-#   specialist: experiments/p3_specialization/diagnostics/results/issue199_minspec/baselines.json
-#               and issue221_positional/baselines.json (specialist provenance is
-#               separate from random; specialist baselines tracked by sibling
-#               issue #238 family, NOT updated here).
+# Per-scenario (random, specialist) per-step references. Sources are
+# tracked separately because the two underlying scripts have different
+# sampling power and were updated by different PRs:
+#
+#   random (n=1000 × 5 seeds, 3-dim sampler):
+#     experiments/p3_specialization/diagnostics/results/issue237_postmerge/
+#     (post-#236 re-derivation at commit dffe1060; issue #237 / PR #244).
+#     Replaces the pre-#236 figures from issue199_minspec/ and
+#     issue221_positional/ baselines.json.
+#
+#   specialist (n=50, seed 42):
+#     experiments/p3_specialization/diagnostics/results/issue238_post236_minspec/baselines.json
+#     experiments/p3_specialization/diagnostics/results/issue238_post236_positional/baselines.json
+#     (re-derived post-#236 under issue #238 / PR #243). Specialist policies
+#     signal honestly (`signal == mode`), so the team-reward distribution is
+#     unchanged from pre-#236 — values match pre-#236 references at the
+#     precision of the n=50 sampler. Note: issue199_baselines.py:53-54 still
+#     uses a 2-dim sampler (issue #246), which masks any random-side shift
+#     in #238's own random measurements; that's why we cite random values
+#     from random_baseline.py instead.
 BASELINES: Dict[str, Tuple[float, float]] = {
     "default": (251.23, 320.94),
     "minimal_specialization": (-87.72, -22.07),

--- a/experiments/p3_specialization/diagnostics/results/issue238_post236_minspec/baselines.json
+++ b/experiments/p3_specialization/diagnostics/results/issue238_post236_minspec/baselines.json
@@ -1,0 +1,86 @@
+{
+  "minimal_specialization": {
+    "scenario": "minimal_specialization",
+    "num_agents": 4,
+    "episodes_per_baseline": 50,
+    "seed": 42,
+    "random": {
+      "label": "random",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": -96.0704468864469,
+        "ci95_lo": -118.34502435897437,
+        "ci95_hi": -74.95526282051283,
+        "std": 78.81588003638295
+      },
+      "per_episode_mean": -1268.54,
+      "episode_length": {
+        "mean": 13.22,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist": {
+      "label": "specialist",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": -22.07174358974359,
+        "ci95_lo": -41.64844890109891,
+        "ci95_hi": -3.2004866300366492,
+        "std": 70.17649194068679
+      },
+      "per_episode_mean": -294.3,
+      "episode_length": {
+        "mean": 13.26,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist_minus_random_per_step": 73.99870329670331,
+    "ratio_specialist_over_random_per_step": 0.22974540355612058
+  },
+  "default": {
+    "scenario": "default",
+    "num_agents": 4,
+    "episodes_per_baseline": 50,
+    "seed": 42,
+    "random": {
+      "label": "random",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 241.8460805860806,
+        "ci95_lo": 216.46809523809523,
+        "ci95_hi": 265.9192527472527,
+        "std": 89.53143684898231
+      },
+      "per_episode_mean": 3198.46,
+      "episode_length": {
+        "mean": 13.22,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist": {
+      "label": "specialist",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 320.93652014652014,
+        "ci95_lo": 299.3515695970696,
+        "ci95_hi": 341.7165796703296,
+        "std": 77.74873313538028
+      },
+      "per_episode_mean": 4252.74,
+      "episode_length": {
+        "mean": 13.26,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist_minus_random_per_step": 79.09043956043953,
+    "ratio_specialist_over_random_per_step": 1.3270279980092081
+  }
+}

--- a/experiments/p3_specialization/diagnostics/results/issue238_post236_positional/baselines.json
+++ b/experiments/p3_specialization/diagnostics/results/issue238_post236_positional/baselines.json
@@ -1,0 +1,86 @@
+{
+  "positional_default": {
+    "scenario": "positional_default",
+    "num_agents": 4,
+    "episodes_per_baseline": 50,
+    "seed": 42,
+    "random": {
+      "label": "random",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 241.3596813063988,
+        "ci95_lo": 215.99572372090998,
+        "ci95_hi": 265.4300244921422,
+        "std": 89.52192433790806
+      },
+      "per_episode_mean": 3192.0379996871948,
+      "episode_length": {
+        "mean": 13.22,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist": {
+      "label": "specialist",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 320.88723344918833,
+        "ci95_lo": 299.30359973755577,
+        "ci95_hi": 341.66901771394635,
+        "std": 77.75886575795121
+      },
+      "per_episode_mean": 4252.081996612549,
+      "episode_length": {
+        "mean": 13.26,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist_minus_random_per_step": 79.52755214278952,
+    "ratio_specialist_over_random_per_step": 1.3294980823322835
+  },
+  "default": {
+    "scenario": "default",
+    "num_agents": 4,
+    "episodes_per_baseline": 50,
+    "seed": 42,
+    "random": {
+      "label": "random",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 241.8460805860806,
+        "ci95_lo": 216.46809523809523,
+        "ci95_hi": 265.9192527472527,
+        "std": 89.53143684898231
+      },
+      "per_episode_mean": 3198.46,
+      "episode_length": {
+        "mean": 13.22,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist": {
+      "label": "specialist",
+      "n_episodes": 50,
+      "per_step": {
+        "mean": 320.93652014652014,
+        "ci95_lo": 299.3515695970696,
+        "ci95_hi": 341.7165796703296,
+        "std": 77.74873313538028
+      },
+      "per_episode_mean": 4252.74,
+      "episode_length": {
+        "mean": 13.26,
+        "median": 13.0,
+        "min": 13,
+        "max": 15
+      }
+    },
+    "specialist_minus_random_per_step": 79.09043956043953,
+    "ratio_specialist_over_random_per_step": 1.3270279980092081
+  }
+}

--- a/research_notebook/2026-05-15_issue199_minimal_specialization.md
+++ b/research_notebook/2026-05-15_issue199_minimal_specialization.md
@@ -148,3 +148,24 @@ The bar between the two decision-tree branches is set at 50%; the result here (1
 1. **Algorithm-side:** open follow-up issue for centralized-critic / MAPPO / COMA. Reuses `minimal_specialization` as the entry point — if the new algorithm can learn this clean signal, that's a green light for `default`; if it can't, the problem is more fundamental than independent critics.
 2. **Run-length extension:** if MAPPO matters more than expected, run `minimal_specialization` PPO to 200+ iters to definitively reject "PPO just needs more time" before committing to algorithm rewrite.
 3. **Default rebalance:** explicitly *out of scope* per the user — but if MAPPO succeeds on `minimal_specialization` and existing PPO does poorly on `default`, the env redesign question reopens.
+
+## Amendment 2026-05-16 — Post-#236 baseline re-derivation (issue #238)
+
+PR #236 promoted the signal channel to a first-class action dimension, so the action width changed from 2 to 3 (`[house, mode, signal]`). To make the `gap_closed` denominator honest under post-#236 evaluations, the specialist + random baselines were re-derived on commit `dffe1060`:
+
+```
+uv run python experiments/p3_specialization/diagnostics/issue199_baselines.py \
+  --scenarios minimal_specialization default \
+  --output-dir experiments/p3_specialization/diagnostics/results/issue238_post236_minspec
+```
+
+| Scenario | Source | Random per-step | Specialist per-step | Gap |
+|---|---|---|---|---|
+| `minimal_specialization` | pre-#236 (issue199_minspec) | -96.0704 | -22.0717 | 73.9987 |
+| `minimal_specialization` | post-#236 (issue238) | **-96.0704** | **-22.0717** | **73.9987** |
+| `default` | pre-#236 (issue199_minspec) | 241.8461 | 320.9365 | 79.0904 |
+| `default` | post-#236 (issue238) | **241.8461** | **320.9365** | **79.0904** |
+
+Absolute shift: **0.0000** per-step (identical to 6 decimal places). This is the expected outcome: the specialist policy signals honestly (`signal == mode`, verified at `bucket_brigade/baselines/specialist.py:107-115`) and the random policy samples uniformly over the 3-element action — so neither lies, and the team-reward distribution under these two evaluators is invariant under #236. Only *trained* policies that learn to lie can shift the denominator.
+
+`analyze_220.py` constants (`MINSPEC_RANDOM`, `MINSPEC_SPECIALIST`) are unchanged in value; the source-of-truth comment was repointed to `diagnostics/results/issue238_post236_minspec/baselines.json` and the docstring was updated to note the post-#236 re-derivation.

--- a/research_notebook/2026-05-16_issue221_positional_default.md
+++ b/research_notebook/2026-05-16_issue221_positional_default.md
@@ -200,3 +200,22 @@ specialist baseline was unchanged by #237.
 Reference: issue #237 amendment block in
 ``research_notebook/2026-05-14_p3_specialization_results.md``.
 4. **MAPPO / CTDE on `positional_default`** — tracked separately in #208 and not blocking this validation.
+
+## Amendment 2026-05-16 — Post-#236 baseline re-derivation (issue #238)
+
+PR #236 promoted the signal channel to a first-class action dimension. Random and specialist baselines for `positional_default` (and the `default` cross-check) were re-derived on commit `dffe1060`:
+
+```
+uv run python experiments/p3_specialization/diagnostics/issue199_baselines.py \
+  --scenarios positional_default default \
+  --output-dir experiments/p3_specialization/diagnostics/results/issue238_post236_positional
+```
+
+| Scenario | Source | Random per-step | Specialist per-step | Gap |
+|---|---|---|---|---|
+| `positional_default` | pre-#236 (issue221_positional) | 241.3597 | 320.8872 | 79.5276 |
+| `positional_default` | post-#236 (issue238) | **241.3597** | **320.8872** | **79.5276** |
+| `default` | pre-#236 (issue221_positional) | 241.8461 | 320.9365 | 79.0904 |
+| `default` | post-#236 (issue238) | **241.8461** | **320.9365** | **79.0904** |
+
+Absolute shift: **0.0000** per-step (identical to 6 decimal places). Same reasoning as the issue #199 amendment — honest specialists + uniform-random action sampling yield invariant team-reward distributions under the new action width. `analyze_231.py`'s `BASELINES` dict is unchanged in value; the comment block was repointed to the post-#236 source JSONs and updated to record the invariance.


### PR DESCRIPTION
## Summary

Re-derives the random + specialist baselines that anchor the `gap_closed` denominators in `analyze_220.py` and `analyze_231.py`, on post-#236 main (commit `dffe1060`). PR #236 promoted the signal channel to a first-class action dimension (`[house, mode, signal]`), so the pre-#236 baselines were measured against a different action width.

**Key result: post-#236 values are numerically identical to pre-#236 (zero shift to 6 decimal places).** Specialist policies signal honestly (`bucket_brigade/baselines/specialist.py:107-115`, returns `signal == mode`) and the random policy samples uniformly over the new 3-element action. Neither evaluator lies, so the team-reward distribution observed under these two baselines is invariant under #236. Only *trained* policies that learn to lie can shift the denominator — re-derivation here re-anchors the source-of-truth comments so future post-#236 work is unambiguous.

### Random / specialist deltas vs pre-#236

| Scenario | Source | Random per-step | Specialist per-step | Gap | Random delta | Specialist delta |
|---|---|---|---|---|---|---|
| `minimal_specialization` | pre-#236 | -96.0704 | -22.0717 | 73.9987 | — | — |
| `minimal_specialization` | post-#236 | -96.0704 | -22.0717 | 73.9987 | **0.0000** | **0.0000** |
| `default` | pre-#236 | 241.8461 | 320.9365 | 79.0904 | — | — |
| `default` | post-#236 | 241.8461 | 320.9365 | 79.0904 | **0.0000** | **0.0000** |
| `positional_default` | pre-#236 | 241.3597 | 320.8872 | 79.5276 | — | — |
| `positional_default` | post-#236 | 241.3597 | 320.8872 | 79.5276 | **0.0000** | **0.0000** |

### Changes

- `analyze_220.py`: docstring updated to cite the post-#236 source; constant comment repointed to `diagnostics/results/issue238_post236_minspec/baselines.json`. Values (`MINSPEC_RANDOM = -96.07`, `MINSPEC_SPECIALIST = -22.07`) unchanged.
- `analyze_231.py`: `BASELINES` comment block repointed to the post-#236 source JSONs. Values unchanged.
- Two new `baselines.json` outputs under `diagnostics/results/issue238_post236_{minspec,positional}/`.
- Dated notebook amendments in both `research_notebook/2026-05-15_issue199_*.md` and `research_notebook/2026-05-16_issue221_*.md`.

### Coordination

- Sibling #237 re-derives random baselines across all 13 scenarios. The three random values above are also in scope for #237; they agree, so no merge conflict on values is expected.
- Sibling #240 (Nash) and #241 (format cleanup) are running in parallel. Edits here are tight to lines 53-54 / 28 of `analyze_220.py` and lines 57-65 of `analyze_231.py` — no formatting drift.
- Sibling #239 (re-run PPO training) consumes these denominators.

## Test plan

- [x] Both `baselines.json` outputs exist and contain `n_episodes: 50` per scenario block
- [x] `specialist_minus_random_per_step > 0` on `minimal_specialization` (73.9987)
- [x] `from experiments.p3_specialization import analyze_220, analyze_231` imports without error
- [x] `gap_closed(specialist) == 1.0` for `minimal_specialization` (algebraic identity holds)
- [x] Manual diff old vs new constants — absolute shift is 0.0000 (recorded in dated notebook amendments)

Closes #238