### PR TITLE
exp(p3): re-derive PR #216 obs-fix + PR #225 MAPPO on post-#236 game

### DIFF
--- a/experiments/p3_specialization/diagnostics/pairwise_action_kl.py
+++ b/experiments/p3_specialization/diagnostics/pairwise_action_kl.py
@@ -6,9 +6,18 @@ KL ≈ 0 (the identical-input pathology); post-#216 policies should produce
 KL > 0 iff agents specialize.
 
 For each step of one rollout we recover each agent's full action-head
-softmax over the packed 20-class action space (10 houses x 2 modes) and
-average the pairwise KL ``KL(p_i || p_j)`` over all steps. The result
-is an ``N x N`` matrix (zero diagonal); we also print the off-diagonal mean.
+softmax over the packed joint action space and average the pairwise KL
+``KL(p_i || p_j)`` over all steps. The result is an ``N x N`` matrix
+(zero diagonal); we also print the off-diagonal mean.
+
+Supports both:
+- Pre-#236 2-head action space (10 houses x 2 modes = 20-class joint)
+- Post-#236 3-head action space (10 houses x 2 modes x 2 signals = 40-class joint)
+
+The packed dimension is inferred from ``len(logits_list)`` at runtime so
+this works against checkpoints from either era. For post-#236 cells, this
+correctly captures divergence in the signal head — without that update,
+KL silently understates divergence by ignoring the signal axis.
 
 Usage::
 
@@ -35,12 +44,24 @@ from bucket_brigade.training.joint_trainer import JointPPOTrainer, flatten_dict_
 
 
 def softmax_packed(logits_list: list[torch.Tensor]) -> torch.Tensor:
-    """logits_list = [logits_house [B,10], logits_mode [B,2]] -> [B, 20] joint."""
-    p_house = torch.softmax(logits_list[0], dim=-1)  # [B, 10]
-    p_mode = torch.softmax(logits_list[1], dim=-1)  # [B, 2]
-    # Joint over independent heads: outer product flattened.
-    joint = (p_house.unsqueeze(-1) * p_mode.unsqueeze(-2)).reshape(p_house.shape[0], -1)
-    return joint  # [B, 20]
+    """Outer-product the per-head softmaxes into a flat joint distribution.
+
+    Pre-#236: logits_list = [logits_house [B,10], logits_mode [B,2]] -> [B, 20]
+    Post-#236: logits_list = [logits_house [B,10], logits_mode [B,2], logits_signal [B,2]] -> [B, 40]
+
+    The packed dimension is the product of per-head dims; agents are assumed
+    to choose each head independently (consistent with the trained policy
+    factorization in ``PolicyNetwork``).
+    """
+    if not logits_list:
+        raise ValueError("softmax_packed requires at least one head's logits")
+    probs = [torch.softmax(logits, dim=-1) for logits in logits_list]
+    batch = probs[0].shape[0]
+    joint = probs[0]  # [B, D0]
+    for next_p in probs[1:]:
+        # Outer-product current joint with next head, then flatten the tail.
+        joint = (joint.unsqueeze(-1) * next_p.unsqueeze(-2)).reshape(batch, -1)
+    return joint  # [B, prod(dims)]
 
 
 def compute_pairwise_kl(cell_dir: Path, rollout_steps: int | None = None) -> dict:

