### PR TITLE
docs: update scenario count from 12/13 to 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Architecture details: [docs/SIMPLIFIED_ARCHITECTURE.md](docs/SIMPLIFIED_ARCHITEC
 
 ## Scenarios
 
-Thirteen named scenarios live in `bucket-brigade-core/src/scenarios.rs` (the canonical source): `default`, `easy`, `hard`, `trivial_cooperation`, `early_containment`, `greedy_neighbor`, `sparse_heroics`, `rest_trap`, `chain_reaction`, `deceptive_calm`, `overcrowding`, `mixed_motivation`, `minimal_specialization`. Each isolates a different dynamic — coordination pressure, social dilemma, sparse work, deceptive signaling, etc. See [docs/game_description.md](docs/game_description.md) for narrative descriptions.
+Fourteen named scenarios live in `bucket-brigade-core/src/scenarios.rs` (the canonical source): `default`, `easy`, `hard`, `trivial_cooperation`, `early_containment`, `greedy_neighbor`, `sparse_heroics`, `rest_trap`, `chain_reaction`, `deceptive_calm`, `overcrowding`, `mixed_motivation`, `minimal_specialization`, `positional_default`. Each isolates a different dynamic — coordination pressure, social dilemma, sparse work, deceptive signaling, etc. See [docs/game_description.md](docs/game_description.md) for narrative descriptions.
 
 ## Custom agents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ This documentation directory contains detailed guides, specifications, and resea
 - **Agents**: 4-10 players, each owning one house
 - **Signals**: Work/Rest intentions (may be deceptive)
 - **Actions**: Choose house and work/rest mode
-- **Scenarios**: 12 named configurations testing different cooperation aspects
+- **Scenarios**: 14 named configurations testing different cooperation aspects
 
 ### Agent Types
 - **Heuristic Agents**: Parameterized behavioral models (Firefighter, Coordinator, etc.)

--- a/docs/game_description.md
+++ b/docs/game_description.md
@@ -88,7 +88,7 @@ This is a **social dilemma** — the Nash equilibrium is not the social optimum.
 
 5. **Parameterizable Scenarios**
    - 12 scenario parameters (fire spread rate, work cost, etc.)
-   - Create diverse cooperation challenges (12 named scenarios)
+   - Create diverse cooperation challenges (14 named scenarios)
    - Same game engine, different strategic landscapes
 
 ---
@@ -162,7 +162,7 @@ assert result1 == result2  # Guaranteed identical
 
 ### 3. Parameterizable Difficulty
 
-**12 Named Scenarios** span the cooperation spectrum:
+**14 Named Scenarios** span the cooperation spectrum:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -626,7 +626,7 @@ But it's designed for **AI vs. AI**, not human play. Human reaction time doesn't
 ✅ **Small enough to understand**: 30-bit state space, 500 lines of code
 ✅ **Fast enough to scale**: 5ms per game, 1000-game tournaments in seconds
 ✅ **Rich enough to be interesting**: Social dilemmas, deception, coordination
-✅ **Parameterizable enough to generalize**: 12 scenarios, continuous parameter space
+✅ **Parameterizable enough to generalize**: 14 scenarios, continuous parameter space
 ✅ **Observable enough to interpret**: Full visibility, hand-coded baselines
 ✅ **Simple enough to implement**: No dependencies, cross-platform support
 


### PR DESCRIPTION
## Summary

Trivial doc count fix, 4 files, no logic. Updates stale scenario-count
references to reflect the current canonical catalog of 14 named scenarios
(positional_default was added by PR #217 but doc counts were never updated).

## Changes

- `README.md:79` — "Thirteen named scenarios" -> "Fourteen named scenarios"; appended `positional_default` to the enumeration list.
- `docs/README.md:56` — "12 named configurations" -> "14 named configurations".
- `docs/game_description.md:91` — "(12 named scenarios)" -> "(14 named scenarios)".
- `docs/game_description.md:165` — "12 Named Scenarios" -> "14 Named Scenarios".
- `docs/game_description.md:629` — "12 scenarios, continuous parameter space" -> "14 scenarios, ...".

Intentionally NOT touched (per curator scope guard):
- `docs/game_description.md:90` — "12 scenario parameters" refers to parameter count on `Scenario`, distinct from scenario count.
- `docs/NASH_BENCHMARKS.md` — "12 scenarios" references a historical benchmark run, not the current catalog.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| README count + enumeration updated | done | grep confirms "Fourteen named" and `positional_default` present |
| docs/README.md count updated | done | grep confirms "14 named configurations" |
| docs/game_description.md three locations updated | done | grep confirms all three reflect 14 |
| No stragglers remain | done | `grep -nE "thirteen\|Thirteen\|12 named\|13 named\|12 Named\|13 Named\|12 scenarios\|13 scenarios"` returns empty on the three files |
| Enumeration matches scenarios.rs declaration order | done | 14 `m.insert(...)` calls in `bucket-brigade-core/src/scenarios.rs`; order matches |

## Test Plan

Docs-only change. No automated tests required.

- [x] `grep -c m.insert bucket-brigade-core/src/scenarios.rs` returns 14
- [x] Stragglers grep returns empty
- [x] Enumeration in `README.md:79` matches `m.insert` order in `scenarios.rs`

Closes #247