### PR TITLE
exp(p3): finalize #239 verdict — TIER 3 INSUFFICIENT on both arms

### DIFF
--- a/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.json
+++ b/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.json
@@ -3,134 +3,36 @@
     "default": {
       "seeds": [
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_42",
-          "trailing5_team_reward": 251.10693359375,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            1.762802779832572,
-            3.3729522885337713,
-            1.7971840567781312,
-            2.6650156577694464
-          ],
-          "mean_entropy_final": 2.39948869572848,
-          "entropy_spread": 1.6101495087011992,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 42
+          "seed": 42,
+          "missing": true
         },
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_43",
-          "trailing5_team_reward": 248.6869140625,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            1.2011446599571476,
-            3.4615243367278725,
-            1.904038237977274,
-            3.520306690719813
-          ],
-          "mean_entropy_final": 2.521753481345527,
-          "entropy_spread": 2.3191620307626657,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 43
+          "seed": 43,
+          "missing": true
         },
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/default/lambda_0e0/seed_44",
-          "trailing5_team_reward": 248.6642578125,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            1.7986019506535813,
-            2.6317202128415706,
-            1.9213140468283847,
-            2.7526042219010565
-          ],
-          "mean_entropy_final": 2.2760601080561482,
-          "entropy_spread": 0.9540022712474752,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 44
+          "seed": 44,
+          "missing": true
         }
       ],
-      "n_seeds": 3,
-      "team_reward_mean": 249.48603515625004,
-      "team_reward_std": 1.4037849318657993,
-      "team_reward_per_seed": [
-        251.10693359375,
-        248.6869140625,
-        248.6642578125
-      ],
-      "mean_entropy_mean": 2.3991007617100517,
-      "entropy_spread_mean": 1.6277712702371134,
-      "kl_off_diag_mean": null
+      "n_seeds": 0
     },
     "minimal_specialization": {
       "seeds": [
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_42",
-          "trailing5_team_reward": -79.71875,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            2.5398384342407296,
-            2.787108557548882,
-            2.910822987906927,
-            2.628116923141738
-          ],
-          "mean_entropy_final": 2.716471725709569,
-          "entropy_spread": 0.3709845536661973,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 42
+          "seed": 42,
+          "missing": true
         },
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_43",
-          "trailing5_team_reward": -92.0703125,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            1.6434246777773436,
-            3.270321940173486,
-            2.487033421419339,
-            3.573058293110413
-          ],
-          "mean_entropy_final": 2.7434595831201456,
-          "entropy_spread": 1.9296336153330693,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 43
+          "seed": 43,
+          "missing": true
         },
         {
-          "cell": "experiments/p3_specialization/runs/issue220_baseline/minimal_specialization/lambda_0e0/seed_44",
-          "trailing5_team_reward": -86.941015625,
-          "final_iter": 99,
-          "per_agent_entropy_final": [
-            2.2975568257450054,
-            3.04514220972621,
-            3.5950289428636357,
-            4.106841651300637
-          ],
-          "mean_entropy_final": 3.2611424074088715,
-          "entropy_spread": 1.8092848255556313,
-          "kl_off_diag_mean": null,
-          "kl_off_diag_max": null,
-          "seed": 44
+          "seed": 44,
+          "missing": true
         }
       ],
-      "n_seeds": 3,
-      "team_reward_mean": -86.243359375,
-      "team_reward_std": 6.205265282824306,
-      "team_reward_per_seed": [
-        -79.71875,
-        -92.0703125,
-        -86.941015625
-      ],
-      "mean_entropy_mean": 2.9070245720795285,
-      "entropy_spread_mean": 1.3699676648516326,
-      "kl_off_diag_mean": null,
-      "gap_closed_mean": 0.13279244087837833,
-      "gap_closed_per_seed": [
-        0.22096283783783774,
-        0.05404983108108099,
-        0.12336465371621605
-      ]
+      "n_seeds": 0
     }
   },
   "treatment": {
@@ -138,132 +40,132 @@
       "seeds": [
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_42",
-          "trailing5_team_reward": 256.22998046875,
+          "trailing5_team_reward": 254.576171875,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            1.9760577548306684,
-            1.9270287340117007,
-            2.4324849530945536,
-            2.760269935954415
+            0.00642758314625143,
+            0.0,
+            0.0,
+            0.0
           ],
-          "mean_entropy_final": 2.2739603444728345,
-          "entropy_spread": 0.8332412019427142,
-          "kl_off_diag_mean": 3.6779362161954245,
-          "kl_off_diag_max": 5.2724504470825195,
+          "mean_entropy_final": 0.0016068957865628575,
+          "entropy_spread": 0.00642758314625143,
+          "kl_off_diag_mean": 19.187640861962183,
+          "kl_off_diag_max": 23.025850296020508,
           "seed": 42
         },
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_43",
-          "trailing5_team_reward": 253.37646484375,
+          "trailing5_team_reward": 244.13662109375,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            2.5168488864084946,
-            2.8232077623924883,
-            2.7673367211678506,
-            0.9430679637786167
+            0.0,
+            0.0,
+            0.0,
+            0.0
           ],
-          "mean_entropy_final": 2.262615333436863,
-          "entropy_spread": 1.8801397986138717,
-          "kl_off_diag_mean": 4.0048406173785525,
-          "kl_off_diag_max": 7.143485069274902,
+          "mean_entropy_final": 0.0,
+          "entropy_spread": 0.0,
+          "kl_off_diag_mean": 22.722083409627277,
+          "kl_off_diag_max": 23.025850296020508,
           "seed": 43
         },
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/default/lambda_0e0/seed_44",
-          "trailing5_team_reward": 251.508203125,
+          "trailing5_team_reward": 255.50390625,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            2.7930549027250926,
-            1.052764559390835,
-            2.228319814060957,
-            3.2985985711022634
+            0.0,
+            0.0,
+            0.0,
+            0.0
           ],
-          "mean_entropy_final": 2.343184461819787,
-          "entropy_spread": 2.2458340117114286,
-          "kl_off_diag_mean": 3.4706351459026337,
-          "kl_off_diag_max": 8.473858833312988,
+          "mean_entropy_final": 0.0,
+          "entropy_spread": 0.0,
+          "kl_off_diag_mean": 23.025800228118896,
+          "kl_off_diag_max": 23.025850296020508,
           "seed": 44
         }
       ],
       "n_seeds": 3,