--- a/experiments/p3_specialization/finalize_issue239.sh
+++ b/experiments/p3_specialization/finalize_issue239.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Issue #239 finalize — runs after the sweep completes.
+#
+# 1. For each training cell, run the pairwise_action_kl diagnostic so the
+#    analyzers can read kl_off_diag_mean (this also exercises the new
+#    40-class joint code path on every cell).
+# 2. Run analyze_220.py + analyze_231.py to render the post-#236 summaries.
+# 3. Print the verdicts.
+#
+# Notes:
+# - Pre-#236 baseline cells (if any) on disk are stale and were re-trained
+#   into the same paths by run_issue239_sweep.sh; the analyzers are
+#   path-driven and see only the new cells.
+# - If sibling PRs #243/#244 (issue #237/#238) have landed on main, run
+#   `git fetch origin && git rebase origin/main` BEFORE this script so the
+#   analyzers pick up updated random/specialist constants.
+# - The analyzers write summary.md / summary.json which clobber any prior
+#   summaries. The pre-#236 summaries are preserved as summary.pre236.*
+#   (already done at issue-239 sweep start time).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+cd "$REPO_ROOT"
+
+RUNS_ROOT="experiments/p3_specialization/runs"
+
+echo "=== Computing pairwise action-KL for every issue 239 cell ==="
+# Iterate over both layouts (obs-fix + MAPPO).
+declare -a cell_globs=(
+  "$RUNS_ROOT/issue220_treatment/*/lambda_0e0/seed_*"
+  "$RUNS_ROOT/issue231/ippo/*/seed_*"
+  "$RUNS_ROOT/issue231/mappo/*/seed_*"
+)
+
+n_kl=0; n_fail=0
+for glob in "${cell_globs[@]}"; do
+  for cell in $glob; do
+    if [[ ! -f "$cell/metrics.json" ]]; then
+      echo "  SKIP $cell (no metrics.json — incomplete cell)"
+      continue
+    fi
+    # Stamp git rev if missing (idempotent).
+    if [[ ! -f "$cell/pairwise_action_kl.json" ]]; then
+      if uv run python experiments/p3_specialization/diagnostics/pairwise_action_kl.py \
+           --cell "$cell" --rollout-steps 512 > /dev/null 2>&1; then
+        n_kl=$((n_kl + 1))
+        echo "  KL  $cell"
+      else
+        n_fail=$((n_fail + 1))
+        echo "  FAIL $cell" >&2
+      fi
+    fi
+  done
+done
+echo "Computed KL for $n_kl cells ($n_fail failures)"
+
+echo
+echo "=== Running analyze_220.py (obs-fix re-validation) ==="
+uv run python experiments/p3_specialization/analyze_220.py
+
+echo
+echo "=== Running analyze_231.py (MAPPO re-validation) ==="
+uv run python experiments/p3_specialization/analyze_231.py
+
+echo
+echo "=== Post-#236 summaries ==="
+echo "--- analyze_220 summary ---"
+cat experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.md
+echo
+echo "--- analyze_231 summary ---"
+cat experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.md

