### PR TITLE
feat(env): add num_houses scenario field + v2_minimal 2x4 diagnostic

### DIFF
--- a/bucket-brigade-core/src/engine/core.rs
+++ b/bucket-brigade-core/src/engine/core.rs
@@ -15,19 +15,25 @@ pub struct BucketBrigade {
     pub(super) rng: DeterministicRng,
     pub scenario: Scenario,
     pub num_agents: usize,
-    /// Owner agent for each of the 10 houses (round-robin assignment).
+    /// Owner agent for each house on the ring (round-robin assignment).
     /// House `i` is owned by agent `i % num_agents`. Mirrors the Python
     /// `BucketBrigadeEnv.house_owners` array so that the per-house ownership
     /// reward fields (`reward_own_house_survives` etc.) can be applied per-agent.
+    ///
+    /// Length matches `scenario.num_houses` (issue #254). The default for
+    /// every pre-#254 scenario is 10; new scenarios like `v2_minimal` use
+    /// a smaller ring.
     pub(super) house_owners: Vec<u8>,
-    /// Per-agent "home position" on the 10-house ring (issue #203). Used by
-    /// the rewards engine to scale the per-step work cost by the ring-arc
+    /// Per-agent "home position" on the ring (issue #203). Used by the
+    /// rewards engine to scale the per-step work cost by the ring-arc
     /// distance from the agent's home to the house it works at. Derived from
     /// `scenario.agent_home_positions` when non-empty, otherwise from the
     /// existing `house_owners` round-robin (the first house each agent owns —
     /// agent `i` -> house `i`). When `scenario.distance_cost_alpha == 0.0`
     /// the cost contribution is zero, so pre-#203 scenarios are bit-exactly
     /// unchanged.
+    ///
+    /// Positions are validated against `scenario.num_houses` (issue #254).
     pub(super) agent_home_positions: Vec<u8>,
     pub(super) trajectory: Vec<GameNight>,
 }