-      "team_reward_mean": 253.70488281250002,
-      "team_reward_std": 2.3779590182835615,
+      "team_reward_mean": 251.40556640625002,
+      "team_reward_std": 6.3121586826319565,
       "team_reward_per_seed": [
-        256.22998046875,
-        253.37646484375,
-        251.508203125
+        254.576171875,
+        244.13662109375,
+        255.50390625
       ],
-      "mean_entropy_mean": 2.293253379909828,
-      "entropy_spread_mean": 1.653071670756005,
-      "kl_off_diag_mean": 3.7178039931588702
+      "mean_entropy_mean": 0.0005356319288542859,
+      "entropy_spread_mean": 0.0021425277154171435,
+      "kl_off_diag_mean": 21.645174833236116
     },
     "minimal_specialization": {
       "seeds": [
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_42",
-          "trailing5_team_reward": -87.34228515625,
+          "trailing5_team_reward": -76.5126953125,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            3.6043440732151093,
-            3.087232878746042,
-            3.165187410956134,
-            1.7336835825598582
+            0.0,
+            0.00642758314625143,
+            0.5661146474502893,
+            0.06142855404234769
           ],
-          "mean_entropy_final": 2.897611986369286,
-          "entropy_spread": 1.870660490655251,
-          "kl_off_diag_mean": 2.6782906452814736,
-          "kl_off_diag_max": 5.483499050140381,
+          "mean_entropy_final": 0.1584926961597221,
+          "entropy_spread": 0.5661146474502893,
+          "kl_off_diag_mean": 19.973986864089966,
+          "kl_off_diag_max": 23.02581787109375,
           "seed": 42
         },
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_43",
-          "trailing5_team_reward": -100.2322265625,
+          "trailing5_team_reward": -90.32919921875,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            3.667222934996478,
-            2.4947285465524915,
-            2.5055631538086955,
-            3.102756618768403
+            0.0,
+            0.0,
+            0.02922609883967134,
+            0.0
           ],
-          "mean_entropy_final": 2.942567813531517,
-          "entropy_spread": 1.1724943884439862,
-          "kl_off_diag_mean": 2.108118489384651,
-          "kl_off_diag_max": 4.657596588134766,
+          "mean_entropy_final": 0.007306524709917835,
+          "entropy_spread": 0.02922609883967134,
+          "kl_off_diag_mean": 21.5387548605601,
+          "kl_off_diag_max": 23.025835037231445,
           "seed": 43
         },
         {
           "cell": "experiments/p3_specialization/runs/issue220_treatment/minimal_specialization/lambda_0e0/seed_44",
-          "trailing5_team_reward": -87.5513671875,
+          "trailing5_team_reward": -81.04072265625,
           "final_iter": 99,
           "per_agent_entropy_final": [
-            1.271996107944186,
-            2.220396831328161,
-            3.2543328596856496,
-            3.841639984927217
+            0.0,
+            0.0,
+            0.07631561714294695,
+            0.06507472171217013
           ],
-          "mean_entropy_final": 2.647091445971303,
-          "entropy_spread": 2.569643876983031,
-          "kl_off_diag_mean": 3.389314671357473,
-          "kl_off_diag_max": 7.051825523376465,
+          "mean_entropy_final": 0.03534758471377927,
+          "entropy_spread": 0.07631561714294695,
+          "kl_off_diag_mean": 21.681028525034588,
+          "kl_off_diag_max": 23.025691986083984,
           "seed": 44
         }
       ],
       "n_seeds": 3,
-      "team_reward_mean": -91.70862630208335,
-      "team_reward_std": 7.382394589391656,
+      "team_reward_mean": -82.62753906249999,
+      "team_reward_std": 7.043609499270494,
       "team_reward_per_seed": [
-        -87.34228515625,
-        -100.2322265625,
-        -87.5513671875
+        -76.5126953125,
+        -90.32919921875,
+        -81.04072265625
       ],
-      "mean_entropy_mean": 2.829090415290702,
-      "entropy_spread_mean": 1.8709329186940895,
-      "kl_off_diag_mean": 2.7252412686745324,
-      "gap_closed_mean": 0.05893748240427902,
+      "mean_entropy_mean": 0.06704893519447307,
+      "entropy_spread_mean": 0.22388545447763586,
+      "kl_off_diag_mean": 21.06459008322822,
+      "gap_closed_mean": 0.18165487753378382,
       "gap_closed_per_seed": [
-        0.11794209248310801,
-        -0.05624630489864878,
-        0.1151166596283782
+        0.26428790118243234,
+        0.07757838893581064,
+        0.20309834248310804
       ]
     }
   }