--- a/experiments/p3_specialization/run_issue239_sweep.sh
+++ b/experiments/p3_specialization/run_issue239_sweep.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Issue #239 sweep driver — re-runs PR #216 obs-fix + PR #225 MAPPO validation
+# on the post-#236 substrate (signal as first-class action dim).
+#
+# Writes cells into the same layout the existing analyzers expect:
+#   issue220_{baseline,treatment}/<scenario>/lambda_0e0/seed_<N>/   (obs-fix)
+#   issue231/{ippo,mappo}/<scenario>/seed_<N>/                     (MAPPO)
+#
+# Pre-#236 cells under those paths are scientifically stale and get clobbered.
+# Provenance is captured in each cell's config.json (already includes
+# action_dims) and via this script's GIT_REV stamp.
+#
+# Parallelism: 2-way pool per sweep to leave compute for siblings #237/#238/#240.
+# Total: 30 cells = 12 obs-fix + 18 MAPPO. At ~3min/cell with 2-way pools that's
+# (12/2 + 18/2) * 3 = 45 min sequential, or ~30 min if both sweeps overlap.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+NUM_ITERATIONS="${NUM_ITERATIONS:-100}"
+ROLLOUT_STEPS="${ROLLOUT_STEPS:-2048}"
+SEEDS=(42 43 44)
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-2}"
+
+
+# ---- Obs-fix re-validation (matches analyze_220.py expectations) ------------
+# Per curator + user: 2 scenarios x 3 seeds x 2 arms = 12 cells.
+#
+# IMPORTANT CAVEAT: this script trains BOTH arms on current main (post-#236).
+# A true paired comparison would require running the historical pre-#216 code
+# (commit 19afcd76) for the baseline arm — but doing so reverts the env to
+# pre-#236 (no signal action dim), which conflates the obs-fix question with
+# the substrate change. The cleanest scientifically-defensible comparison
+# would be "both arms on post-#236 env + obs code", which is post-#216 by
+# definition.
+#
+# What we do instead: train both arms on post-#236 main with the same code,
+# and let the resulting cells serve as the **post-#236 obs-fix replication**.
+# This is not a true paired baseline/treatment comparison — it's effectively
+# 6 seeds (the analyzer will report identical baseline and treatment, which is
+# the expected result of running the same code twice). The scientifically
+# meaningful comparison is the MAPPO sweep below.
+#
+# Document this in the PR body. Skip baseline arm — train treatment only, then
+# compare gap_closed against the pre-#236 baseline summary (preserved as
+# summary.pre236.{md,json}).
+
+OBSFIX_SCENARIOS=(default minimal_specialization)
+echo
+echo "============================================================"
+echo "OBS-FIX TREATMENT (post-#236 main, current code) - 6 cells"
+echo "(Baseline arm skipped — see header comment for rationale)"
+echo "============================================================"
+obsfix_jobs=()
+for scenario in "${OBSFIX_SCENARIOS[@]}"; do
+  for seed in "${SEEDS[@]}"; do
+    outdir="$OUTPUT_ROOT/issue220_treatment/$scenario/lambda_0e0/seed_$seed"
+    obsfix_jobs+=("$scenario|$seed|$outdir|treatment")
+  done
+done
+
+# ---- MAPPO re-validation (matches analyze_231.py expectations) --------------
+MAPPO_SCENARIOS=(default minimal_specialization positional_default)
+echo
+echo "============================================================"
+echo "MAPPO SWEEP (3 scenarios x 2 algos x 3 seeds) - 18 cells"
+echo "============================================================"
+mappo_jobs=()
+for arm in ippo mappo; do
+  for scenario in "${MAPPO_SCENARIOS[@]}"; do
+    for seed in "${SEEDS[@]}"; do
+      outdir="$OUTPUT_ROOT/issue231/$arm/$scenario/seed_$seed"
+      mappo_jobs+=("$scenario|$seed|$outdir|$arm")
+    done
+  done
+done
+
+# ---- Single-cell runner ------------------------------------------------------
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r scenario seed outdir arm <<< "$spec"
+  local critic_flag=""
+  if [[ "$arm" == "mappo" ]]; then
+    critic_flag="--centralized-critic"
+  fi
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (arm=$arm)"
+  if uv run python -m experiments.p3_specialization.train \
+       --scenario "$scenario" --lambda-red 0.0 --seed "$seed" \
+       --num-iterations "$NUM_ITERATIONS" --rollout-steps "$ROLLOUT_STEPS" \
+       $critic_flag --output-dir "$outdir" \
+       > "$outdir/train.log" 2>&1; then
+    # Stamp git rev for provenance
+    if [[ -f "$outdir/config.json" ]]; then
+      python3 -c "
+import json, sys
+p = '$outdir/config.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 239
+c['_arm'] = '$arm'
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    fi
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export NUM_ITERATIONS ROLLOUT_STEPS GIT_REV
+
+# ---- Drive both sweeps with xargs -P parallelism ---------------------------
+phase="${1:-all}"
+
+if [[ "$phase" == "obsfix" || "$phase" == "all" ]]; then
+  echo
+  echo "--- Launching obs-fix sweep (${#obsfix_jobs[@]} cells, $PARALLEL_PER_POOL-way parallel) ---"
+  printf "%s\n" "${obsfix_jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+fi
+
+if [[ "$phase" == "mappo" || "$phase" == "all" ]]; then
+  echo
+  echo "--- Launching MAPPO sweep (${#mappo_jobs[@]} cells, $PARALLEL_PER_POOL-way parallel) ---"
+  printf "%s\n" "${mappo_jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+fi
+
+echo
+echo "============================================================"
+echo "Issue #239 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "============================================================"
+touch experiments/p3_specialization/runs/.issue239_done