@@ -39,9 +45,15 @@ pub struct BucketBrigade {
 /// * Otherwise the round-robin `house_owners` assignment is reused (agent
 ///   `i`'s home is house `i`, since `i % num_agents == i` for `i < num_agents`).
 fn derive_agent_home_positions(scenario: &Scenario, num_agents: usize) -> Vec<u8> {
+    let num_houses = scenario.num_houses as usize;
     if scenario.agent_home_positions.is_empty() {
         // Backward-compat fallback: reuse the round-robin ownership anchor.
-        (0..num_agents as u8).collect()
+        // Issue #254: wrap modulo `num_houses` so this stays in-range when
+        // `num_agents > num_houses` (e.g. `v2_minimal` with 4 agents on
+        // 2 houses gives positions [0, 1, 0, 1]). For pre-#254 scenarios
+        // where `num_agents <= num_houses`, `i % num_houses == i` so the
+        // result is identical to the pre-#254 `(0..num_agents)` derivation.
+        (0..num_agents).map(|i| (i % num_houses) as u8).collect()
     } else {
         assert_eq!(
             scenario.agent_home_positions.len(),
@@ -53,27 +65,41 @@ fn derive_agent_home_positions(scenario: &Scenario, num_agents: usize) -> Vec<u8
         );
         for (i, &pos) in scenario.agent_home_positions.iter().enumerate() {
             assert!(
-                (pos as usize) < 10,
-                "Scenario.agent_home_positions[{}] = {} is out of range [0, 10)",
+                (pos as usize) < num_houses,
+                "Scenario.agent_home_positions[{}] = {} is out of range [0, {})",
                 i,
-                pos
+                pos,
+                num_houses
             );
         }
         scenario.agent_home_positions.clone()
     }
 }
 
-/// Minimum-arc distance between two indices on a ring of length 10.
+/// Minimum-arc distance between two indices on a ring of length `n`.
 ///
 /// Used by the work-cost calculation in `engine/rewards.rs` (issue #203) and
 /// exposed at crate-private scope for direct unit-testing of the spatial
-/// cost term.
+/// cost term. Issue #254 generalized this from a hardcoded length-10 ring
+/// (`ring_dist_10`) to a length parameter so non-10-house scenarios work
+/// correctly. The `ring_dist_10` wrapper below is kept for callers that
+/// always run on the canonical 10-house ring.
 #[inline]
-pub(super) fn ring_dist_10(a: u8, b: u8) -> u8 {
+pub(super) fn ring_dist(n: u8, a: u8, b: u8) -> u8 {
+    let n = n as i32;
     let a = a as i32;
     let b = b as i32;
     let raw = (a - b).abs();
-    raw.min(10 - raw) as u8
+    raw.min(n - raw) as u8
+}
+
+/// Backward-compatible wrapper around [`ring_dist`] pinned to the 10-house
+/// ring. Existing call sites that always run on the pre-#254 fixed-10 ring
+/// can keep using this; new code should call `ring_dist(n, a, b)` directly.
+#[inline]
+#[allow(dead_code)]
+pub(super) fn ring_dist_10(a: u8, b: u8) -> u8 {
+    ring_dist(10, a, b)
 }
 
 impl BucketBrigade {
@@ -87,9 +113,22 @@ impl BucketBrigade {
         scenario
             .validate()
             .unwrap_or_else(|e| panic!("Invalid Scenario passed to BucketBrigade::new: {e}"));
+        let num_houses = scenario.num_houses as usize;
+        assert!(
+            num_houses >= 2,
+            "Scenario.num_houses must be at least 2 (got {}) — the engine \
+             spread phase assumes a real ring with distinct neighbors",
+            num_houses
+        );
+        // Note: we intentionally do NOT require `num_agents <= num_houses`.
+        // `v2_minimal` (issue #254) has 4 agents on 2 houses — agents 2 and
+        // 3 are "unowned-house workers" under the round-robin
+        // `house_owners[i] = i % num_agents` semantics. This matches the
+        // architect's option-E spec; if the user wants exclusive 1:1
+        // ownership they should set `num_agents <= num_houses` themselves.
         let agent_home_positions = derive_agent_home_positions(&scenario, num_agents);
         let mut engine = Self {
-            houses: vec![0; 10],
+            houses: vec![0; num_houses],
             agent_positions: vec![0; num_agents],
             agent_signals: vec![0; num_agents],
             last_actions: vec![[0, 0, 0]; num_agents],
@@ -99,7 +138,7 @@ impl BucketBrigade {
             rng: DeterministicRng::new(seed),
             scenario,
             num_agents,
-            house_owners: (0..10).map(|i| (i % num_agents) as u8).collect(),
+            house_owners: (0..num_houses).map(|i| (i % num_agents) as u8).collect(),
             agent_home_positions,
             trajectory: Vec::new(),
         };
@@ -108,7 +147,8 @@ impl BucketBrigade {
     }
 
     pub fn reset(&mut self) {
-        self.houses = vec![0; 10];
+        let num_houses = self.scenario.num_houses as usize;
+        self.houses = vec![0; num_houses];
         self.agent_positions = vec![0; self.num_agents];
         self.agent_signals = vec![0; self.num_agents];
         self.last_actions = vec![[0, 0, 0]; self.num_agents];
@@ -116,14 +156,16 @@ impl BucketBrigade {
         self.done = false;
         self.rewards = vec![0.0; self.num_agents];
         // Re-initialize house ownership in case num_agents changed via external mutation.
-        self.house_owners = (0..10).map(|i| (i % self.num_agents) as u8).collect();
+        self.house_owners = (0..num_houses)
+            .map(|i| (i % self.num_agents) as u8)
+            .collect();
         // Re-derive home positions for the same reason (and to pick up any
         // scenario mutation).
         self.agent_home_positions = derive_agent_home_positions(&self.scenario, self.num_agents);
         self.trajectory = Vec::new();
 
         // Initialize fires - probabilistic per-house
-        for house_idx in 0..10 {
+        for house_idx in 0..num_houses {
             if self.rng.random() < self.scenario.prob_house_catches_fire {
                 self.houses[house_idx] = 1;
             }

--- a/bucket-brigade-core/src/engine/phases.rs
+++ b/bucket-brigade-core/src/engine/phases.rs
@@ -3,7 +3,8 @@ use crate::Action;
 
 impl BucketBrigade {
     pub(super) fn extinguish_fires(&mut self, actions: &[Action]) {
-        for house_idx in 0..10 {
+        let num_houses = self.scenario.num_houses as usize;
+        for house_idx in 0..num_houses {
             if self.houses[house_idx] != 1 {
                 continue;
             }
@@ -25,17 +26,25 @@ impl BucketBrigade {
     }
 
     pub(super) fn spread_fires(&mut self) {
+        // Issue #254: ring length is now `scenario.num_houses` rather than a
+        // hardcoded 10. The neighbor wraparound modulo also tracks the
+        // scenario value so 2-house and other small-ring topologies wrap
+        // correctly. Note that on a 2-house ring the (i-1) and (i+1)
+        // neighbors are the same house, so spread is single-step but the
+        // probability roll still happens twice — matching the way the
+        // 10-ring case handled it for the trivial wrap edge.
+        let num_houses = self.scenario.num_houses as usize;
         let mut new_houses = self.houses.clone();
 
-        for house_idx in 0..10 {
+        for house_idx in 0..num_houses {
             if self.houses[house_idx] != 1 {
                 continue;
             }
 
-            // Check neighbors
+            // Check neighbors (wrap modulo num_houses).
             let neighbors = [
-                (house_idx + 9) % 10, // (i-1) mod 10
-                (house_idx + 1) % 10, // (i+1) mod 10
+                (house_idx + num_houses - 1) % num_houses,
+                (house_idx + 1) % num_houses,
             ];
 
             for &neighbor in &neighbors {
@@ -59,7 +68,8 @@ impl BucketBrigade {
     }
 
     pub(super) fn spontaneous_ignition(&mut self) {
-        for house_idx in 0..10 {
+        let num_houses = self.scenario.num_houses as usize;
+        for house_idx in 0..num_houses {
             if self.houses[house_idx] == 0
                 && self.rng.random() < self.scenario.prob_house_catches_fire
             {

--- a/bucket-brigade-core/src/engine/rewards.rs
+++ b/bucket-brigade-core/src/engine/rewards.rs
@@ -1,4 +1,4 @@
-use super::core::{ring_dist_10, BucketBrigade};
+use super::core::{ring_dist, BucketBrigade};
 use crate::{Action, HouseState};
 
 impl BucketBrigade {
@@ -12,11 +12,16 @@ impl BucketBrigade {
 
         let mut rewards = vec![0.0; self.num_agents];
 
+        // Issue #254: divide by `scenario.num_houses` (defaults to 10 for
+        // every pre-#254 scenario, so the math is unchanged).
+        let num_houses = self.scenario.num_houses as usize;
+        let num_houses_f = num_houses as f32;
+
         // Count current house states
         let saved_houses = self.houses.iter().filter(|&&h| h == 0).count() as f32;
         let ruined_houses = self.houses.iter().filter(|&&h| h == 2).count() as f32;
-        let total_saved_fraction = saved_houses / 10.0;
-        let total_burned_fraction = ruined_houses / 10.0;
+        let total_saved_fraction = saved_houses / num_houses_f;
+        let total_burned_fraction = ruined_houses / num_houses_f;
 
         // Team reward component (shared by all, public goods)
         let team_reward = self.scenario.team_reward_house_survives * total_saved_fraction
@@ -40,7 +45,8 @@ impl BucketBrigade {
                 } else {
                     let home = self.agent_home_positions[agent_idx];
                     let target = actions[agent_idx][0];
-                    let dist = ring_dist_10(home, target) as f32;
+                    // Issue #254: ring length now reads from the scenario.
+                    let dist = ring_dist(self.scenario.num_houses, home, target) as f32;
                     base_cost + alpha * dist
                 };
                 rewards[agent_idx] -= work_cost;
@@ -60,7 +66,7 @@ impl BucketBrigade {
             // vectors by `deserialize_scalar_or_vec` in `scenarios.rs`, so
             // existing scenarios behave identically to the pre-#198 scalar
             // semantics.
-            for house_idx in 0..10 {
+            for house_idx in 0..num_houses {
                 let is_own = (self.house_owners[house_idx] as usize) == agent_idx;
 
                 // Save event: BURNING -> SAFE this step.

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -681,6 +681,129 @@ fn test_engine_home_positions_fallback_to_house_owners() {
 }
 
 // ==============================================================================
+// Issue #254 — `num_houses` parameterization smoke tests
+// ==============================================================================
+
+/// `v2_minimal` (2 houses, 4 agents) constructs cleanly and exposes the
+/// expected per-ring sizing on the engine state vectors.
+#[test]
+fn test_v2_minimal_engine_construction() {
+    let scenario = SCENARIOS.get("v2_minimal").unwrap().clone();
+    let engine = BucketBrigade::new(scenario, 4, Some(42));
+
+    assert_eq!(engine.scenario.num_houses, 2);
+    assert_eq!(engine.houses.len(), 2);
+    assert_eq!(engine.house_owners.len(), 2);
+    // House owners on a 2-house ring with 4 agents: [0 % 4, 1 % 4] = [0, 1].
+    assert_eq!(engine.house_owners, vec![0, 1]);
+    assert_eq!(engine.num_agents, 4);
+    assert_eq!(engine.agent_positions.len(), 4);
+    assert_eq!(engine.rewards.len(), 4);
+}
+
+/// Random rollout on `v2_minimal` completes 20 steps without panicking on
+/// out-of-range house indices (the engine paths previously hardcoded
+/// `0..10` and would index out of bounds at length-2).
+#[test]
+fn test_v2_minimal_random_rollout() {
+    let scenario = SCENARIOS.get("v2_minimal").unwrap().clone();
+    let mut engine = BucketBrigade::new(scenario, 4, Some(7));
+
+    for step in 0..20 {
+        if engine.done {
+            break;
+        }
+        // Actions confined to the 2-house ring (action[0] in {0, 1}).
+        let actions: Vec<[u8; 3]> = (0..4).map(|i| [(i % 2) as u8, 1, 1]).collect();
+        let result = engine.step(&actions);
+        assert_eq!(
+            result.rewards.len(),
+            4,
+            "step {} returned wrong reward count",
+            step
+        );
+    }
+
+    let obs = engine.get_observation(0);
+    assert_eq!(
+        obs.houses.len(),
+        2,
+        "observation houses must size to num_houses=2"
+    );
+}
+
+/// `v2_minimal` observation has the expected shape: `houses` is length 2
+/// (from `num_houses`), other fields scale with `num_agents=4`.
+#[test]
+fn test_v2_minimal_observation_shape() {
+    let scenario = SCENARIOS.get("v2_minimal").unwrap().clone();
+    let engine = BucketBrigade::new(scenario, 4, None);
+    let obs = engine.get_observation(0);
+
+    assert_eq!(obs.houses.len(), 2);
+    assert_eq!(obs.signals.len(), 4);
+    assert_eq!(obs.locations.len(), 4);
+    assert_eq!(obs.last_actions.len(), 4);
+    // scenario_info layout is fixed (12 elements regardless of ring size).
+    assert_eq!(obs.scenario_info.len(), 12);
+}
+
+/// Backward compat: every pre-#254 scenario constructed via `BucketBrigade::new`
+/// must still produce a 10-element `houses` vector. This is the engine-side
+/// mirror of `scenarios::tests::test_non_v2_scenarios_have_ten_houses`.
+#[test]
+fn test_pre_254_scenarios_still_ten_houses_in_engine() {
+    for name in SCENARIOS.keys() {
+        if name.starts_with("v2_") {
+            continue;
+        }
+        let scenario = SCENARIOS.get(name).unwrap().clone();
+        let engine = BucketBrigade::new(scenario, 4, Some(0));
+        assert_eq!(
+            engine.houses.len(),
+            10,
+            "Pre-#254 scenario '{}' regressed: houses.len()={}, expected 10",
+            name,
+            engine.houses.len()
+        );
+        assert_eq!(
+            engine.house_owners.len(),
+            10,
+            "Pre-#254 scenario '{}' regressed: house_owners.len()={}, expected 10",
+            name,
+            engine.house_owners.len()
+        );
+    }
+}
+
+/// `BucketBrigade::new` rejects degenerate `num_houses` values
+/// (`num_houses < 2` doesn't allow any wraparound; the spread phase math
+/// assumes a real ring).
+#[test]
+#[should_panic(expected = "num_houses must be at least 2")]
+fn test_engine_rejects_one_house_scenario() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.num_houses = 1;
+    let _ = BucketBrigade::new(scenario, 1, Some(0));
+}
+
+/// Issue #254: `num_agents > num_houses` is supported (this is the
+/// `v2_minimal` case — 4 agents on 2 houses, with agents 2 and 3 as
+/// "unowned-house workers"). Verifies the engine doesn't panic on this
+/// configuration and that the round-robin ownership pattern is correct.
+#[test]
+fn test_engine_allows_more_agents_than_houses() {
+    let scenario = SCENARIOS.get("v2_minimal").unwrap().clone();
+    let engine = BucketBrigade::new(scenario, 4, Some(0));
+    // House ownership is `i % num_agents`, not `i % num_houses`, so houses
+    // 0 and 1 are owned by agents 0 and 1 respectively.
+    assert_eq!(engine.house_owners, vec![0, 1]);
+    // Agent home positions wrap modulo `num_houses` (issue #254 fallback),
+    // so agents [0, 1, 2, 3] anchor to houses [0, 1, 0, 1].
+    assert_eq!(engine.agent_home_positions, vec![0, 1, 0, 1]);
+}
+
+// ==============================================================================
 // Property-Based Tests
 // ==============================================================================
 
@@ -856,6 +979,8 @@ mod proptests {
                 agent_home_positions: Vec::new(),
                 distance_cost_alpha: 0.0,
                 distance_metric: "ring_arc".to_string(),
+                // Issue #254: pre-#254 fixed-10 ring for these proptests.
+                num_houses: 10,
             };
 
             let mut engine = BucketBrigade::new(scenario, 4, Some(42));

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -36,7 +36,11 @@ impl PyBucketBrigade {
             .map(|a| match a.len() {
                 2 => [a[0], a[1], a[1]],
                 3 => [a[0], a[1], a[2]],
-                _ => [a[0], a.get(1).copied().unwrap_or(0), a.get(2).copied().unwrap_or(0)],
+                _ => [
+                    a[0],
+                    a.get(1).copied().unwrap_or(0),
+                    a.get(2).copied().unwrap_or(0),
+                ],
             })
             .collect();
 
@@ -148,6 +152,12 @@ impl PyScenario {
             agent_home_positions: Vec::new(),
             distance_cost_alpha: 0.0,
             distance_metric: "ring_arc".to_string(),
+            // Issue #254: PyScenario constructor defaults to the 10-house
+            // ring (every pre-#254 scenario). Non-10-house scenarios like
+            // `v2_minimal` are accessed by name through
+            // ``bucket_brigade_core.SCENARIOS["v2_minimal"]`` which routes
+            // through the JSON path that preserves all fields.
+            num_houses: 10,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator. The literal above is safe today but the helper keeps the
@@ -231,6 +241,16 @@ impl PyScenario {
     #[getter]
     fn distance_metric(&self) -> String {
         self.inner.distance_metric.clone()
+    }
+
+    /// Issue #254: number of houses on the ring. Defaults to 10 for every
+    /// pre-#254 scenario. New scenarios like ``v2_minimal`` use a smaller
+    /// ring. Python env wrappers read this via ``scenario.num_houses`` to
+    /// size their action spaces (``MultiDiscrete([num_houses, 2, 2])``)
+    /// and observation tensors.
+    #[getter]
+    fn num_houses(&self) -> u8 {
+        self.inner.num_houses
     }
 }
 
@@ -453,7 +473,11 @@ impl PyVectorEnv {
                 ));
             }
 
-            let signal = if action.len() == 3 { action[2] } else { action[1] };
+            let signal = if action.len() == 3 {
+                action[2]
+            } else {
+                action[1]
+            };
             let rust_action = [action[0], action[1], signal];
             let result = env.step(&[rust_action]);
 

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -7,6 +7,18 @@ use std::sync::LazyLock;
 /// the default vector length for the four ownership reward fields.
 const MAX_AGENTS: usize = 10;
 
+/// Default for `Scenario::num_houses` (issue #254).
+///
+/// Every pre-#254 scenario assumed a 10-house ring; this default keeps JSON
+/// deserialization, programmatic construction, and the WASM frontend
+/// bit-exactly backward-compatible. New scenarios (`v2_minimal`) override it
+/// by setting the field explicitly. The WASM surface (`wasm.rs`) panics if
+/// it sees any other value — the browser UI is still hard-coded to 10
+/// houses visually, so non-10 scenarios are Python-only for now.
+fn default_num_houses() -> u8 {
+    10
+}
+
 /// Deserialize a value that is either a scalar `f32` or an array of `f32`s.
 ///
 /// This allows JSON scenario definitions (and other external serialized
@@ -97,6 +109,16 @@ fn default_agent_home_positions() -> Vec<u8> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Scenario {
+    // Topology (issue #254): number of houses on the ring. Defaults to 10
+    // for backward compatibility with every pre-#254 scenario; serde reads
+    // the field as optional so existing JSON files don't need updating.
+    // The engine, Python envs, and PyO3 surface all read this field instead
+    // of the literal `10`. The WASM frontend (`wasm.rs`) panics if it
+    // receives a scenario with `num_houses != 10` because the browser UI
+    // still assumes a 10-house ring visually.
+    #[serde(default = "default_num_houses")]
+    pub num_houses: u8,
+
     // Fire dynamics
     pub prob_fire_spreads_to_neighbor: f32, // Probability fire spreads to adjacent house
     pub prob_solo_agent_extinguishes_fire: f32, // Probability one agent extinguishes fire
@@ -214,6 +236,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -234,6 +257,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -254,6 +278,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -275,6 +300,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -295,6 +321,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -315,6 +342,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -335,6 +363,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -355,6 +384,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -375,6 +405,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -395,6 +426,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -415,6 +447,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -435,6 +468,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -462,6 +496,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
+            num_houses: default_num_houses(),
         },
     );
 
@@ -488,6 +523,37 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             agent_home_positions: vec![0, 3, 5, 8],
             distance_cost_alpha: 0.1,
             distance_metric: "ring_arc".to_string(),
+            num_houses: default_num_houses(),
+        },
+    );
+
+    // Issue #254 / option E of architect proposal #234: a minimal 2-house x
+    // 4-agent diagnostic for PPO learnability. Joint action space shrinks
+    // from `4 * (10 * 2 * 2)` = 1,600 per-agent moves to `4 * (2 * 2 * 2)`
+    // = 32 per-agent moves, so PPO has a tractable exploration problem.
+    // Ownership pattern is round-robin: houses 0 and 1 are owned by
+    // agents 0 and 1 respectively (agents 2 and 3 are unowned-house
+    // workers under the pre-#254 `house_owners = i % num_agents`
+    // semantics). Ignition rate is bumped to 0.05 because with only
+    // 2 houses the default 0.02 leaves most episodes empty of fires.
+    m.insert(
+        "v2_minimal",
+        Scenario {
+            prob_fire_spreads_to_neighbor: 0.25,
+            prob_solo_agent_extinguishes_fire: 0.5,
+            prob_house_catches_fire: 0.05,
+            team_reward_house_survives: 10.0,
+            team_penalty_house_burns: 10.0,
+            cost_to_work_one_night: 0.5,
+            min_nights: 8,
+            reward_own_house_survives: per_agent(50.0),
+            reward_other_house_survives: per_agent(0.0),
+            penalty_own_house_burns: per_agent(100.0),
+            penalty_other_house_burns: per_agent(0.0),
+            agent_home_positions: default_agent_home_positions(),
+            distance_cost_alpha: default_distance_cost_alpha(),
+            distance_metric: default_distance_metric(),
+            num_houses: 2,
         },
     );
 
@@ -522,6 +588,8 @@ mod tests {
         assert!(SCENARIOS.get("mixed_motivation").is_some());
         assert!(SCENARIOS.get("minimal_specialization").is_some());
         assert!(SCENARIOS.get("positional_default").is_some());
+        // Issue #254: v2_minimal is the 2x4 PPO learnability diagnostic.
+        assert!(SCENARIOS.get("v2_minimal").is_some());
     }
 
     #[test]
@@ -657,8 +725,8 @@ mod tests {
     fn test_scenario_count() {
         let count = SCENARIOS.keys().count();
         assert_eq!(
-            count, 14,
-            "Expected 14 predefined scenarios (3 difficulty + 9 research + 1 sanity-check + 1 positional)"
+            count, 15,
+            "Expected 15 predefined scenarios (3 difficulty + 9 research + 1 sanity-check + 1 positional + 1 v2 minimal)"
         );
     }
 
@@ -861,8 +929,12 @@ mod tests {
         //     reward=penalty=10 so the per-agent ownership signal (50/100)
         //     dominates the shared team signal — that's the entire point
         //     of the sanity-check scenario.
+        //   - "v2_minimal" (issue #254) mirrors `minimal_specialization`'s
+        //     reward shape on a 2-house ring as a PPO learnability unit
+        //     test (option E of architect proposal #234).
         for (name, scenario) in SCENARIOS.iter() {
-            if name == &"overcrowding" || name == &"minimal_specialization" {
+            if name == &"overcrowding" || name == &"minimal_specialization" || name == &"v2_minimal"
+            {
                 continue;
             }
             assert_eq!(
@@ -944,6 +1016,9 @@ mod tests {
     /// Scalar JSON inputs that omit the new #203 fields should round-trip
     /// through serde, yielding the documented defaults
     /// (alpha=0.0, metric="ring_arc", home_positions=[]).
+    ///
+    /// Issue #254 extension: also confirms `num_houses` defaults to 10
+    /// when omitted, so all 14 pre-#254 scenarios remain bit-exact.
     #[test]
     fn test_scenario_pre203_fields_optional_in_json() {
         let json = r#"{
@@ -963,6 +1038,8 @@ mod tests {
         assert_eq!(scenario.distance_cost_alpha, 0.0);
         assert_eq!(scenario.distance_metric, "ring_arc");
         assert!(scenario.agent_home_positions.is_empty());
+        // Issue #254: num_houses defaults to 10 when omitted.
+        assert_eq!(scenario.num_houses, 10);
     }
 
     /// Issue #222: unknown ``distance_metric`` values must be rejected at
@@ -1046,6 +1123,7 @@ mod tests {
             agent_home_positions: default_agent_home_positions(),
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: "bogus".to_string(),
+            num_houses: default_num_houses(),
         };
         let err = scenario
             .validate()
@@ -1082,5 +1160,93 @@ mod tests {
     fn test_allowlist_contains_default_metric() {
         assert!(ALLOWED_DISTANCE_METRICS.contains(&"ring_arc"));
         assert!(ALLOWED_DISTANCE_METRICS.contains(&default_distance_metric().as_str()));
+    }
+
+    /// Issue #254: ``v2_minimal`` is the 2-house x 4-agent PPO learnability
+    /// diagnostic (option E from architect proposal #234). Reward shape
+    /// mirrors ``minimal_specialization``; ignition rate is bumped to 0.05
+    /// because a 2-house ring at 0.02 has too many fire-free episodes.
+    #[test]
+    fn test_v2_minimal_values() {
+        let scenario = SCENARIOS.get("v2_minimal").unwrap();
+        assert_eq!(scenario.num_houses, 2);
+        assert_eq!(scenario.team_reward_house_survives, 10.0);
+        assert_eq!(scenario.team_penalty_house_burns, 10.0);
+        assert_eq!(scenario.prob_house_catches_fire, 0.05);
+        assert_eq!(scenario.prob_fire_spreads_to_neighbor, 0.25);
+        assert_eq!(scenario.prob_solo_agent_extinguishes_fire, 0.5);
+        assert_eq!(scenario.cost_to_work_one_night, 0.5);
+        assert_eq!(scenario.min_nights, 8);
+        assert!(scenario
+            .reward_own_house_survives
+            .iter()
+            .all(|&v| v == 50.0));
+        assert!(scenario
+            .reward_other_house_survives
+            .iter()
+            .all(|&v| v == 0.0));
+        assert!(scenario.penalty_own_house_burns.iter().all(|&v| v == 100.0));
+        assert!(scenario.penalty_other_house_burns.iter().all(|&v| v == 0.0));
+    }
+
+    /// Issue #254: every non-v2 scenario must keep `num_houses = 10` so the
+    /// pre-#254 14 scenarios are bit-exactly preserved (the engine paths
+    /// that previously hardcoded `10` now read `scenario.num_houses`, but
+    /// the result is identical when `num_houses == 10`).
+    #[test]
+    fn test_non_v2_scenarios_have_ten_houses() {
+        for (name, scenario) in SCENARIOS.iter() {
+            if name.starts_with("v2_") {
+                continue;
+            }
+            assert_eq!(
+                scenario.num_houses, 10,
+                "Pre-#254 scenario '{}' must keep num_houses = 10 (bit-exact)",
+                name
+            );
+        }
+    }
+
+    /// Issue #254: `num_houses` is optional in JSON and defaults to 10.
+    /// Verifies the serde default function is wired up.
+    #[test]
+    fn test_num_houses_defaults_to_ten_in_json() {
+        let json = r#"{
+            "prob_fire_spreads_to_neighbor": 0.25,
+            "prob_solo_agent_extinguishes_fire": 0.5,
+            "prob_house_catches_fire": 0.02,
+            "team_reward_house_survives": 100.0,
+            "team_penalty_house_burns": 100.0,
+            "reward_own_house_survives": 1.0,
+            "reward_other_house_survives": 0.0,
+            "penalty_own_house_burns": 2.0,
+            "penalty_other_house_burns": 0.0,
+            "cost_to_work_one_night": 0.5,
+            "min_nights": 12
+        }"#;
+        let scenario: Scenario = serde_json::from_str(json).unwrap();
+        assert_eq!(scenario.num_houses, 10);
+    }
+
+    /// Issue #254: explicit `num_houses` in JSON is preserved (not silently
+    /// overridden by the default).
+    #[test]
+    fn test_num_houses_explicit_value_preserved() {
+        let json = r#"{
+            "num_houses": 2,
+            "prob_fire_spreads_to_neighbor": 0.25,
+            "prob_solo_agent_extinguishes_fire": 0.5,
+            "prob_house_catches_fire": 0.02,
+            "team_reward_house_survives": 100.0,
+            "team_penalty_house_burns": 100.0,
+            "reward_own_house_survives": 1.0,
+            "reward_other_house_survives": 0.0,
+            "penalty_own_house_burns": 2.0,
+            "penalty_other_house_burns": 0.0,
+            "cost_to_work_one_night": 0.5,
+            "min_nights": 12
+        }"#;
+        let scenario: Scenario = serde_json::from_str(json).unwrap();
+        assert_eq!(scenario.num_houses, 2);
     }
 }

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -14,6 +14,24 @@ impl WasmBucketBrigade {
         let scenario: Scenario = serde_json::from_str(scenario_json)
             .map_err(|e| JsValue::from_str(&format!("Failed to parse scenario: {}", e)))?;
 
+        // Issue #254: the WASM frontend (browser UI in `web/`) is fixed at
+        // 10 houses visually and assumes that ring length throughout the
+        // TypeScript layer. Approach 3 of the issue's curator analysis
+        // explicitly defers the WASM/UI rework to a follow-up issue, so we
+        // reject non-10 scenarios here with a clear message rather than
+        // letting them render broken or crash deep in the renderer. The
+        // Rust core, PyO3 surface, and Python envs all support arbitrary
+        // `num_houses`; non-10 scenarios (e.g. `v2_minimal`) are
+        // Python-only for now.
+        if scenario.num_houses != 10 {
+            return Err(JsValue::from_str(&format!(
+                "WASM frontend is fixed at 10 houses; scenario has num_houses={}. \
+                 Non-10-house scenarios (e.g. v2_minimal, issue #254) are \
+                 Python-only — use bucket_brigade.envs.* from Python instead.",
+                scenario.num_houses
+            )));
+        }
+
         Ok(Self {
             inner: BucketBrigade::new(scenario, num_agents, None),
         })
@@ -36,10 +54,8 @@ impl WasmBucketBrigade {
         let actions: Vec<[u8; 3]> = match serde_json::from_str::<Vec<[u8; 3]>>(actions_json) {
             Ok(a) => a,
             Err(_) => {
-                let legacy: Vec<[u8; 2]> =
-                    serde_json::from_str(actions_json).map_err(|e| {
-                        JsValue::from_str(&format!("Failed to parse actions: {}", e))
-                    })?;
+                let legacy: Vec<[u8; 2]> = serde_json::from_str(actions_json)
+                    .map_err(|e| JsValue::from_str(&format!("Failed to parse actions: {}", e)))?;
                 legacy.into_iter().map(|a| [a[0], a[1], a[1]]).collect()
             }
         };
@@ -144,6 +160,10 @@ impl WasmScenario {
             agent_home_positions: Vec::new(),
             distance_cost_alpha: 0.0,
             distance_metric: "ring_arc".to_string(),
+            // Issue #254: WASM frontend is fixed at 10 houses; hardcode
+            // here so the rest of the constructor path can't accidentally
+            // produce a non-10 scenario via the WASM surface.
+            num_houses: 10,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator so future kwargs additions can't reintroduce silent

--- a/bucket_brigade/agents/heuristic_agent.py
+++ b/bucket_brigade/agents/heuristic_agent.py
@@ -65,12 +65,16 @@ class HeuristicAgent(AgentBase):
         # Extract observation components
         signals = obs["signals"]  # (N,) - current signals
         locations = obs["locations"]  # (N,) - current locations
-        houses = obs["houses"]  # (10,) - house states
+        # Issue #254: ring size is now `len(obs["houses"])`, not hardcoded
+        # 10. Every pre-#254 scenario produces length-10 observations so
+        # behavior is unchanged for them; v2_minimal yields length-2 here.
+        houses = obs["houses"]  # (num_houses,) - house states
+        num_houses = int(len(houses))
         # last_actions = obs['last_actions'] # (N,2) - previous actions (not used)
         scenario_info = obs["scenario_info"]  # Scenario parameters
 
-        # Determine owned house
-        owned_house = self.agent_id % 10
+        # Determine owned house (round-robin over the ring).
+        owned_house = self.agent_id % num_houses
 
         # 1. Signal selection (broadcast intent)
         # Pre-#235 this signal was computed and then thrown away — the engine
@@ -86,9 +90,9 @@ class HeuristicAgent(AgentBase):
         )
         mode_choice = self._choose_mode(signal, work_intent)
 
-        # 3. Apply exploration
+        # 3. Apply exploration (uniform over the actual ring).
         if np.random.random() < self.exploration_rate:
-            house_choice = np.random.randint(10)
+            house_choice = np.random.randint(num_houses)
             mode_choice = np.random.randint(2)
 
         # 4. Apply fatigue memory (tendency to repeat)
@@ -105,7 +109,9 @@ class HeuristicAgent(AgentBase):
     ) -> float:
         """Compute internal tendency to work this night."""
         burning_fraction = np.mean(houses == 1)  # Fraction of burning houses
-        owned_house = self.agent_id % 10
+        # Issue #254: ring size from len(houses), not hardcoded 10.
+        num_houses = int(len(houses))
+        owned_house = self.agent_id % num_houses
         own_house_burning = houses[owned_house] == 1
 
         # Base work tendency
@@ -140,16 +146,24 @@ class HeuristicAgent(AgentBase):
         owned_house: int,
         scenario_info: np.ndarray,
     ) -> int:
-        """Choose which house to target."""
+        """Choose which house to target.
+
+        Issue #254: ring length is `len(houses)`, not hardcoded 10. This
+        lets the heuristic agent run on non-10-house scenarios like
+        `v2_minimal` (2 houses) without indexing past the end of the array.
+        """
+        # Ring length derived from the observation.
+        num_houses = int(len(houses))
         candidates = []
 
         # Evaluate each house
-        for house_idx in range(10):
+        for house_idx in range(num_houses):
             score = 0.0
 
             # Distance from owned house (prefer closer houses)
             distance = min(
-                abs(house_idx - owned_house), 10 - abs(house_idx - owned_house)
+                abs(house_idx - owned_house),
+                num_houses - abs(house_idx - owned_house),
             )
             proximity_bonus = 1.0 / (1.0 + distance)
             score += proximity_bonus * 0.1
@@ -162,8 +176,11 @@ class HeuristicAgent(AgentBase):
             if houses[house_idx] == 1:  # Burning
                 score += 0.5
 
-            # Neighbor help bias
-            neighbors = [(house_idx - 1) % 10, (house_idx + 1) % 10]
+            # Neighbor help bias (ring wrap modulo num_houses).
+            neighbors = [
+                (house_idx - 1) % num_houses,
+                (house_idx + 1) % num_houses,
+            ]
             neighbor_burning = any(houses[n] == 1 for n in neighbors)
             if neighbor_burning:
                 score += self.neighbor_help_bias * 0.3

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -14,8 +14,10 @@ class BucketBrigadeEnv:
     """
     Multi-agent environment implementing the Bucket Brigade firefighting game.
 
-    Agents cooperate on a ring of 10 houses to prevent fires from spreading.
-    The game ends when all fires are extinguished or all houses are ruined.
+    Agents cooperate on a ring of houses to prevent fires from spreading.
+    Ring length is ``scenario.num_houses`` (defaults to 10 for every
+    pre-#254 scenario; ``v2_minimal`` uses 2). The game ends when all fires
+    are extinguished or all houses are ruined.
     """
 
     # House states
@@ -42,9 +44,15 @@ class BucketBrigadeEnv:
 
         self.scenario = scenario
         self.num_agents = scenario.num_agents
+        # Issue #254: read ring size from the scenario rather than hardcoding
+        # 10. Every pre-#254 scenario keeps num_houses=10 (the dataclass
+        # default), so this is bit-exact backward compatible.
+        self.num_houses = int(getattr(scenario, "num_houses", 10))
 
         # Environment state
-        self.houses = np.zeros(10, dtype=np.int8)  # House states: SAFE, BURNING, RUINED
+        self.houses = np.zeros(
+            self.num_houses, dtype=np.int8
+        )  # House states: SAFE, BURNING, RUINED
         self.locations = np.zeros(self.num_agents, dtype=np.int8)  # Agent positions
         self.signals = np.zeros(
             self.num_agents, dtype=np.int8
@@ -68,12 +76,13 @@ class BucketBrigadeEnv:
         self.trajectory: List[Dict] = []
 
         # Previous house state for reward computation
-        self._prev_houses_state: np.ndarray = np.zeros(10, dtype=np.int8)
+        self._prev_houses_state: np.ndarray = np.zeros(self.num_houses, dtype=np.int8)
 
-        # House ownership: assign agents to houses in round-robin fashion
-        self.house_owners = np.arange(10) % self.num_agents
+        # House ownership: assign agents to houses in round-robin fashion.
+        # Issue #254: vector length scales with num_houses.
+        self.house_owners = np.arange(self.num_houses) % self.num_agents
 
-        # Per-agent "home position" on the 10-house ring (issue #203). Used by
+        # Per-agent "home position" on the ring (issue #203). Used by
         # ``_compute_rewards`` to scale the per-step work cost by the ring-arc
         # distance from the agent's home to the house it works at. Sourced from
         # ``scenario.agent_home_positions`` when non-empty; otherwise the
@@ -81,12 +90,18 @@ class BucketBrigadeEnv:
         # When ``scenario.distance_cost_alpha == 0.0`` (the implicit default
         # for every pre-#203 scenario) the spatial term collapses to zero, so
         # behavior is bit-exactly identical to the pre-#203 env.
+        #
+        # Issue #254: the round-robin fallback now wraps modulo
+        # ``num_houses`` so it stays in-range when ``num_agents > num_houses``
+        # (e.g. v2_minimal: 4 agents on 2 houses -> [0, 1, 0, 1]).
         if getattr(self.scenario, "agent_home_positions", None):
             self.agent_home_positions = np.array(
                 self.scenario.agent_home_positions, dtype=np.int8
             )
         else:
-            self.agent_home_positions = np.arange(self.num_agents, dtype=np.int8)
+            self.agent_home_positions = np.array(
+                [i % self.num_houses for i in range(self.num_agents)], dtype=np.int8
+            )
 
         # Initialize random state for reproducibility
         self.rng = np.random.RandomState()
@@ -112,8 +127,9 @@ class BucketBrigadeEnv:
         # Houses and the prev-houses cache must be cleared before
         # _initialize_houses() rolls fresh fires --- otherwise RUINED houses
         # from a previous episode leak into the new one.
-        self.houses = np.zeros(10, dtype=np.int8)
-        self._prev_houses_state = np.zeros(10, dtype=np.int8)
+        # Issue #254: vector length scales with num_houses.
+        self.houses = np.zeros(self.num_houses, dtype=np.int8)
+        self._prev_houses_state = np.zeros(self.num_houses, dtype=np.int8)
 
         # Initialize house states
         self._initialize_houses()
@@ -205,8 +221,9 @@ class BucketBrigadeEnv:
 
     def _initialize_houses(self) -> None:
         """Initialize houses with probabilistic fires based on prob_house_catches_fire."""
-        # Each house has independent probability of starting on fire
-        for house_idx in range(10):
+        # Each house has independent probability of starting on fire.
+        # Issue #254: iterate over scenario.num_houses, not literal 10.
+        for house_idx in range(self.num_houses):
             if self.rng.random() < self.scenario.prob_house_catches_fire:
                 self.houses[house_idx] = self.BURNING
 
@@ -217,7 +234,7 @@ class BucketBrigadeEnv:
         Formula: P(extinguish with k workers) = 1 - (1 - kappa)^k
         This matches the Rust implementation and game design specification.
         """
-        for house_idx in range(10):
+        for house_idx in range(self.num_houses):
             if self.houses[house_idx] != self.BURNING:
                 continue
 
@@ -238,15 +255,22 @@ class BucketBrigadeEnv:
                 self.houses[house_idx] = self.SAFE
 
     def _spread_fires(self) -> None:
-        """Spread fires to neighboring safe houses."""
+        """Spread fires to neighboring safe houses.
+
+        Issue #254: ring length is now `scenario.num_houses` rather than a
+        hardcoded 10, and the neighbor wraparound modulo tracks the
+        scenario value so 2-house and other small-ring topologies wrap
+        correctly. Mirrors the Rust ``engine/phases.rs::spread_fires``
+        behavior.
+        """
         # Burning houses try to ignite their safe neighbors
-        for house_idx in range(10):
+        for house_idx in range(self.num_houses):
             if self.houses[house_idx] != self.BURNING:
                 continue
 
             # Check both neighbors
             for neighbor_offset in [-1, 1]:
-                neighbor_idx = (house_idx + neighbor_offset) % 10
+                neighbor_idx = (house_idx + neighbor_offset) % self.num_houses
                 if self.houses[neighbor_idx] == self.SAFE:
                     if self.rng.random() < self.scenario.prob_fire_spreads_to_neighbor:
                         self.houses[neighbor_idx] = self.BURNING
@@ -259,7 +283,8 @@ class BucketBrigadeEnv:
 
     def _spark_fires(self) -> None:
         """Add spontaneous fires."""
-        for house_idx in range(10):
+        # Issue #254: iterate over scenario.num_houses, not literal 10.
+        for house_idx in range(self.num_houses):
             if (
                 self.houses[house_idx] == self.SAFE
                 and self.rng.random() < self.scenario.prob_house_catches_fire
@@ -279,8 +304,11 @@ class BucketBrigadeEnv:
         # Count final outcomes
         saved_houses = np.sum(self.houses == self.SAFE)
         ruined_houses = np.sum(self.houses == self.RUINED)
-        total_saved_fraction = saved_houses / 10.0
-        total_burned_fraction = ruined_houses / 10.0
+        # Issue #254: divide by scenario.num_houses (defaults to 10 for
+        # every pre-#254 scenario, so the math is unchanged).
+        num_houses_f = float(self.num_houses)
+        total_saved_fraction = saved_houses / num_houses_f
+        total_burned_fraction = ruined_houses / num_houses_f
 
         # Team reward component (shared by all)
         team_reward = (
@@ -312,7 +340,8 @@ class BucketBrigadeEnv:
                     home = int(self.agent_home_positions[agent_idx])
                     target = int(actions[agent_idx, 0])
                     raw = abs(home - target)
-                    dist = min(raw, 10 - raw)  # ring_dist on the 10-house ring
+                    # Issue #254: ring length now reads from the scenario.
+                    dist = min(raw, self.num_houses - raw)
                     work_cost = base_cost + alpha * dist
                 individual_rewards[agent_idx] -= work_cost
             else:
@@ -330,7 +359,7 @@ class BucketBrigadeEnv:
             # ``Scenario.__post_init__`` auto-promotes scalar JSON inputs
             # to ``[scalar] * num_agents`` so existing scenarios behave
             # identically.
-            for house_idx in range(10):
+            for house_idx in range(self.num_houses):
                 is_own = self.house_owners[house_idx] == agent_idx
 
                 # Save event: any non-SAFE state -> SAFE this step.
@@ -417,6 +446,9 @@ class BucketBrigadeEnv:
                 "cost_to_work_one_night": self.scenario.cost_to_work_one_night,
                 "min_nights": self.scenario.min_nights,
                 "num_agents": self.scenario.num_agents,
+                # Issue #254: include num_houses so replays of non-10-house
+                # scenarios (e.g. v2_minimal) round-trip cleanly.
+                "num_houses": int(getattr(self.scenario, "num_houses", 10)),
             },
             "nights": self.trajectory,
         }

--- a/bucket_brigade/envs/puffer_env.py
+++ b/bucket_brigade/envs/puffer_env.py
@@ -59,6 +59,10 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
             scenario = default_scenario(num_opponents + 1)  # +1 for trained agent
         self.scenario = scenario
 
+        # Issue #254: derive ring size from scenario (defaults to 10 for
+        # every pre-#254 scenario; v2_minimal uses 2).
+        self.num_houses: int = int(getattr(scenario, "num_houses", 10))
+
         # Initialize underlying environment
         self.env = BucketBrigadeEnv(scenario)
 
@@ -66,18 +70,21 @@ class PufferBucketBrigade(pufferlib.PufferEnv):
         self.opponent_agents: List[Any] = []
 
         # PufferLib single observation/action spaces (for one agent)
-        # Observation: [houses(10), agent_signals(N), agent_locations(N), last_actions(N,2), scenario_info(10)]
+        # Observation: [houses(num_houses), agent_signals(N), agent_locations(N), last_actions(N,2), scenario_info(10)]
         total_agents = num_opponents + 1
-        obs_size = 10 + total_agents + total_agents + (total_agents * 2) + 10
+        obs_size = (
+            self.num_houses + total_agents + total_agents + (total_agents * 2) + 10
+        )
         self.single_observation_space = gym_spaces.Box(
             low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float32
         )
 
         # Action: [house_index, mode, signal] (issue #235) where
-        # house_index in [0,9], mode in {0=REST, 1=WORK}, signal in
-        # {0=REST, 1=WORK}. The signal is broadcast independently of the
+        # house_index in [0, num_houses-1], mode in {0=REST, 1=WORK}, signal
+        # in {0=REST, 1=WORK}. The signal is broadcast independently of the
         # mode; honest agents emit ``signal == mode``.
-        self.single_action_space = gym_spaces.MultiDiscrete([10, 2, 2])
+        # Issue #254: house dim scales with the scenario.
+        self.single_action_space = gym_spaces.MultiDiscrete([self.num_houses, 2, 2])
 
         # Initialize PufferEnv (sets up buffers and joint spaces)
         # PufferLib's __init__ will call set_buffers() which assigns directly to attributes
@@ -246,14 +253,22 @@ class PufferBucketBrigadeVectorized(PufferBucketBrigade):
         super().__init__(**kwargs)
         self.num_envs = num_envs
 
-        # Vectorized observation space
-        obs_size = 10 + self.num_agents + self.num_agents + (self.num_agents * 2) + 10
+        # Vectorized observation space (issue #254: houses channel scales
+        # with num_houses).
+        obs_size = (
+            self.num_houses
+            + self.num_agents
+            + self.num_agents
+            + (self.num_agents * 2)
+            + 10
+        )
         self.observation_space = gym_spaces.Box(
             low=-np.inf, high=np.inf, shape=(num_envs, obs_size), dtype=np.float32
         )
 
         # Issue #235: 3-element [house, mode, signal] action.
-        self.action_space = gym_spaces.MultiDiscrete([num_envs, 10, 2, 2])
+        # Issue #254: house dim scales with num_houses.
+        self.action_space = gym_spaces.MultiDiscrete([num_envs, self.num_houses, 2, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/bucket_brigade/envs/puffer_env_rust.py
+++ b/bucket_brigade/envs/puffer_env_rust.py
@@ -29,13 +29,20 @@ def _heuristic_action(
     is the opponent-agent fast-path and defaults to honest signaling
     (``signal == mode``); the full Python ``HeuristicAgent.act`` is what
     drives the Liar archetype's deceptive behavior.
+
+    Issue #254: ring size is inferred from ``len(obs_dict['houses'])``
+    rather than hardcoding 10. With v2_minimal (2 houses) the owned-house
+    derivation wraps modulo the ring size, matching the engine's
+    round-robin ``house_owners`` assignment.
     """
     work_tendency = theta[1]
     own_house_priority = theta[3]
     rest_reward_bias = theta[8]
 
+    num_houses = len(obs_dict["houses"])
+
     if rng.random() < work_tendency * (1 - rest_reward_bias):
-        owned_house = agent_id % 10
+        owned_house = agent_id % num_houses
         if obs_dict["houses"][owned_house] == 1 and rng.random() < own_house_priority:
             house = owned_house
         else:
@@ -46,7 +53,7 @@ def _heuristic_action(
                 house = owned_house
         mode = 1  # WORK
     else:
-        house = agent_id % 10
+        house = agent_id % num_houses
         mode = 0  # REST
 
     # Honest signal: broadcast matches actual mode.
@@ -98,6 +105,12 @@ class RustPufferBucketBrigade(gym.Env):
         self.rust_scenario = core.SCENARIOS[scenario_name]
         self.scenario_name = scenario_name
 
+        # Issue #254: derive ring size from the scenario rather than
+        # hardcoding 10. Pre-#254 scenarios keep num_houses=10 (Rust
+        # default), so action/observation shapes are bit-exact for them.
+        # New scenarios like v2_minimal use a smaller ring (2 houses).
+        self.num_houses: int = int(getattr(self.rust_scenario, "num_houses", 10))
+
         # Initialize Rust environment
         self.env: Optional[core.BucketBrigade] = None  # Will be created in reset()
 
@@ -116,8 +129,11 @@ class RustPufferBucketBrigade(gym.Env):
         # are distinct. This wrapper only exposes the trained agent's view
         # (always ``agent_id=0``), but the dim must include the identity
         # tail so downstream policy networks size their input layer correctly.
+        # Issue #254: `houses` and scenario_info dimensions now scale with
+        # num_houses for the houses channel (scenario_info stays at 10
+        # elements — it's a fixed feature vector, not a per-house tensor).
         obs_size = (
-            10
+            self.num_houses
             + self.num_agents
             + self.num_agents
             + (self.num_agents * 2)
@@ -129,10 +145,11 @@ class RustPufferBucketBrigade(gym.Env):
         )
 
         # Action: [house_index, mode, signal] (issue #235) where
-        # house_index in [0,9], mode in {0=REST, 1=WORK}, signal in
-        # {0=REST, 1=WORK}. The signal is broadcast independently of the
+        # house_index in [0, num_houses-1], mode in {0=REST, 1=WORK}, signal
+        # in {0=REST, 1=WORK}. The signal is broadcast independently of the
         # mode; honest agents emit ``signal == mode``, liars don't.
-        self.action_space = spaces.MultiDiscrete([10, 2, 2])
+        # Issue #254: house_index range now scales with the scenario.
+        self.action_space = spaces.MultiDiscrete([self.num_houses, 2, 2])
 
         # Track episode statistics
         self.episode_rewards: List[float] = []
@@ -323,8 +340,9 @@ class RustPufferBucketBrigadeVectorized(RustPufferBucketBrigade):
         self.num_envs = num_envs
 
         # Vectorized observation space (issue #204 — include identity one-hot tail).
+        # Issue #254: houses channel scales with num_houses; rest unchanged.
         obs_size = (
-            10
+            self.num_houses
             + self.num_agents
             + self.num_agents
             + (self.num_agents * 2)
@@ -336,7 +354,8 @@ class RustPufferBucketBrigadeVectorized(RustPufferBucketBrigade):
         )
 
         # Issue #235: 3-element action [house, mode, signal] per env.
-        self.action_space = spaces.MultiDiscrete([num_envs, 10, 2, 2])
+        # Issue #254: house dim scales with num_houses.
+        self.action_space = spaces.MultiDiscrete([num_envs, self.num_houses, 2, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -77,6 +77,14 @@ class Scenario:
     distance_cost_alpha: float = 0.0
     distance_metric: str = "ring_arc"
 
+    # Topology (issue #254). Number of houses on the ring. Defaults to
+    # 10 so all 14 pre-#254 scenarios (and any external JSON without the
+    # field) remain bit-exact. New scenarios like ``v2_minimal`` set
+    # this to a smaller value (2 in the v2 case). The Python env
+    # wrappers read ``scenario.num_houses`` to size their action space
+    # (``MultiDiscrete([num_houses, 2, 2])``) and observation arrays.
+    num_houses: int = 10
+
     def __post_init__(self) -> None:
         """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -107,6 +115,16 @@ class Scenario:
                     )
                 setattr(self, fname, promoted)
 
+        # Issue #254 num_houses validation. Must be at least 2 for the
+        # spread phase ring math to have distinct neighbors. Kept tight
+        # to surface configuration mistakes early rather than blowing
+        # up deep in a rollout.
+        if self.num_houses < 2:
+            raise ValueError(
+                f"Scenario.num_houses={self.num_houses} is too small; "
+                "must be at least 2."
+            )
+
         # Issue #203 spatial-field validation.
         if self.agent_home_positions:
             positions = [int(p) for p in self.agent_home_positions]
@@ -117,10 +135,13 @@ class Scenario:
                     "Per-agent home position vectors must match num_agents."
                 )
             for i, p in enumerate(positions):
-                if not (0 <= p < 10):
+                # Issue #254: range bound is now `num_houses`, not the
+                # hardcoded 10. Pre-#254 scenarios are unchanged because
+                # `num_houses` defaults to 10.
+                if not (0 <= p < self.num_houses):
                     raise ValueError(
                         f"Scenario.agent_home_positions[{i}]={p} "
-                        "is out of range [0, 10)."
+                        f"is out of range [0, {self.num_houses})."
                     )
             self.agent_home_positions = positions
         # Keep in sync with the Rust allowlist in
@@ -420,6 +441,25 @@ def positional_default_scenario(num_agents: int) -> Scenario:
     )
 
 
+def v2_minimal_scenario(num_agents: int) -> Scenario:
+    """Issue #254 / option E of architect proposal #234: 2-house x 4-agent PPO learnability diagnostic. Joint action space shrinks to 4 * (2 * 2 * 2) = 32 per-agent moves vs default 4 * (10 * 2 * 2) = 1600, so PPO has a tractable exploration problem. Reward shape mirrors minimal_specialization (per-agent ownership dominates 10 team reward). Ignition rate bumped 0.02->0.05 because at 0.02 a 2-house ring has too many fire-free episodes. Python/Rust only - WASM frontend (web/) is fixed at 10 houses; non-10 scenarios panic in wasm.rs."""
+    return Scenario(
+        prob_fire_spreads_to_neighbor=0.25,
+        prob_solo_agent_extinguishes_fire=0.5,
+        prob_house_catches_fire=0.05,
+        team_reward_house_survives=10.0,
+        team_penalty_house_burns=10.0,
+        reward_own_house_survives=[50.0, 50.0, 50.0, 50.0],
+        reward_other_house_survives=[0.0, 0.0, 0.0, 0.0],
+        penalty_own_house_burns=[100.0, 100.0, 100.0, 100.0],
+        penalty_other_house_burns=[0.0, 0.0, 0.0, 0.0],
+        cost_to_work_one_night=0.5,
+        min_nights=8,
+        num_agents=num_agents,
+        num_houses=2,
+    )
+
+
 # Registry of all scenarios
 SCENARIO_REGISTRY = {
     "default": default_scenario,
@@ -436,6 +476,7 @@ SCENARIO_REGISTRY = {
     "mixed_motivation": mixed_motivation_scenario,
     "minimal_specialization": minimal_specialization_scenario,
     "positional_default": positional_default_scenario,
+    "v2_minimal": v2_minimal_scenario,
 }
 
 

--- a/definitions/scenarios.json
+++ b/definitions/scenarios.json
@@ -200,6 +200,21 @@
       "distance_cost_alpha": 0.1,
       "distance_metric": "ring_arc",
       "description": "Issue #203 option A: spatial cost asymmetry on the 10-ring. Same reward magnitudes as `default`, but per-agent work cost is base_cost + alpha * ring_dist(home, target). With home positions [0,3,5,8] and alpha=0.1 the cheapest action for each agent is to defend its own neighborhood, creating a per-agent gradient that doesn't rely on reward magnitude differences. When distance_cost_alpha=0 (the implicit default for every other scenario) behavior is bit-exactly identical to today's env."
+    },
+    "v2_minimal": {
+      "num_houses": 2,
+      "prob_fire_spreads_to_neighbor": 0.25,
+      "prob_solo_agent_extinguishes_fire": 0.5,
+      "prob_house_catches_fire": 0.05,
+      "team_reward_house_survives": 10.0,
+      "team_penalty_house_burns": 10.0,
+      "cost_to_work_one_night": 0.5,
+      "min_nights": 8,
+      "reward_own_house_survives": [50.0, 50.0, 50.0, 50.0],
+      "reward_other_house_survives": [0.0, 0.0, 0.0, 0.0],
+      "penalty_own_house_burns": [100.0, 100.0, 100.0, 100.0],
+      "penalty_other_house_burns": [0.0, 0.0, 0.0, 0.0],
+      "description": "Issue #254 / option E of architect proposal #234: 2-house x 4-agent PPO learnability diagnostic. Joint action space shrinks to 4 * (2 * 2 * 2) = 32 per-agent moves vs default 4 * (10 * 2 * 2) = 1600, so PPO has a tractable exploration problem. Reward shape mirrors minimal_specialization (per-agent ownership dominates 10 team reward). Ignition rate bumped 0.02->0.05 because at 0.02 a 2-house ring has too many fire-free episodes. Python/Rust only - WASM frontend (web/) is fixed at 10 houses; non-10 scenarios panic in wasm.rs."
     }
   }
 }

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -37,9 +37,7 @@ def _format_with_ruff(path: Path) -> None:
         except FileNotFoundError:
             continue
         except subprocess.CalledProcessError as exc:
-            print(
-                f"⚠ ruff format failed on {path}: {exc}", file=sys.stderr
-            )
+            print(f"⚠ ruff format failed on {path}: {exc}", file=sys.stderr)
             return
     print(
         f"⚠ ruff not found; skipping format of {path}. "
@@ -53,7 +51,7 @@ def generate_archetypes(json_path: Path, output_path: Path):
     with open(json_path) as f:
         data = json.load(f)
 
-    archetypes = data['archetypes']
+    archetypes = data["archetypes"]
 
     # Generate Python code
     code = dedent('''\
@@ -76,7 +74,7 @@ def generate_archetypes(json_path: Path, output_path: Path):
         constant_name = f"{name.upper()}_PARAMS"
         code += f"# {spec['description']}\n"
         code += f"{constant_name} = np.array([\n"
-        for param in spec['params']:
+        for param in spec["params"]:
             code += f"    {param},\n"
         code += "], dtype=np.float32)\n\n"
 
@@ -90,7 +88,7 @@ def generate_archetypes(json_path: Path, output_path: Path):
 
     # Write output
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, 'w') as f:
+    with open(output_path, "w") as f:
         f.write(code)
 
     # Re-format with ruff so the next CI run stays green (issue #188).
@@ -104,7 +102,7 @@ def generate_scenarios(json_path: Path, output_path: Path):
     with open(json_path) as f:
         data = json.load(f)
 
-    scenarios = data['scenarios']
+    scenarios = data["scenarios"]
 
     # Generate Python code
     code = dedent('''\
@@ -179,6 +177,14 @@ def generate_scenarios(json_path: Path, output_path: Path):
         distance_cost_alpha: float = 0.0
         distance_metric: str = "ring_arc"
 
+        # Topology (issue #254). Number of houses on the ring. Defaults to
+        # 10 so all 14 pre-#254 scenarios (and any external JSON without the
+        # field) remain bit-exact. New scenarios like ``v2_minimal`` set
+        # this to a smaller value (2 in the v2 case). The Python env
+        # wrappers read ``scenario.num_houses`` to size their action space
+        # (``MultiDiscrete([num_houses, 2, 2])``) and observation arrays.
+        num_houses: int = 10
+
         def __post_init__(self) -> None:
             """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -209,6 +215,16 @@ def generate_scenarios(json_path: Path, output_path: Path):
                         )
                     setattr(self, fname, promoted)
 
+            # Issue #254 num_houses validation. Must be at least 2 for the
+            # spread phase ring math to have distinct neighbors. Kept tight
+            # to surface configuration mistakes early rather than blowing
+            # up deep in a rollout.
+            if self.num_houses < 2:
+                raise ValueError(
+                    f"Scenario.num_houses={self.num_houses} is too small; "
+                    "must be at least 2."
+                )
+
             # Issue #203 spatial-field validation.
             if self.agent_home_positions:
                 positions = [int(p) for p in self.agent_home_positions]
@@ -219,10 +235,13 @@ def generate_scenarios(json_path: Path, output_path: Path):
                         "Per-agent home position vectors must match num_agents."
                     )
                 for i, p in enumerate(positions):
-                    if not (0 <= p < 10):
+                    # Issue #254: range bound is now `num_houses`, not the
+                    # hardcoded 10. Pre-#254 scenarios are unchanged because
+                    # `num_houses` defaults to 10.
+                    if not (0 <= p < self.num_houses):
                         raise ValueError(
                             f"Scenario.agent_home_positions[{i}]={p} "
-                            "is out of range [0, 10)."
+                            f"is out of range [0, {self.num_houses})."
                         )
                 self.agent_home_positions = positions
             # Keep in sync with the Rust allowlist in
@@ -281,32 +300,40 @@ def generate_scenarios(json_path: Path, output_path: Path):
 
     for name, spec in scenarios.items():
         function_name = f"{name}_scenario"
-        code += f'def {function_name}(num_agents: int) -> Scenario:\n'
+        code += f"def {function_name}(num_agents: int) -> Scenario:\n"
         code += f'    """{spec["description"]}"""\n'
-        code += f'    return Scenario(\n'
-        code += f'        prob_fire_spreads_to_neighbor={spec["prob_fire_spreads_to_neighbor"]},\n'
-        code += f'        prob_solo_agent_extinguishes_fire={spec["prob_solo_agent_extinguishes_fire"]},\n'
-        code += f'        prob_house_catches_fire={spec["prob_house_catches_fire"]},\n'
-        code += f'        team_reward_house_survives={spec["team_reward_house_survives"]},\n'
-        code += f'        team_penalty_house_burns={spec["team_penalty_house_burns"]},\n'
-        code += f'        reward_own_house_survives={_emit_value(spec["reward_own_house_survives"])},\n'
-        code += f'        reward_other_house_survives={_emit_value(spec["reward_other_house_survives"])},\n'
-        code += f'        penalty_own_house_burns={_emit_value(spec["penalty_own_house_burns"])},\n'
-        code += f'        penalty_other_house_burns={_emit_value(spec["penalty_other_house_burns"])},\n'
-        code += f'        cost_to_work_one_night={spec["cost_to_work_one_night"]},\n'
-        code += f'        min_nights={spec["min_nights"]},\n'
-        code += f'        num_agents=num_agents,\n'
+        code += f"    return Scenario(\n"
+        code += f"        prob_fire_spreads_to_neighbor={spec['prob_fire_spreads_to_neighbor']},\n"
+        code += f"        prob_solo_agent_extinguishes_fire={spec['prob_solo_agent_extinguishes_fire']},\n"
+        code += f"        prob_house_catches_fire={spec['prob_house_catches_fire']},\n"
+        code += f"        team_reward_house_survives={spec['team_reward_house_survives']},\n"
+        code += (
+            f"        team_penalty_house_burns={spec['team_penalty_house_burns']},\n"
+        )
+        code += f"        reward_own_house_survives={_emit_value(spec['reward_own_house_survives'])},\n"
+        code += f"        reward_other_house_survives={_emit_value(spec['reward_other_house_survives'])},\n"
+        code += f"        penalty_own_house_burns={_emit_value(spec['penalty_own_house_burns'])},\n"
+        code += f"        penalty_other_house_burns={_emit_value(spec['penalty_other_house_burns'])},\n"
+        code += f"        cost_to_work_one_night={spec['cost_to_work_one_night']},\n"
+        code += f"        min_nights={spec['min_nights']},\n"
+        code += f"        num_agents=num_agents,\n"
         # Issue #203 optional spatial-cost fields. Emit only when set in JSON
         # (every other scenario keeps the dataclass defaults: empty list,
         # alpha=0.0, metric="ring_arc") so behavior is byte-identical to
         # pre-#203 codegen output for those scenarios.
         if "agent_home_positions" in spec:
-            code += f'        agent_home_positions={list(spec["agent_home_positions"])!r},\n'
+            code += f"        agent_home_positions={list(spec['agent_home_positions'])!r},\n"
         if "distance_cost_alpha" in spec:
-            code += f'        distance_cost_alpha={spec["distance_cost_alpha"]},\n'
+            code += f"        distance_cost_alpha={spec['distance_cost_alpha']},\n"
         if "distance_metric" in spec:
-            code += f'        distance_metric={spec["distance_metric"]!r},\n'
-        code += f'    )\n\n\n'
+            code += f"        distance_metric={spec['distance_metric']!r},\n"
+        # Issue #254 optional num_houses field. Emit only when explicitly
+        # set in JSON so every pre-#254 scenario factory is byte-identical
+        # to pre-#254 codegen output (they all keep the dataclass default
+        # of 10).
+        if "num_houses" in spec:
+            code += f"        num_houses={spec['num_houses']},\n"
+        code += f"    )\n\n\n"
 
     # Generate SCENARIO_REGISTRY
     code += "\n# Registry of all scenarios\n"
@@ -359,7 +386,7 @@ def generate_scenarios(json_path: Path, output_path: Path):
 
     # Write output
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, 'w') as f:
+    with open(output_path, "w") as f:
         f.write(code)
 
     # Re-format with ruff so the next CI run stays green (issue #188).
@@ -375,12 +402,12 @@ def main():
 
     generate_archetypes(
         definitions_dir / "archetypes.json",
-        root / "bucket_brigade" / "agents" / "archetypes_generated.py"
+        root / "bucket_brigade" / "agents" / "archetypes_generated.py",
     )
 
     generate_scenarios(
         definitions_dir / "scenarios.json",
-        root / "bucket_brigade" / "envs" / "scenarios_generated.py"
+        root / "bucket_brigade" / "envs" / "scenarios_generated.py",
     )
 
     print("\n✓ Python code generation complete!")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -873,3 +873,82 @@ class TestPositionalScenario:
             _, r_a, _, _ = env_a.step(actions)
             _, r_b, _, _ = env_b.step(actions)
             np.testing.assert_allclose(r_a, r_b)
+
+
+class TestV2MinimalScenario:
+    """Issue #254: ``v2_minimal`` (2 houses x 4 agents) — the PPO
+    learnability diagnostic. The Python env must size all its
+    house-indexed arrays from ``scenario.num_houses`` rather than the
+    pre-#254 hardcoded 10."""
+
+    def _v2_scenario(self):
+        from bucket_brigade.envs.scenarios_generated import v2_minimal_scenario
+
+        return v2_minimal_scenario(num_agents=4)
+
+    def test_v2_minimal_scenario_values(self):
+        """Scenario factory produces the documented values."""
+        s = self._v2_scenario()
+        assert s.num_houses == 2
+        assert s.num_agents == 4
+        assert s.team_reward_house_survives == 10.0
+        assert s.team_penalty_house_burns == 10.0
+        assert s.prob_house_catches_fire == 0.05
+        assert s.min_nights == 8
+        # Per-agent vectors length 4.
+        assert s.reward_own_house_survives == [50.0, 50.0, 50.0, 50.0]
+        assert s.penalty_own_house_burns == [100.0, 100.0, 100.0, 100.0]
+
+    def test_env_construction_uses_num_houses(self):
+        """``BucketBrigadeEnv`` sizes its house vectors from
+        ``scenario.num_houses``."""
+        env = BucketBrigadeEnv(scenario=self._v2_scenario())
+        assert env.num_houses == 2
+        assert env.houses.shape == (2,)
+        assert env._prev_houses_state.shape == (2,)
+        assert env.house_owners.shape == (2,)
+        # Round-robin: house 0 -> agent 0, house 1 -> agent 1.
+        np.testing.assert_array_equal(env.house_owners, np.array([0, 1]))
+        # Home positions wrap modulo num_houses for the 4-on-2 case.
+        np.testing.assert_array_equal(env.agent_home_positions, np.array([0, 1, 0, 1]))
+
+    def test_reset_observation_shape(self):
+        """After ``reset()`` the observation houses field is length 2."""
+        env = BucketBrigadeEnv(scenario=self._v2_scenario())
+        obs = env.reset(seed=42)
+        assert obs["houses"].shape == (2,)
+
+    def test_random_rollout_no_crash(self):
+        """A 20-step random rollout completes without panicking on
+        out-of-range house indices."""
+        env = BucketBrigadeEnv(scenario=self._v2_scenario())
+        env.reset(seed=42)
+        rng = np.random.RandomState(0)
+        for _ in range(20):
+            actions = rng.randint(0, 2, size=(4, 3)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 2, size=4)  # house in [0, 1]
+            obs, rewards, dones, _ = env.step(actions)
+            assert obs["houses"].shape == (2,)
+            assert rewards.shape == (4,)
+            if dones[0]:
+                break
+
+    def test_pre_254_scenarios_still_ten_houses(self):
+        """Backward compat: every existing scenario still produces a
+        10-house env (the engine paths previously hardcoded 10 now read
+        ``scenario.num_houses`` which defaults to 10, but the resulting
+        behavior must be identical for pre-#254 scenarios)."""
+        from bucket_brigade.envs.scenarios_generated import (
+            SCENARIO_REGISTRY,
+        )
+
+        for name, factory in SCENARIO_REGISTRY.items():
+            if name.startswith("v2_"):
+                continue
+            scenario = factory(num_agents=4)
+            assert scenario.num_houses == 10, (
+                f"Pre-#254 scenario '{name}' regressed: num_houses={scenario.num_houses}"
+            )
+            env = BucketBrigadeEnv(scenario=scenario)
+            assert env.num_houses == 10
+            assert env.houses.shape == (10,)

--- a/web/src/utils/scenarioGenerator.generated.ts
+++ b/web/src/utils/scenarioGenerator.generated.ts
@@ -31,6 +31,7 @@ export const SCENARIO_TYPES = {
   MIXED_MOTIVATION: 'mixed_motivation',
   MINIMAL_SPECIALIZATION: 'minimal_specialization',
   POSITIONAL_DEFAULT: 'positional_default',
+  V2_MINIMAL: 'v2_minimal',
 } as const;
 
 export type ScenarioType = (typeof SCENARIO_TYPES)[keyof typeof SCENARIO_TYPES];
@@ -297,6 +298,24 @@ const SCENARIO_TEMPLATES: Record<
       reward_other_house_survives: 0.0,
       penalty_own_house_burns: 40.0,
       penalty_other_house_burns: 0.0,
+      num_agents: 4,
+    },
+  },
+  [SCENARIO_TYPES.V2_MINIMAL]: {
+    name: 'V2 Minimal',
+    description: 'Issue #254 / option E of architect proposal #234: 2-house x 4-agent PPO learnability diagnostic. Joint action space shrinks to 4 * (2 * 2 * 2) = 32 per-agent moves vs default 4 * (10 * 2 * 2) = 1600, so PPO has a tractable exploration problem. Reward shape mirrors minimal_specialization (per-agent ownership dominates 10 team reward). Ignition rate bumped 0.02->0.05 because at 0.02 a 2-house ring has too many fire-free episodes. Python/Rust only - WASM frontend (web/) is fixed at 10 houses; non-10 scenarios panic in wasm.rs.',
+    parameters: {
+      prob_fire_spreads_to_neighbor: 0.25,
+      prob_solo_agent_extinguishes_fire: 0.5,
+      prob_house_catches_fire: 0.05,
+      team_reward_house_survives: 10.0,
+      team_penalty_house_burns: 10.0,
+      cost_to_work_one_night: 0.5,
+      min_nights: 8,
+      reward_own_house_survives: [50.0, 50.0, 50.0, 50.0],
+      reward_other_house_survives: [0.0, 0.0, 0.0, 0.0],
+      penalty_own_house_burns: [100.0, 100.0, 100.0, 100.0],
+      penalty_other_house_burns: [0.0, 0.0, 0.0, 0.0],
       num_agents: 4,
     },
   },


### PR DESCRIPTION
## Summary

Implements approach 3 from the curator analysis on issue #254: parameterize `num_houses` through the Rust core and Python envs only, freezing the WASM frontend at 10 houses. Adds the `v2_minimal` scenario (2 houses, 4 agents) as a PPO learnability unit test per architect proposal #234 option E.

**Why this matters**: `v2_minimal` shrinks the joint action space from `4 × 1600` to `4 × 32` per-agent moves, giving PPO a tractable exploration problem for diagnosing whether learning failures are env-design or algorithmic.

- **Backward compat preserved bit-exactly**: every pre-#254 scenario keeps `num_houses=10` via serde default. Verified by `test_non_v2_scenarios_have_ten_houses` (Rust) and `test_pre_254_scenarios_still_ten_houses` (Python).
- **WASM guarded with panic**: `wasm.rs::WasmBucketBrigade::new` rejects any scenario with `num_houses != 10` with a clear error pointing to the Python env. The browser UI in `web/` still assumes a 10-house ring visually; non-10 scenarios are Python-only for now.
- **No PPO smoke run included**: per CLAUDE.md compute guidelines, training runs must execute remotely. PPO smoke on `v2_minimal` is a follow-up issue.

## Implementation notes

**Rust core** (`bucket-brigade-core/src/`):
- `scenarios.rs`: `Scenario` gains `num_houses: u8` with `serde(default = 10)`. Added `v2_minimal` static scenario, 4 new tests, and updated count test (14 → 15).
- `engine/core.rs`: `houses`, `house_owners`, `agent_home_positions` vectors now size from `scenario.num_houses`. Generalized `ring_dist_10(a, b)` → `ring_dist(n, a, b)` with a kept-for-back-compat `ring_dist_10` wrapper. Engine rejects `num_houses < 2`.
- `engine/phases.rs`: replaced 4× `for house_idx in 0..10` and `% 10` ring wrap with `num_houses`-derived values.
- `engine/rewards.rs`: `/ 10.0` fraction denominators now use `num_houses`; `ring_dist_10` call site uses the new generalized `ring_dist`.
- `python.rs`: added `num_houses` getter on `PyScenario`; constructor defaults to 10.
- `wasm.rs`: explicit guard panics on `num_houses != 10`.

**Python envs**:
- `bucket_brigade_env.py`: derives `self.num_houses`; all `range(10)`, `np.zeros(10)`, `% 10` sites parameterized.
- `puffer_env.py` / `puffer_env_rust.py`: `MultiDiscrete([10, 2, 2])` → `MultiDiscrete([num_houses, 2, 2])`; observation `houses` channel sizes from `num_houses`.
- `agents/heuristic_agent.py`: ring math derives ring size from `len(houses)` so opponents work on any ring topology (without this, heuristic-opponent rollouts on `v2_minimal` crash with `IndexError`).

**Code generation**:
- `scripts/generate_python.py`: emits `num_houses` only when explicitly set in JSON (preserves byte-identical pre-#254 codegen output for the 14 existing scenarios).
- `definitions/scenarios.json`: added `v2_minimal` entry.
- `bucket_brigade/envs/scenarios_generated.py`: regenerated.
- `web/src/utils/scenarioGenerator.generated.ts`: auto-regenerated by the codegen build step (template only; the runtime WASM panic protects against actual use).

## Test plan

- [x] **Rust unit tests**: `cargo test --no-default-features` — 114 passed (5 new v2_minimal engine tests, 4 new num_houses scenarios tests).
- [x] **Rust WASM compile**: `cargo check --features wasm --target wasm32-unknown-unknown` — clean.
- [x] **Python env tests**: `pytest tests/test_environment.py tests/test_agents.py tests/test_rust_integration.py tests/test_code_generation.py tests/test_baselines.py tests/test_env_health_diagnostics.py tests/test_equilibrium.py tests/test_heuristic_signaling.py tests/test_info_theory.py tests/test_integration.py` — 144 passed, 26 skipped (5 new v2_minimal env tests).
- [x] **Backward-compat regression**: explicit assertion that every pre-#254 scenario factory produces `num_houses=10` (Rust + Python).
- [x] **Manual v2_minimal smoke**: Rust core rollout + Python env rollout + Rust-backed puffer env rollout all complete 20 steps without crashes; observation/action shapes are `MultiDiscrete([2, 2, 2])` and obs houses length 2.
- [x] **Lint clean**: `ruff check` + `ruff format --check` + `cargo fmt --check`.

## Follow-up issues recommended

- **PPO smoke sweep on v2_minimal** (remote compute required per CLAUDE.md). Success criterion from curator spec: PPO closes ≥50% of (random → specialist) gap. Failure ⇒ env design itself is the bottleneck, not algorithm.
- **WASM/web UI support for non-10-house scenarios** (massive TS rework — defer until research path justifies it).
- **Re-derive random baseline for v2_minimal** (small follow-up, pattern from #196).

## Coordination

Sibling builders on issues #251 (k-hop action mask) and #253 (continuous extinguish) will need to rebase against this engine change. The new interface is `scenario.num_houses` everywhere; `ring_dist_10` is kept as a backward-compatible wrapper for callers that always run on the 10-house ring.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)