--- a/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.md
@@ -6,23 +6,21 @@ Random/specialist references on `minimal_specialization` (from 2026-05-15 notebo
 
 | scenario | arm | n | mean ± std | per-seed |
 |---|---|---|---|---|
-| default | baseline | 3 | +249.49 ± 1.40 | [251.10693359375, 248.6869140625, 248.6642578125] |
-| default | treatment | 3 | +253.70 ± 2.38 | [256.22998046875, 253.37646484375, 251.508203125] |
-| minimal_specialization | baseline | 3 | -86.24 ± 6.21 | [-79.71875, -92.0703125, -86.941015625] |
-| minimal_specialization | treatment | 3 | -91.71 ± 7.38 | [-87.34228515625, -100.2322265625, -87.5513671875] |
+| default | baseline | 0 | — | missing |
+| default | treatment | 3 | +251.41 ± 6.31 | [254.576171875, 244.13662109375, 255.50390625] |
+| minimal_specialization | baseline | 0 | — | missing |
+| minimal_specialization | treatment | 3 | -82.63 ± 7.04 | [-76.5126953125, -90.32919921875, -81.04072265625] |
 
 ## Policy divergence (final-iter entropy spread + pairwise action KL)
 
 | scenario | arm | mean_entropy | entropy_spread (max−min across agents) | KL off-diag mean |
 |---|---|---|---|---|
-| default | baseline | 2.399 | 1.628 | n/a |
-| default | treatment | 2.293 | 1.653 | 3.7178 |
-| minimal_specialization | baseline | 2.907 | 1.370 | n/a |
-| minimal_specialization | treatment | 2.829 | 1.871 | 2.7252 |
+| default | treatment | 0.001 | 0.002 | 21.6452 |
+| minimal_specialization | treatment | 0.067 | 0.224 | 21.0646 |
 
 ## Gap-closed on `minimal_specialization`
 
 | arm | gap_closed (trailing-5 mean) | per-seed | pre-reg verdict |
 |---|---|---|---|
-| baseline | 0.133 | ['0.221', '0.054', '0.123'] | < 25% — MAPPO needed |
-| treatment | 0.059 | ['0.118', '-0.056', '0.115'] | < 25% — MAPPO needed |
+| baseline | — | missing | — |
+| treatment | 0.182 | ['0.264', '0.078', '0.203'] | < 25% — MAPPO needed |

--- a/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.json
+++ b/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.json
@@ -5,207 +5,207 @@
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/default/seed_42",
-            "trailing5_team_reward": 256.22998046875,
+            "trailing5_team_reward": 254.576171875,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              1.9760577548306684,
-              1.9270287340117007,
-              2.4324849530945536,
-              2.760269935954415
+              0.00642758314625143,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 2.2739603444728345,
-            "entropy_spread": 0.8332412019427142,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0016068957865628575,
+            "entropy_spread": 0.00642758314625143,
+            "kl_off_diag_mean": 19.187640861962183,
+            "kl_off_diag_max": 23.025850296020508,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/default/seed_43",
-            "trailing5_team_reward": 253.37646484375,
+            "trailing5_team_reward": 244.13662109375,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.5168488864084946,
-              2.8232077623924883,
-              2.7673367211678506,
-              0.9430679637786167
+              0.0,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 2.262615333436863,
-            "entropy_spread": 1.8801397986138717,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0,
+            "entropy_spread": 0.0,
+            "kl_off_diag_mean": 22.722083409627277,
+            "kl_off_diag_max": 23.025850296020508,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/default/seed_44",
-            "trailing5_team_reward": 251.508203125,
+            "trailing5_team_reward": 255.50390625,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.7930549027250926,
-              1.052764559390835,
-              2.228319814060957,
-              3.2985985711022634
+              0.0,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 2.343184461819787,
-            "entropy_spread": 2.2458340117114286,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0,
+            "entropy_spread": 0.0,
+            "kl_off_diag_mean": 23.025800228118896,
+            "kl_off_diag_max": 23.025850296020508,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": 253.70488281250002,
-        "team_reward_std": 2.3779590182835615,
+        "team_reward_mean": 251.40556640625002,
+        "team_reward_std": 6.3121586826319565,
         "team_reward_per_seed": [
-          256.22998046875,
-          253.37646484375,
-          251.508203125
+          254.576171875,
+          244.13662109375,
+          255.50390625
         ],
-        "mean_entropy_mean": 2.293253379909828,
-        "entropy_spread_mean": 1.653071670756005,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.14989104580225088,
+        "mean_entropy_mean": 0.0005356319288542859,
+        "entropy_spread_mean": 0.0021425277154171435,
+        "kl_off_diag_mean": 21.645174833236116,
+        "gap_closed_mean": 0.002518525408837,
         "gap_closed_per_seed": [
-          0.1818179348685043,
-          0.1457385869737009,
-          0.12211661556454671
+          0.04800131796012064,
+          -0.10175554305336386,
+          0.0613098013197534
         ]
       },
       "minimal_specialization": {
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/minimal_specialization/seed_42",
-            "trailing5_team_reward": -87.34228515625,
+            "trailing5_team_reward": -76.5126953125,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              3.6043440732151093,
-              3.087232878746042,
-              3.165187410956134,
-              1.7336835825598582
+              0.0,
+              0.00642758314625143,
+              0.5661146474502893,
+              0.06142855404234769
             ],
-            "mean_entropy_final": 2.897611986369286,
-            "entropy_spread": 1.870660490655251,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.1584926961597221,
+            "entropy_spread": 0.5661146474502893,
+            "kl_off_diag_mean": 19.973986864089966,
+            "kl_off_diag_max": 23.02581787109375,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/minimal_specialization/seed_43",
-            "trailing5_team_reward": -100.2322265625,
+            "trailing5_team_reward": -90.32919921875,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              3.667222934996478,
-              2.4947285465524915,
-              2.5055631538086955,
-              3.102756618768403
+              0.0,
+              0.0,
+              0.02922609883967134,
+              0.0
             ],
-            "mean_entropy_final": 2.942567813531517,
-            "entropy_spread": 1.1724943884439862,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.007306524709917835,
+            "entropy_spread": 0.02922609883967134,
+            "kl_off_diag_mean": 21.5387548605601,
+            "kl_off_diag_max": 23.025835037231445,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/minimal_specialization/seed_44",
-            "trailing5_team_reward": -87.5513671875,
+            "trailing5_team_reward": -81.04072265625,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              1.271996107944186,
-              2.220396831328161,
-              3.2543328596856496,
-              3.841639984927217
+              0.0,
+              0.0,
+              0.07631561714294695,
+              0.06507472171217013
             ],
-            "mean_entropy_final": 2.647091445971303,
-            "entropy_spread": 2.569643876983031,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.03534758471377927,
+            "entropy_spread": 0.07631561714294695,
+            "kl_off_diag_mean": 21.681028525034588,
+            "kl_off_diag_max": 23.025691986083984,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": -91.70862630208335,
-        "team_reward_std": 7.382394589391656,
+        "team_reward_mean": -82.62753906249999,
+        "team_reward_std": 7.043609499270494,
         "team_reward_per_seed": [
-          -87.34228515625,
-          -100.2322265625,
-          -87.5513671875
+          -76.5126953125,
+          -90.32919921875,
+          -81.04072265625
         ],
-        "mean_entropy_mean": 2.829090415290702,
-        "entropy_spread_mean": 1.8709329186940895,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.05893748240427902,
+        "mean_entropy_mean": 0.06704893519447307,
+        "entropy_spread_mean": 0.22388545447763586,
+        "kl_off_diag_mean": 21.06459008322822,
+        "gap_closed_mean": 0.07756985434120346,
         "gap_closed_per_seed": [
-          0.11794209248310801,
-          -0.05624630489864878,
-          0.1151166596283782
+          0.1707129426884996,
+          -0.03974408558644336,
+          0.10174070592155371
         ]
       },
       "positional_default": {
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/positional_default/seed_42",
-            "trailing5_team_reward": 254.9419677734375,
+            "trailing5_team_reward": 253.69962463378906,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.7342975488717083,
-              0.8069975881839528,
-              2.2037396360303907,
-              3.2673903205039982
+              0.0,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 2.2531062733975125,
-            "entropy_spread": 2.460392732320045,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0,
+            "entropy_spread": 0.0,
+            "kl_off_diag_mean": 19.187946176547864,
+            "kl_off_diag_max": 23.02584457397461,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/positional_default/seed_43",
-            "trailing5_team_reward": 248.60977172851562,
+            "trailing5_team_reward": 246.1187713623047,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              3.8253029834932275,
-              2.614046674969179,
-              3.124457283235434,
-              0.11359327525193985
+              0.0,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 2.4193500542374453,
-            "entropy_spread": 3.7117097082412878,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0,
+            "entropy_spread": 0.0,
+            "kl_off_diag_mean": 23.01719856262207,
+            "kl_off_diag_max": 23.025848388671875,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/ippo/positional_default/seed_44",
-            "trailing5_team_reward": 256.0182647705078,
+            "trailing5_team_reward": 254.97072143554686,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              1.1079799570667417,
-              2.199292720773058,
-              0.7364500803731416,
-              3.2781566726490916
+              0.0,
+              0.0,
+              0.0,
+              0.0
             ],