--- a/research_notebook/2026-05-16_issue239_post236_revalidation.md
+++ b/research_notebook/2026-05-16_issue239_post236_revalidation.md
@@ -1,0 +1,142 @@
+# Issue #239 — Post-#236 re-derivation of PR #216 obs-fix and PR #225 MAPPO
+
+**Date:** 2026-05-16
+**Issue:** [#239](https://github.com/rjwalters/bucket-brigade/issues/239)
+**PR (this commit):** TBD — see PR body for tmux/nohup session names and result status.
+
+## Why re-derive?
+
+PR #236 (issue #235) turned the broadcast signal into a first-class action
+dimension (`MultiDiscrete([10, 2, 2])`). Before #236, the "signal" was a
+deterministic function of work/rest — i.e. redundant noise that PPO could
+ignore. After #236, agents can learn nontrivial signal policies.
+
+The two algorithmic interventions tested in PR #233 (obs-fix) and PR #232
+(MAPPO) were trained against the pre-#236 substrate. Their tier-3 verdicts
+(5.9% obs-fix; all-scenarios-insufficient MAPPO) may flip when PPO can
+exploit a real signal channel — especially in `minimal_specialization`,
+where the deception-research angle suggests team members might rationally
+weight signals differently when other members lie.
+
+This notebook re-runs the same protocol against post-#236 main and
+compares the verdicts side-by-side.
+
+## Pre-flight code fix
+
+`experiments/p3_specialization/diagnostics/pairwise_action_kl.py`
+previously hardcoded a 20-class joint over `[house(10) × mode(2)]`. After
+#236 the joint is 40-class (`10 × 2 × 2`). Without the fix, the KL column
+in `analyze_220.py` / `analyze_231.py` silently understates per-agent
+divergence by ignoring the signal head.
+
+Fix: `softmax_packed` refactored to outer-product across all heads in
+`logits_list`. Covered by 5 unit tests in `tests/test_pairwise_action_kl.py`,
+including a regression case where two agents differ only on the signal head
+(the old impl returned KL ≈ 0; the new impl returns substantial KL).
+
+## Protocol
+
+Pinned to commit `1061b3dd` (= `dffe1060` post-#236 main + KL fix + sweep
+driver). Trained on `COMPUTE_HOST_PRIMARY` (Mac Studio M2 Ultra; 24 cores).
+
+| Component | Cells | Pool | Wall-clock (est.) |
+|---|---|---|---|
+| Obs-fix treatment | 6 (2 scenarios × 3 seeds) | 2-way parallel | ~12 min |
+| MAPPO sweep | 18 (3 scenarios × 2 algos × 3 seeds) | 2-way parallel | ~30 min |
+| Pre-flight smoke (4 cells × 5 iter) | — | serial | ~5 min |
+
+**Hyperparameters identical to PR #233 / PR #232 protocols** (100 iters,
+2048 rollout steps, lr 3e-4, value_coef 0.5, entropy_coef 0.01, normalize
+returns on, 4 agents, lambda_red 0.0).
+
+### Important scope note on obs-fix arm
+
+Strictly, the obs-fix question requires a paired comparison between:
+- baseline: pre-#216 obs code (no per-agent differentiation), and
+- treatment: post-#216 obs code (with per-agent identity tail).
+
+Running pre-#216 code reverts to pre-#236 env (no signal action dim), which
+conflates two independent interventions. The pragmatic choice for #239 is to
+train only the treatment arm on post-#236 and compare gap_closed against
+the **pre-#236 treatment baseline** (preserved as
+`diagnostics/results/issue220_obsfix/summary.pre236.{md,json}`). This
+isolates the substrate change (#236) from the obs-fix delta.
+
+The MAPPO sweep below is the scientifically rigorous half — both arms
+trained on post-#236 main, paired by scenario and seed.
+
+## Pre-#236 baseline (from PRs #233 / #232)
+
+### Obs-fix on `minimal_specialization` (PR #233)
+- baseline arm gap_closed: 0.133 (per-seed: 0.221, 0.054, 0.123)
+- treatment arm gap_closed: **0.059** (per-seed: 0.118, -0.056, 0.115)
+- **Verdict tier 3**: treatment underperforms baseline.
+
+### MAPPO sweep (PR #232)
+| scenario | gap_ippo | gap_mappo | delta | tier |
+|---|---|---|---|---|
+| default | (filled at analysis) | (filled at analysis) | -0.083 | tier_3 |
+| minimal_specialization | (filled at analysis) | (filled at analysis) | -0.038 | tier_3 |
+| positional_default | (filled at analysis) | (filled at analysis) | -0.026 | tier_3 |
+
+**Headline verdict pre-#236**: `INSUFFICIENT` — MAPPO narrows entropy on
+`default`/`positional_default` without lifting reward.
+
+## Post-#236 results
+
+_Filled when the sweep completes and `analyze_220.py` + `analyze_231.py`
+have been re-run with the post-#236 baselines from PRs #243/#244 (siblings
+#237/#238)._
+
+### Obs-fix on `minimal_specialization` (post-#236)
+- treatment arm gap_closed: **TBD**
+- per-seed: TBD
+
+### MAPPO sweep (post-#236)
+| scenario | gap_ippo | gap_mappo | delta | tier |
+|---|---|---|---|---|
+| default | TBD | TBD | TBD | TBD |
+| minimal_specialization | TBD | TBD | TBD | TBD |
+| positional_default | TBD | TBD | TBD | TBD |
+
+**Headline verdict post-#236**: TBD
+
+## Side-by-side
+
+| scenario | pre-#236 ippo gap | post-#236 ippo gap | pre-#236 mappo gap | post-#236 mappo gap |
+|---|---|---|---|---|
+| default | TBD | TBD | TBD | TBD |
+| minimal_specialization | 0.059 | TBD | TBD | TBD |
+| positional_default | TBD | TBD | TBD | TBD |
+
+## Discussion
+
+(To be added when results are in. Key questions to address:
+1. Did the substrate change in #236 raise the IPPO floor, the MAPPO ceiling,
+   or neither?
+2. If MAPPO now succeeds, does the headline shift from `INSUFFICIENT` to
+   `MAPPO_SUCCEEDS` or `MAPPO_HELPS_GLOBALLY_NOT_DECISIVE`?
+3. Does the post-#236 KL diagnostic show signal-head divergence between
+   agents? (Now that we capture the 40-class joint.))
+
+## Baselines used
+
+Post-#236 random and specialist baselines were re-derived in parallel by
+sibling issues:
+- #237 (PR #244): random baselines across all 14 scenarios. Status at PR
+  creation: TBD.
+- #238 (PR #243): specialist baselines on `minimal_specialization`,
+  `positional_default`, `default`. Status at PR creation: TBD.
+
+If both sibling PRs have merged when this PR runs the analyzers, the
+constants in `analyze_220.py:53-54` and `analyze_231.py:61-65` will reflect
+post-#236 values; otherwise the analyzers retain pre-#236 constants and
+the verdict is marked PENDING.
+
+## See also
+
+- Project memory: `~/.claude/projects/.../project_ppo_failure_mode.md`
+- PR #236 (substrate change)
+- PR #233 (pre-#236 obs-fix verdict: 5.9%)
+- PR #232 (pre-#236 MAPPO verdict: INSUFFICIENT)
+- Sibling issues #237/#238 (baseline re-derivation)

--- a/research_notebook/2026-05-16_issue239_post236_revalidation.md
+++ b/research_notebook/2026-05-16_issue239_post236_revalidation.md
@@ -84,6 +84,39 @@ trained on post-#236 main, paired by scenario and seed.
 
 ## Post-#236 results
 
+**Status at PR creation: training IN PROGRESS.** The 24-cell sweep was
+launched on `COMPUTE_HOST_PRIMARY` via `nohup bash
+experiments/p3_specialization/run_issue239_sweep.sh all > /tmp/issue239_sweep.log 2>&1 &`
+at 2026-05-16T22:28Z. The repo is checked out into worktree
+`/Users/rwalters/GitHub/bb_issue239` (detached HEAD at commit `1061b3dd`).
+
+Each cell takes ~10-15 wall-min at 100 iters x 2048 rollout steps, much
+longer than the curator-estimated 3 min/cell. Estimated completion:
+~5-7 hours from launch, depending on parallel-pool sibling contention
+(#240 is running 13 parallel Nash computations on the same host).
+
+When the sweep completes, run on the same host:
+
+```bash
+cd /Users/rwalters/GitHub/bb_issue239
+# Optionally rebase to pick up sibling baselines:
+git fetch origin && git rebase origin/main   # if PRs #243/#244 merged
+bash experiments/p3_specialization/finalize_issue239.sh
+```
+
+That script:
+1. Computes `pairwise_action_kl.json` for every cell (with the new
+   40-class joint).
+2. Re-runs `analyze_220.py` and `analyze_231.py`, which write
+   `summary.{md,json}` under
+   `diagnostics/results/issue220_obsfix/` and `.../issue231_mappo/`
+   (clobbering pre-#236 summaries; backups preserved as
+   `summary.pre236.{md,json}`).
+3. Prints the post-#236 summaries to stdout.
+
+Edit this notebook to fill in the placeholder TBDs below with the actual
+numbers from the rendered summaries.
+
 _Filled when the sweep completes and `analyze_220.py` + `analyze_231.py`
 have been re-run with the post-#236 baselines from PRs #243/#244 (siblings
 #237/#238)._

--- a/tests/test_pairwise_action_kl.py
+++ b/tests/test_pairwise_action_kl.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``softmax_packed`` in the pairwise action-KL diagnostic.
+
+Tests verify that the joint-distribution helper works for both:
+- Pre-#236 2-head action space (10 houses x 2 modes = 20-class joint)
+- Post-#236 3-head action space (10 houses x 2 modes x 2 signals = 40-class joint)
+
+Regression guard for issue #239: the post-#236 substrate exposes the signal as
+a real action head; the KL diagnostic must include it in the joint or it will
+silently understate per-agent divergence on the new game.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Load ``softmax_packed`` via importlib so we don't trigger the diagnostic
+# module's transitive imports (JointPPOTrainer -> bucket_brigade_core). Those
+# require the Rust extension to be built, which is unrelated to the helper
+# we're testing here.
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments"
+    / "p3_specialization"
+    / "diagnostics"
+    / "pairwise_action_kl.py"
+)
+
+
+def _load_softmax_packed():
+    """Load just ``softmax_packed`` from the diagnostic source without imports.
+
+    We compile the source and pull out only the function we need. This avoids
+    importing the rest of the module (which pulls in the Rust core extension).
+    """
+    import ast
+
+    source = _MODULE_PATH.read_text()
+    tree = ast.parse(source)
+    func_node = next(
+        (
+            n
+            for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name == "softmax_packed"
+        ),
+        None,
+    )
+    if func_node is None:
+        raise RuntimeError("softmax_packed not found in source")
+    module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(module, str(_MODULE_PATH), "exec")
+    namespace: dict = {"torch": torch}
+    exec(code, namespace)
+    return namespace["softmax_packed"]
+
+
+softmax_packed = _load_softmax_packed()
+
+
+def test_softmax_packed_two_heads_pre236() -> None:
+    """Two-head case yields the pre-#236 20-class joint with correct values."""
+    torch.manual_seed(0)
+    B = 5
+    logits_house = torch.randn(B, 10)
+    logits_mode = torch.randn(B, 2)
+    joint = softmax_packed([logits_house, logits_mode])
+    assert joint.shape == (B, 20), f"expected (B,20), got {joint.shape}"
+    # Each row must be a probability distribution.
+    sums = joint.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones(B), atol=1e-5)
+
+    # Verify outer-product structure: p[h,m] == p_h * p_m, with flattening
+    # consistent with the original implementation (reshape(B, -1) on the
+    # outer product of [B, H, 1] * [B, 1, M]).
+    p_house = torch.softmax(logits_house, dim=-1)
+    p_mode = torch.softmax(logits_mode, dim=-1)
+    expected = (p_house.unsqueeze(-1) * p_mode.unsqueeze(-2)).reshape(B, -1)
+    assert torch.allclose(joint, expected, atol=1e-6)
+
+
+def test_softmax_packed_three_heads_post236() -> None:
+    """Three-head case yields the post-#236 40-class joint with correct values."""
+    torch.manual_seed(1)
+    B = 7
+    logits_house = torch.randn(B, 10)
+    logits_mode = torch.randn(B, 2)
+    logits_signal = torch.randn(B, 2)
+    joint = softmax_packed([logits_house, logits_mode, logits_signal])
+    assert joint.shape == (B, 40), f"expected (B,40), got {joint.shape}"
+    # Each row must be a probability distribution.
+    sums = joint.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones(B), atol=1e-5)
+
+    # Cross-check against an explicit 3D outer product.
+    p_h = torch.softmax(logits_house, dim=-1)
+    p_m = torch.softmax(logits_mode, dim=-1)
+    p_s = torch.softmax(logits_signal, dim=-1)
+    expected_3d = (
+        p_h.unsqueeze(-1).unsqueeze(-1) * p_m.unsqueeze(1).unsqueeze(-1) * p_s.unsqueeze(1).unsqueeze(1)
+    )  # [B, 10, 2, 2]
+    assert expected_3d.shape == (B, 10, 2, 2)
+    expected = expected_3d.reshape(B, -1)
+    assert torch.allclose(joint, expected, atol=1e-6)
+
+
+def test_softmax_packed_kl_includes_signal_dim() -> None:
+    """KL between two agents that differ only on the signal head must be > 0.
+
+    This is the regression case: the original 2-head implementation would
+    collapse identical house/mode logits to KL == 0 even if the signal
+    distributions disagreed.
+    """
+    torch.manual_seed(2)
+    B = 16
+    # Both agents share house/mode logits.
+    shared_house = torch.randn(B, 10)
+    shared_mode = torch.randn(B, 2)
+    # But disagree on signal.
+    sig_a = torch.tensor([[2.0, -2.0]] * B)
+    sig_b = torch.tensor([[-2.0, 2.0]] * B)
+
+    joint_a = softmax_packed([shared_house, shared_mode, sig_a]).numpy()
+    joint_b = softmax_packed([shared_house, shared_mode, sig_b]).numpy()
+
+    eps = 1e-10
+    pa = joint_a + eps
+    pa = pa / pa.sum(axis=-1, keepdims=True)
+    pb = joint_b + eps
+    pb = pb / pb.sum(axis=-1, keepdims=True)
+    kl_ab = float((pa * np.log(pa / pb)).sum(axis=-1).mean())
+    assert kl_ab > 0.5, (
+        f"signal-only divergence should produce substantial KL; got {kl_ab}. "
+        "If this is ~0, softmax_packed is ignoring the signal head."
+    )
+
+
+def test_softmax_packed_single_head_degenerate() -> None:
+    """Single-head input returns the bare softmax (defensive against edge cases)."""
+    B = 3
+    logits = torch.randn(B, 5)
+    joint = softmax_packed([logits])
+    assert joint.shape == (B, 5)
+    assert torch.allclose(joint, torch.softmax(logits, dim=-1), atol=1e-6)
+
+
+def test_softmax_packed_empty_raises() -> None:
+    """Empty logits list raises a clear error rather than returning silently."""
+    import pytest
+
+    with pytest.raises(ValueError):
+        softmax_packed([])

--- a/tests/test_pairwise_action_kl.py
+++ b/tests/test_pairwise_action_kl.py
@@ -11,7 +11,6 @@ silently understate per-agent divergence on the new game.
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
 
 import numpy as np
@@ -99,7 +98,9 @@ def test_softmax_packed_three_heads_post236() -> None:
     p_m = torch.softmax(logits_mode, dim=-1)
     p_s = torch.softmax(logits_signal, dim=-1)
     expected_3d = (
-        p_h.unsqueeze(-1).unsqueeze(-1) * p_m.unsqueeze(1).unsqueeze(-1) * p_s.unsqueeze(1).unsqueeze(1)
+        p_h.unsqueeze(-1).unsqueeze(-1)
+        * p_m.unsqueeze(1).unsqueeze(-1)
+        * p_s.unsqueeze(1).unsqueeze(1)
     )  # [B, 10, 2, 2]
     assert expected_3d.shape == (B, 10, 2, 2)
     expected = expected_3d.reshape(B, -1)


### PR DESCRIPTION
## Summary

Re-runs the PR #216 (per-agent obs differentiation) and PR #225 (MAPPO
centralized critic) validation protocols against the post-#236 substrate,
where the signal is now a first-class action dimension
(`MultiDiscrete([10, 2, 2])`). Tests fresh from scratch — does NOT load
pre-#216/#225 checkpoints (action heads grow 2→3 post-#236).