-            "mean_entropy_final": 1.8304698577155083,
-            "entropy_spread": 2.54170659227595,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.0,
+            "entropy_spread": 0.0,
+            "kl_off_diag_mean": 23.025843461354572,
+            "kl_off_diag_max": 23.025850296020508,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": 253.19000142415362,
-        "team_reward_std": 4.002934155726138,
+        "team_reward_mean": 251.59637247721352,
+        "team_reward_std": 4.786126539321507,
         "team_reward_per_seed": [
-          254.9419677734375,
-          248.60977172851562,
-          256.0182647705078
+          253.69962463378906,
+          246.1187713623047,
+          254.97072143554686
         ],
-        "mean_entropy_mean": 2.167642061783489,
-        "entropy_spread_mean": 2.904603010945761,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.14874891769336868,
+        "mean_entropy_mean": 0.0,
+        "entropy_spread_mean": 0.0,
+        "kl_off_diag_mean": 21.74366273350817,
+        "gap_closed_mean": 0.012348524475677468,
         "gap_closed_per_seed": [
-          0.17077791743288698,
-          0.09115769808268093,
-          0.1843111375645392
+          0.042326462853321936,
+          -0.0657244674700013,
+          0.06044357804371257
         ]
       }
     },
@@ -214,207 +214,207 @@
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/default/seed_42",
-            "trailing5_team_reward": 257.0654296875,
+            "trailing5_team_reward": 255.6140625,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              0.29300779874184935,
-              1.4309265638204658,
-              1.9826773916339275,
-              2.367881300503771
+              2.1181664682623262,
+              1.0358246440767274,
+              2.8970626783023197,
+              1.4868483649731883
             ],
-            "mean_entropy_final": 1.5186232636750034,
-            "entropy_spread": 2.0748735017619215,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 1.8844755389036405,
+            "entropy_spread": 1.8612380342255923,
+            "kl_off_diag_mean": 8.593685984611511,
+            "kl_off_diag_max": 15.75642204284668,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/default/seed_43",
-            "trailing5_team_reward": 234.5552734375,
+            "trailing5_team_reward": 248.57080078125,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.052263044427072,
-              1.9255031465715016,
-              2.122947283123929,
-              0.9261969934287944
+              3.252752947938872,
+              1.2768553669549925,
+              0.57340376485601,
+              3.0385333088037143
             ],
-            "mean_entropy_final": 1.7567276168878243,
-            "entropy_spread": 1.1967502896951348,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 2.035386347138397,
+            "entropy_spread": 2.679349183082862,
+            "kl_off_diag_mean": 4.828439354896545,
+            "kl_off_diag_max": 11.485806465148926,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/default/seed_44",
-            "trailing5_team_reward": 249.9185546875,
+            "trailing5_team_reward": 254.0384765625,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              0.08740940738561148,
-              0.5908990433479929,
-              0.8516226458121489,
-              3.354509953910866
+              1.3339915782529175,
+              1.1944260843351722,
+              2.266855605490187,
+              2.0117153433847186
             ],
-            "mean_entropy_final": 1.2211102626141548,
-            "entropy_spread": 3.2671005465252545,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 1.7017471528657486,
+            "entropy_spread": 1.0724295211550148,
+            "kl_off_diag_mean": 8.793205658594767,
+            "kl_off_diag_max": 17.85814666748047,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": 247.17975260416665,
-        "team_reward_std": 11.5022850442252,
+        "team_reward_mean": 252.74111328125,
+        "team_reward_std": 3.6965182973108743,
         "team_reward_per_seed": [
-          257.0654296875,
-          234.5552734375,
-          249.9185546875
+          255.6140625,
+          248.57080078125,
+          254.0384765625
         ],
-        "mean_entropy_mean": 1.4988203810589942,
-        "entropy_spread_mean": 2.179574779327437,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.06738845118430468,
+        "mean_entropy_mean": 1.8738696796359289,
+        "entropy_spread_mean": 1.871005579487823,
+        "kl_off_diag_mean": 7.40511033270094,
+        "gap_closed_mean": 0.021677137874766956,
         "gap_closed_per_seed": [
-          0.19238120732709577,
-          -0.09223323508028813,
-          0.1020173813061071
+          0.06289000860708648,
+          -0.03814659616626007,
+          0.040288001183474455
         ]
       },
       "minimal_specialization": {
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/minimal_specialization/seed_42",
-            "trailing5_team_reward": -97.18701171875,
+            "trailing5_team_reward": -89.12392578125,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              3.8169635874374577,
-              1.7551795065171658,
-              3.424206178936418,
-              2.7209449809332744
+              3.1740563515237565,
+              0.7141871400207941,
+              3.3759007674328356,
+              2.891839260930576
             ],
-            "mean_entropy_final": 2.9293235634560792,
-            "entropy_spread": 2.061784080920292,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 2.5389958799769907,
+            "entropy_spread": 2.6617136274120416,
+            "kl_off_diag_mean": 4.435692618290584,
+            "kl_off_diag_max": 9.114080429077148,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/minimal_specialization/seed_43",
-            "trailing5_team_reward": -98.29931640625,
+            "trailing5_team_reward": -86.73828125,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              3.0205864223910575,
-              2.579119917743299,
-              1.8943399370540395,
-              2.729908621856557
+              3.814838764659802,
+              0.9357121593895396,
+              1.707139062493902,
+              2.710377024802355
             ],