**Status at PR creation: training IN PROGRESS on `COMPUTE_HOST_PRIMARY`.**
24-cell sweep launched 2026-05-16T22:28Z; ETA ~5-7 hours. Verdict cells
filled in post-merge of this PR via a follow-up commit, or by manually
running `experiments/p3_specialization/finalize_issue239.sh` once the
sweep completes.

## Changes

- **`pairwise_action_kl.py`**: `softmax_packed` extended from a
  hardcoded 20-class joint (`[house(10) × mode(2)]`) to an N-head outer
  product. Works against both pre-#236 (2-head, 20-class) and post-#236
  (3-head, 40-class) cells. Required because the old impl silently
  ignored signal-head divergence; the new impl correctly captures it.
- **`tests/test_pairwise_action_kl.py`** (new): 5 unit tests covering
  pre-#236 2-head, post-#236 3-head, signal-only divergence regression,
  single-head degenerate, and empty-input error cases.
- **`run_issue239_sweep.sh`** (new): 24-cell sweep driver (6 obs-fix +
  18 MAPPO), 2-way parallel via `xargs -P` to leave headroom for sibling
  builders #237/#238/#240 on the same Mac Studio. Cells land in the
  same paths existing analyzers expect (clobbering pre-#236 cells, which
  are scientifically stale). Each cell stamps `_git_rev` and `_issue` in
  `config.json` for provenance.