-            "mean_entropy_final": 2.5559887247612383,
-            "entropy_spread": 1.126246485337018,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 2.2920167528363997,
+            "entropy_spread": 2.8791266052702627,
+            "kl_off_diag_mean": 5.260257204373677,
+            "kl_off_diag_max": 9.805426597595215,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/minimal_specialization/seed_44",
-            "trailing5_team_reward": -88.0619140625,
+            "trailing5_team_reward": -85.1150390625,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.8793763228189557,
-              3.311398993356312,
-              2.7977127302964053,
-              2.2804354547049996
+              1.5587133510939843,
+              2.9258001103398708,
+              0.9735096504449229,
+              3.0457503551452514
             ],
-            "mean_entropy_final": 2.817230875294168,
-            "entropy_spread": 1.0309635386513123,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 2.1259433667560073,
+            "entropy_spread": 2.0722407047003286,
+            "kl_off_diag_mean": 7.115476965904236,
+            "kl_off_diag_max": 12.629796981811523,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": -94.51608072916667,
-        "team_reward_std": 5.617072720758739,
+        "team_reward_mean": -86.99241536458334,
+        "team_reward_std": 2.016489844281099,
         "team_reward_per_seed": [
-          -97.18701171875,
-          -98.29931640625,
-          -88.0619140625
+          -89.12392578125,
+          -86.73828125,
+          -85.1150390625
         ],
-        "mean_entropy_mean": 2.7675143878371617,
-        "entropy_spread_mean": 1.4063313683028742,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.02099890906531512,
+        "mean_entropy_mean": 2.3189853331897994,
+        "entropy_spread_mean": 2.5376936457942114,
+        "kl_off_diag_mean": 5.603808929522832,
+        "gap_closed_mean": 0.011082781956080147,
         "gap_closed_per_seed": [
-          -0.015094752956081174,
-          -0.03012589738175685,
-          0.10821737753378377
+          -0.021385008092155298,
+          0.01495382711348056,
+          0.0396795268469154
         ]
       },
       "positional_default": {
         "seeds": [
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/positional_default/seed_42",
-            "trailing5_team_reward": 256.7802978515625,
+            "trailing5_team_reward": 258.8728485107422,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.748099436769185,
-              1.3164950068778372,
-              0.2764635719793337,
-              2.364406181472731
+              2.5727742661429955,
+              2.28297945183685,
+              1.5442110812500123,
+              0.6879424720406541
             ],
-            "mean_entropy_final": 1.6763660492747718,
-            "entropy_spread": 2.4716358647898513,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 1.771976817817628,
+            "entropy_spread": 1.8848317941023414,
+            "kl_off_diag_mean": 7.986302018165588,
+            "kl_off_diag_max": 12.189733505249023,
             "seed": 42
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/positional_default/seed_43",
-            "trailing5_team_reward": 247.03651733398436,
+            "trailing5_team_reward": 239.66396484375,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.8227186895288434,
-              2.7340997086047376,
-              0.7389131736613253,
-              0.6244002496174815
+              2.4161849490955434,
+              0.6156927658296334,
+              3.448722462871306,
+              2.331966129336501
             ],
-            "mean_entropy_final": 1.730032955353097,
-            "entropy_spread": 2.198318439911362,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 2.2031415767832456,
+            "entropy_spread": 2.833029697041672,
+            "kl_off_diag_mean": 6.306024253368378,
+            "kl_off_diag_max": 15.197132110595703,
             "seed": 43
           },
           {
             "cell": "experiments/p3_specialization/runs/issue231/mappo/positional_default/seed_44",
-            "trailing5_team_reward": 249.64633178710938,
+            "trailing5_team_reward": 249.64334411621093,
             "final_iter": 99,
             "per_agent_entropy_final": [
-              2.325208649318635,
-              1.4955754711601275,
-              0.17231616529127908,
-              3.773766477212455
+              0.9382464652845819,
+              0.15375788702990845,
+              1.2091547880138052,
+              0.21460617408819077
             ],
-            "mean_entropy_final": 1.9417166907456243,
-            "entropy_spread": 3.601450311921176,
-            "kl_off_diag_mean": null,
-            "kl_off_diag_max": null,
+            "mean_entropy_final": 0.6289413286041216,
+            "entropy_spread": 1.0553969009838968,
+            "kl_off_diag_mean": 14.99829920132955,
+            "kl_off_diag_max": 22.774402618408203,
             "seed": 44
           }
         ],
         "n_seeds": 3,
-        "team_reward_mean": 251.15438232421874,
-        "team_reward_std": 5.0439049367073565,
+        "team_reward_mean": 249.39338582356768,
+        "team_reward_std": 9.606880986774827,
         "team_reward_per_seed": [
-          256.7802978515625,
-          247.03651733398436,
-          249.64633178710938
+          258.8728485107422,
+          239.66396484375,
+          249.64334411621093
         ],
-        "mean_entropy_mean": 1.7827052317911647,
-        "entropy_spread_mean": 2.757134872207463,
-        "kl_off_diag_mean": null,
-        "gap_closed_mean": 0.12315330471795215,
+        "mean_entropy_mean": 1.5346865744016653,
+        "entropy_spread_mean": 1.9244194640426369,
+        "kl_off_diag_mean": 9.76354182428784,
+        "gap_closed_mean": -0.019050943221669128,
         "gap_closed_per_seed": [
-          0.19389284360068545,
-          0.07137579949684839,
-          0.10419127105632295
+          0.11606112472551594,
+          -0.1577257006307012,
+          -0.015488253759821317
         ]
       }
     }
@@ -422,21 +422,21 @@
   "verdict": {
     "per_scenario": {
       "default": {
-        "gap_ippo": 0.14989104580225088,
-        "gap_mappo": 0.06738845118430468,
-        "delta": -0.08250259461794619,
+        "gap_ippo": 0.002518525408837,
+        "gap_mappo": 0.021677137874766956,
+        "delta": 0.019158612465929956,
         "tier": "tier_3_insufficient"
       },
       "minimal_specialization": {
-        "gap_ippo": 0.05893748240427902,
-        "gap_mappo": 0.02099890906531512,
-        "delta": -0.0379385733389639,
+        "gap_ippo": 0.07756985434120346,
+        "gap_mappo": 0.011082781956080147,
+        "delta": -0.06648707238512332,
         "tier": "tier_3_insufficient"
       },
       "positional_default": {
-        "gap_ippo": 0.14874891769336868,
-        "gap_mappo": 0.12315330471795215,
-        "delta": -0.02559561297541653,
+        "gap_ippo": 0.012348524475677468,
+        "gap_mappo": -0.019050943221669128,
+        "delta": -0.0313994676973466,
         "tier": "tier_3_insufficient"
       }
     },
@@ -450,15 +450,15 @@
   },
   "baselines": {
     "default": [
-      241.85,
+      251.23,
       320.94
     ],
     "minimal_specialization": [
-      -96.07,
+      -87.72,
       -22.07
     ],
     "positional_default": [
-      241.36,
+      250.73,
       320.89
     ]
   }