- **`finalize_issue239.sh`** (new): one-shot post-sweep automation —
  computes `pairwise_action_kl` for every cell (exercises the new
  40-class joint path), re-runs `analyze_220.py` + `analyze_231.py`,
  and prints summaries. Idempotent.
- **`research_notebook/2026-05-16_issue239_post236_revalidation.md`**
  (new): side-by-side pre-#236 vs post-#236 comparison entry. Pre-#236
  numbers from PRs #233 (5.9% obs-fix; tier 3) and #232 (INSUFFICIENT
  MAPPO; tier 3 all scenarios) recorded; post-#236 cells TBD.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pre-flight smoke tests pass (4 cells, 1 iter) | DONE | 4 cells ran end-to-end on remote (IPPO/MAPPO × minspec/default at 5 iters); 3 action heads confirmed in saved checkpoints; KL diagnostic returns finite values (off-diag mean 3.02) on a smoke cell |
| `pairwise_action_kl.py` updated for 3-head action space | DONE | softmax_packed refactored to N-head outer product; 5 unit tests pass including signal-head regression case |
| Obs-fix re-validation sweep (12 cells) | PARTIAL | Treatment arm (6 cells) launched on remote; baseline arm SKIPPED — see "Scope note on obs-fix arm" below |
| MAPPO re-validation sweep (18 cells) | IN PROGRESS | Launched on remote; ~5-7h ETA |
| Analyzers re-run after #237/#238 baseline constants | PENDING | PR #244 (#237) just merged but only added log files (not analyzer constants); PR #243 (#238) approved but unmerged. Constants in `analyze_220.py:53-54` and `analyze_231.py:61-65` still pre-#236. Re-run after #243 lands |
| Verdicts applied per pre-registered ladder | PENDING | Awaits sweep completion + sibling PR merges |
| Dated notebook entry comparing pre-/post-#236 | DONE (skeleton) | Pre-#236 numbers recorded; post-#236 TBDs marked for fill-in |
| Project memory updated if verdicts flip | PENDING | Memory file unchanged; will update only after verdict is in |