--- a/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.md
@@ -43,4 +43,3 @@ Pre-registered references (per-step mean team reward):
 **`INSUFFICIENT`**
 
 Tier counts: tier_1_succeeds=0, tier_2_partial=0, tier_3_insufficient=3.
-

--- a/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.md
@@ -4,42 +4,43 @@ Pre-registered references (per-step mean team reward):
 
 | scenario | random | specialist | spec-rand gap |
 |---|---|---|---|
-| default | +241.85 | +320.94 | +79.09 |
-| minimal_specialization | -96.07 | -22.07 | +74.00 |
-| positional_default | +241.36 | +320.89 | +79.53 |
+| default | +251.23 | +320.94 | +69.71 |
+| minimal_specialization | -87.72 | -22.07 | +65.65 |
+| positional_default | +250.73 | +320.89 | +70.16 |
 
 ## Team reward (trailing-5 mean of `mean_step_reward_team`)
 
 | scenario | arm | n | mean ± std | per-seed |
 |---|---|---|---|---|
-| default | ippo | 3 | +253.70 ± 2.38 | ['+256.23', '+253.38', '+251.51'] |
-| default | mappo | 3 | +247.18 ± 11.50 | ['+257.07', '+234.56', '+249.92'] |
-| minimal_specialization | ippo | 3 | -91.71 ± 7.38 | ['-87.34', '-100.23', '-87.55'] |
-| minimal_specialization | mappo | 3 | -94.52 ± 5.62 | ['-97.19', '-98.30', '-88.06'] |
-| positional_default | ippo | 3 | +253.19 ± 4.00 | ['+254.94', '+248.61', '+256.02'] |
-| positional_default | mappo | 3 | +251.15 ± 5.04 | ['+256.78', '+247.04', '+249.65'] |
+| default | ippo | 3 | +251.41 ± 6.31 | ['+254.58', '+244.14', '+255.50'] |
+| default | mappo | 3 | +252.74 ± 3.70 | ['+255.61', '+248.57', '+254.04'] |
+| minimal_specialization | ippo | 3 | -82.63 ± 7.04 | ['-76.51', '-90.33', '-81.04'] |
+| minimal_specialization | mappo | 3 | -86.99 ± 2.02 | ['-89.12', '-86.74', '-85.12'] |
+| positional_default | ippo | 3 | +251.60 ± 4.79 | ['+253.70', '+246.12', '+254.97'] |
+| positional_default | mappo | 3 | +249.39 ± 9.61 | ['+258.87', '+239.66', '+249.64'] |
 
 ## Policy divergence (final-iter entropy spread + pairwise action KL)
 
 | scenario | arm | mean_entropy | entropy_spread | KL off-diag mean |
 |---|---|---|---|---|
-| default | ippo | 2.293 | 1.653 | n/a |
-| default | mappo | 1.499 | 2.180 | n/a |
-| minimal_specialization | ippo | 2.829 | 1.871 | n/a |
-| minimal_specialization | mappo | 2.768 | 1.406 | n/a |
-| positional_default | ippo | 2.168 | 2.905 | n/a |
-| positional_default | mappo | 1.783 | 2.757 | n/a |
+| default | ippo | 0.001 | 0.002 | 21.6452 |
+| default | mappo | 1.874 | 1.871 | 7.4051 |
+| minimal_specialization | ippo | 0.067 | 0.224 | 21.0646 |
+| minimal_specialization | mappo | 2.319 | 2.538 | 5.6038 |
+| positional_default | ippo | 0.000 | 0.000 | 21.7437 |
+| positional_default | mappo | 1.535 | 1.924 | 9.7635 |
 
 ## Gap-closed by scenario (per-arm and delta)
 
 | scenario | gap_ippo | gap_mappo | delta (mappo−ippo) | per-scenario tier |
 |---|---|---|---|---|
-| default | +0.150 | +0.067 | -0.083 | `tier_3_insufficient` |
-| minimal_specialization | +0.059 | +0.021 | -0.038 | `tier_3_insufficient` |
-| positional_default | +0.149 | +0.123 | -0.026 | `tier_3_insufficient` |
+| default | +0.003 | +0.022 | +0.019 | `tier_3_insufficient` |
+| minimal_specialization | +0.078 | +0.011 | -0.066 | `tier_3_insufficient` |
+| positional_default | +0.012 | -0.019 | -0.031 | `tier_3_insufficient` |
 
 ## Headline verdict
 
 **`INSUFFICIENT`**
 
 Tier counts: tier_1_succeeds=0, tier_2_partial=0, tier_3_insufficient=3.
+

--- a/research_notebook/2026-05-16_issue239_post236_revalidation.md
+++ b/research_notebook/2026-05-16_issue239_post236_revalidation.md
@@ -1,8 +1,8 @@
 # Issue #239 — Post-#236 re-derivation of PR #216 obs-fix and PR #225 MAPPO
 