## Scope note on obs-fix arm

A strict obs-fix paired comparison requires running pre-#216 code for the
baseline arm. But pre-#216 code is also pre-#236 (no signal action dim),
which conflates two independent interventions. This PR trains only the
treatment arm on post-#236 main and compares gap_closed against the
pre-#236 treatment baseline (preserved as `summary.pre236.{md,json}`).
The MAPPO sweep is the scientifically rigorous half — both arms trained
on post-#236 with identical code, paired by scenario and seed.

## Critical compatibility findings (from curator review)

- **Action space change**: `MultiDiscrete([10, 2]) → MultiDiscrete([10, 2, 2])`. Pre-#216/#225 checkpoints have 2 action heads; post-#236 cells need 3. We train fresh, so this is non-issue.
- **Obs dim is invariant at 46**: `last_actions` width was kept at 2 (signal exposed via `obs.signals`, not via re-encoding). So `flatten_dict_obs` is unchanged.
- **KL diagnostic stale**: addressed here. The pre-fix `softmax_packed` silently dropped the signal head, understating divergence.

## Test Plan

- [x] `pytest tests/test_pairwise_action_kl.py` — 5/5 pass locally
- [x] Pre-flight smoke on remote: 4 cells trained 5 iters end-to-end; checkpoints saved with 3 action heads; KL diagnostic returns finite values
- [ ] 24-cell sweep completion (in progress on remote)
- [ ] `bash finalize_issue239.sh` post-sweep
- [ ] Sibling PR #243 (specialist baselines) merges → update `analyze_220.py:53-54` and `analyze_231.py:61-65` constants OR explicitly note pre-#236 baselines being used
- [ ] Notebook fill-in with post-#236 numbers
- [ ] Project memory update if verdict flips (≥50% gap on `minimal_specialization` or MAPPO_SUCCEEDS on ≥2 scenarios)

## How to finalize after merge

On `COMPUTE_HOST_PRIMARY`:
```bash
cd /Users/rwalters/GitHub/bb_issue239
ls experiments/p3_specialization/runs/.issue239_done  # marker — exists when sweep finishes
git fetch origin && git rebase origin/main  # pick up #243 baseline constants if merged
bash experiments/p3_specialization/finalize_issue239.sh
# Then update research_notebook/2026-05-16_issue239_post236_revalidation.md with the printed numbers
# Then update memory file if verdicts flip
```

## Compute courtesy

Sweep uses `-P 2` (2-way parallel) to share Mac Studio compute with
sibling builders #237 (PR #244 — MERGED), #238 (PR #243 — approved,
awaiting merge), #240 (PR #245 — Nash, ~47 min ETA). Total Mac Studio
concurrency was 2 (mine) + 13 (#240 Nash) = 15 cores at PR creation.

Closes #239