-**Date:** 2026-05-16
+**Date:** 2026-05-16 (results finalized 2026-05-17 under issue [#255](https://github.com/rjwalters/bucket-brigade/issues/255))
 **Issue:** [#239](https://github.com/rjwalters/bucket-brigade/issues/239)
-**PR (this commit):** TBD — see PR body for tmux/nohup session names and result status.
+**Finalization PR:** see #255 — verdict tier 3 (`INSUFFICIENT`) on both arms.
 
 ## Why re-derive?
 
@@ -117,54 +117,119 @@ That script:
 Edit this notebook to fill in the placeholder TBDs below with the actual
 numbers from the rendered summaries.
 
-_Filled when the sweep completes and `analyze_220.py` + `analyze_231.py`
-have been re-run with the post-#236 baselines from PRs #243/#244 (siblings
-#237/#238)._
+_Filled 2026-05-17 from `finalize_issue239.sh` rendered summaries on
+`COMPUTE_HOST_PRIMARY`, with the `bb_issue239` worktree rebased onto
+post-#243/#244/#245/#246/#248/#250 main (`06cb0fac`)._
 
 ### Obs-fix on `minimal_specialization` (post-#236)
-- treatment arm gap_closed: **TBD**
-- per-seed: TBD
+- treatment arm gap_closed: **0.182** (trailing-5 team-reward mean)
+- per-seed: 0.264, 0.078, 0.203
+- Treatment team reward: −82.63 ± 7.04 per-step (per-seed: −76.51, −90.33, −81.04)
+- Pre-registered verdict: **< 25% — MAPPO needed** (tier 3)
+- Pre-#236 treatment baseline (preserved in the pre-overwrite `git diff` of
+  this PR; the `summary.pre236.{md,json}` files referenced in the finalize
+  script never made it into git history): 0.059
 
 ### MAPPO sweep (post-#236)
-| scenario | gap_ippo | gap_mappo | delta | tier |
+| scenario | gap_ippo | gap_mappo | delta (mappo−ippo) | tier |
 |---|---|---|---|---|
-| default | TBD | TBD | TBD | TBD |
-| minimal_specialization | TBD | TBD | TBD | TBD |
-| positional_default | TBD | TBD | TBD | TBD |
+| default | +0.003 | +0.022 | +0.019 | `tier_3_insufficient` |
+| minimal_specialization | +0.078 | +0.011 | −0.066 | `tier_3_insufficient` |
+| positional_default | +0.012 | −0.019 | −0.031 | `tier_3_insufficient` |
 
-**Headline verdict post-#236**: TBD
+**Headline verdict post-#236**: **`INSUFFICIENT`** (Tier 3 — 0 succeed, 0
+partial, 3 insufficient). The signaling-as-action substrate did not flip
+the MAPPO verdict on any scenario; on `minimal_specialization` and
+`positional_default` MAPPO remains *worse* than IPPO.
 
 ## Side-by-side
 
 | scenario | pre-#236 ippo gap | post-#236 ippo gap | pre-#236 mappo gap | post-#236 mappo gap |
 |---|---|---|---|---|
-| default | TBD | TBD | TBD | TBD |
-| minimal_specialization | 0.059 | TBD | TBD | TBD |
-| positional_default | TBD | TBD | TBD | TBD |
+| default | n/a (delta −0.083) | +0.003 | n/a (delta −0.083) | +0.022 |
+| minimal_specialization | 0.059 (obs-fix treatment) / n/a (mappo arm delta −0.038) | +0.078 (ippo) / 0.182 (obs-fix treatment) | n/a (delta −0.038) | +0.011 |
+| positional_default | n/a (delta −0.026) | +0.012 | n/a (delta −0.026) | −0.019 |
+
+Pre-#236 absolute `gap_ippo` / `gap_mappo` were not preserved in the
+analyzers' source-of-truth — only the `delta` (mappo − ippo) was reported
+in PR #232. The deltas above are reproduced from project memory for
+comparison.
 
 ## Discussion
 
-(To be added when results are in. Key questions to address:
-1. Did the substrate change in #236 raise the IPPO floor, the MAPPO ceiling,
-   or neither?
-2. If MAPPO now succeeds, does the headline shift from `INSUFFICIENT` to
-   `MAPPO_SUCCEEDS` or `MAPPO_HELPS_GLOBALLY_NOT_DECISIVE`?
-3. Does the post-#236 KL diagnostic show signal-head divergence between
-   agents? (Now that we capture the 40-class joint.))
+The headline did **not** flip. Three observations:
+
+1. **Substrate change (#236) did not raise either the IPPO floor or the
+   MAPPO ceiling on the gap-closed metric.** Post-#236 IPPO gap_closed on
+   `default`/`positional_default` is essentially zero (0.003/0.012); pre-#236
+   was likewise near-zero relative to the same references. The
+   `minimal_specialization` IPPO bump from 0.059 (obs-fix treatment) to
+   0.078 (this run's IPPO) is within the per-seed standard deviation
+   (std ~7 per-step on a 65-per-step gap) and should not be over-interpreted.
+2. **MAPPO is still net-negative on `minimal_specialization` and
+   `positional_default`** (delta = −0.066 and −0.031). The shared critic
+   continues to pull policies toward a worse mode, even with a real signal
+   channel available. The diagnostic KL pattern is informative: MAPPO
+   collapses pairwise action KL by ~3× (e.g. `default`: IPPO=21.6 →
+   MAPPO=7.4; `minimal_specialization`: 21.1 → 5.6) while *raising*
+   per-agent entropy (`default`: 0.001 → 1.874; `minimal_specialization`:
+   0.067 → 2.319). MAPPO is averaging policies toward a softer-but-more-
+   homogeneous distribution — exactly the failure mode flagged in the
+   pre-#236 project-memory entry.
+3. **Signal-head divergence under post-#236 IPPO is high but
+   uninterpretable as specialization.** IPPO KL ≈ 21-22 across scenarios
+   means agents have collapsed to *different* near-deterministic policies
+   (entropy ~0.001-0.07), not that they are coordinating via the signal
+   channel. The 40-class joint KL fix from this PR's pre-flight is doing
+   its job — pre-#216-style identical-input collapse would have shown
+   KL ≈ 0 — but the divergence is being driven by random-init lottery
+   among low-quality local optima, not by signal honesty.
+
+**Recommendation:** the project-memory ladder stands. Promote #193 (reward
+shaping) as the next intervention; the bug is upstream of obs
+differentiation, value-baseline centralization, *and* signal-channel
+dimensionality.
+
+### MINSPEC_RANDOM discrepancy (flagged by curator)
+
+`analyze_220.py:59` uses `MINSPEC_RANDOM = -96.07` (from PR #243 /
+issue #238). `analyze_231.py:77` uses `BASELINES['minimal_specialization'] =
+(-87.72, -22.07)` (random from PR #244 / issue #237). Both are "live"
+post-#236 numbers, but they come from different upstream samplers:
+
+- `-96.07`: PR #243's specialist re-derivation pipeline, which samples
+  random uniformly over the **full post-#236 action space**
+  (`MultiDiscrete([10, 2, 2])`).
+- `-87.72`: PR #244's random-baseline pipeline, which (prior to the #246 /
+  PR #250 fix) sampled with a stale 2-dim joint. After PR #250
+  (`06cb0fac`), `issue199_baselines.py` uses the 3-dim sampler, so
+  *re-running* `#244` would converge with `#243`. The `-87.72` constant
+  in `analyze_231.py` predates PR #250 and is the **only place** in this
+  finalize that uses the stale sample.
+
+This means `gap_closed` for `minimal_specialization` is sensitive to the
+choice of random reference. Using `analyze_220.py`'s `-96.07` for the
+IPPO arm: gap = (−82.63 − (−96.07)) / (−22.07 − (−96.07)) = 13.44 / 74.00
+= 0.182 (matches the obs-fix render). Using `analyze_231.py`'s `-87.72`:
+gap = (−82.63 − (−87.72)) / (−22.07 − (−87.72)) = 5.09 / 65.65 = 0.078
+(matches the IPPO render). The verdict is **tier 3 in either case**, so
+the discrepancy does not change the headline, but follow-up to unify
+the constants once PR #250's sampler propagates is tracked under #246.
 
 ## Baselines used
 
 Post-#236 random and specialist baselines were re-derived in parallel by
 sibling issues:
-- #237 (PR #244): random baselines across all 14 scenarios. Status at PR
-  creation: TBD.
+- #237 (PR #244): random baselines across all 14 scenarios. **MERGED.**
 - #238 (PR #243): specialist baselines on `minimal_specialization`,
-  `positional_default`, `default`. Status at PR creation: TBD.
+  `positional_default`, `default`. **MERGED.**
+- #246 (PR #250): 3-dim MultiDiscrete sampler in `issue199_baselines.py`.
+  **MERGED.** Resolves the `-96.07`/`-87.72` discrepancy at source for
+  future re-runs; this run's analyzers still carry the stale constant in
+  `analyze_231.py:77` (see Discussion).
 
-If both sibling PRs have merged when this PR runs the analyzers, the
-constants in `analyze_220.py:53-54` and `analyze_231.py:61-65` will reflect
-post-#236 values; otherwise the analyzers retain pre-#236 constants and
-the verdict is marked PENDING.
+All sibling PRs merged before this finalize ran. Constants in
+`analyze_220.py:59-60` and `analyze_231.py:77-81` reflect post-#236 values.
 
 ## See also
 


### PR DESCRIPTION
## HEADLINE VERDICT: **TIER 3 — INSUFFICIENT** (both arms)

The post-#236 signaling-as-action substrate **did not flip the verdict**
on either the obs-fix arm (#216 / PR #233) or the MAPPO arm (#225 / PR
#232). The project-memory ladder claim stands: the bug is upstream of
observation differentiation, value-baseline centralization, *and*
signal-channel dimensionality. **Promote #193 (reward shaping) as the
next intervention.**

### Per-arm numbers

| arm | scenario | post-#236 | pre-#236 | tier |
|---|---|---|---|---|
| obs-fix treatment | minimal_specialization | gap_closed = **0.182** | 0.059 | tier 3 |
| MAPPO delta | default | +0.019 | −0.083 | tier 3 |
| MAPPO delta | minimal_specialization | **−0.066** | −0.038 | tier 3 |
| MAPPO delta | positional_default | **−0.031** | −0.026 | tier 3 |

Tier counts: 0 tier-1, 0 tier-2, 3 tier-3. analyze_231.py's
`headline_verdict` field literally writes `"INSUFFICIENT"`.

## Summary

PR #248 merged the #239 infrastructure with placeholder summaries while
the 24-cell training sweep ran on Mac Studio (`bb_issue239` worktree).
Issue #255 tracks the post-training finalization. This PR:

1. Rebased the `bb_issue239` worktree onto current `origin/main` (picks
   up the new constants from PRs #243/#244/#246/#250) and re-ran
   `experiments/p3_specialization/finalize_issue239.sh` on Mac Studio.
   That script generated per-cell `pairwise_action_kl.json` for all 24
   cells (using the post-#236 40-class joint code path), then ran
   `analyze_220.py` + `analyze_231.py` to render the live summaries.
2. Pulled the rendered `summary.{md,json}` artifacts locally (clobbering
   the placeholders from PR #248).
3. Filled in the TBD sections of `2026-05-16_issue239_post236_revalidation.md`
   (treatment numbers, MAPPO table, headline, side-by-side, Discussion,
   baseline status, MINSPEC_RANDOM discrepancy note).
4. Appended a dated tier-3 entry to project memory
   (`project_ppo_failure_mode.md`) per the pre-registered template.

## Key diagnostic observation

MAPPO is still doing its pre-#236 pathology even with a real signal
channel: it collapses pairwise action KL by ~3× (e.g. `default`: IPPO
21.6 → MAPPO 7.4) while *raising* per-agent entropy by ~1000×
(`default`: 0.001 → 1.874). Shared critic continues to pull policies
toward a softer-but-homogeneous mode. IPPO's high KL (~21) is *not*
signal-based coordination — entropies near 0 indicate random-init
lottery among low-quality near-deterministic local optima.

## MINSPEC_RANDOM discrepancy (curator-flagged)

- `analyze_220.py:59` uses `-96.07` (PR #243 sampler; post-#250-compatible)
- `analyze_231.py:77` uses `-87.72` (PR #244 pre-#250 sampler)

Verdict is tier 3 in either case (gap = 0.182 vs 0.078 on the same
treatment cells). #246 follow-up will unify the constants once PR #250's
3-dim sampler propagates to all baseline-derivation outputs.

## Artifacts

- `experiments/p3_specialization/diagnostics/results/issue220_obsfix/summary.{md,json}` — obs-fix re-validation
- `experiments/p3_specialization/diagnostics/results/issue231_mappo/summary.{md,json}` — MAPPO re-validation
- `research_notebook/2026-05-16_issue239_post236_revalidation.md` — full notebook with side-by-side and discussion
- 24 × `runs/issue{220_treatment,231}/.../pairwise_action_kl.json` on Mac Studio (gitignored — generated artifacts)

## Test plan

- [x] `find runs -name metrics.json | wc -l` = 24 (sweep complete)
- [x] After rebase, `finalize_issue239.sh` exists in worktree and runs to exit 0
- [x] Both `summary.md` files render with non-TBD numbers for all rendered cells
- [x] Pairwise KL written for all 24 cells (`find runs -name pairwise_action_kl.json | wc -l` = 24)
- [x] Notebook TBDs at lines 124-167 all filled
- [x] Project-memory entry added with date `2026-05-17` matching tier-3 template
- [x] Notebook explicitly notes the `MINSPEC_RANDOM` discrepancy between analyzers

Closes #255