### PR TITLE
feat(env): action-conditioned reward shaping (alpha/beta)

### DIFF
--- a/bucket-brigade-core/src/engine/rewards.rs
+++ b/bucket-brigade-core/src/engine/rewards.rs
@@ -95,6 +95,65 @@ impl BucketBrigade {
             rewards[agent_idx] += team_reward;
         }
 
+        // 5. Action-conditioned reward shaping (issue #259).
+        //
+        // When both alpha and beta are zero (the default for every
+        // pre-#259 scenario) we skip this loop entirely so the per-step
+        // reward stream is byte-identical to pre-#259 behavior.
+        //
+        // alpha: credit-shared bonus for each worker that participates in
+        // extinguishing a fire (BURNING -> SAFE transition). Each worker at
+        // house h receives `alpha * (1 / workers_at_h)`. Note this uses the
+        // *strict* BURNING(1) -> SAFE(0) check, which is a stricter form of
+        // the save-event detection in the per-house ownership loop above
+        // (that loop fires on any non-SAFE -> SAFE, which type-wise includes
+        // the impossible RUINED -> SAFE transition).
+        //
+        // beta: flat bonus for each agent working at a house that was SAFE
+        // at start-of-step AND still SAFE at end-of-step (preventive presence).
+        // Not credit-shared; the prevention is per-agent.
+        //
+        // REST actions (action[1] == 0) never receive either bonus.
+        let alpha = self.scenario.action_shaping_alpha;
+        let beta = self.scenario.action_shaping_beta;
+        if alpha != 0.0 || beta != 0.0 {
+            // Pre-count workers per house in one pass, mirroring the
+            // counting pattern in `engine/phases.rs::extinguish_fires`.
+            let mut workers_per_house: Vec<usize> = vec![0; num_houses];
+            for action in actions.iter() {
+                if action[1] == 1 {
+                    let h = action[0] as usize;
+                    if h < num_houses {
+                        workers_per_house[h] += 1;
+                    }
+                }
+            }
+
+            for agent_idx in 0..self.num_agents {
+                if actions[agent_idx][1] != 1 {
+                    continue; // REST receives no shaping bonus.
+                }
+                let h = actions[agent_idx][0] as usize;
+                if h >= num_houses {
+                    continue;
+                }
+                let workers_h = workers_per_house[h];
+                if workers_h == 0 {
+                    continue; // Defensive; should be at least 1 (this agent).
+                }
+
+                // alpha: extinguish credit share. Strict BURNING(1) -> SAFE(0).
+                if alpha != 0.0 && prev_houses[h] == 1 && self.houses[h] == 0 {
+                    rewards[agent_idx] += alpha / (workers_h as f32);
+                }
+
+                // beta: preventive presence. SAFE(0) start AND SAFE(0) end.
+                if beta != 0.0 && prev_houses[h] == 0 && self.houses[h] == 0 {
+                    rewards[agent_idx] += beta;
+                }
+            }
+        }
+
         rewards
     }
 }

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -804,6 +804,241 @@ fn test_engine_allows_more_agents_than_houses() {
 }
 
 // ==============================================================================
+// Issue #259 — Action-conditioned reward shaping
+// ==============================================================================
+
+/// Backward compat: when both shaping knobs are zero (the default for
+/// every pre-#259 scenario) the per-step reward trace is byte-identical
+/// to today's behavior. The fast-path skip in `compute_rewards` is the
+/// only thing that lets us claim bit-exactness for the default.
+#[test]
+fn test_zero_shaping_preserves_default_rewards() {
+    // Identical scenario, identical seed, identical actions
+    // -> identical reward vector. Pre-#259 baseline check.
+    let scenario = SCENARIOS.get("default").unwrap().clone();
+    assert_eq!(scenario.action_shaping_alpha, 0.0);
+    assert_eq!(scenario.action_shaping_beta, 0.0);
+    let mut engine_a = BucketBrigade::new(scenario.clone(), 4, Some(11));
+    let mut engine_b = BucketBrigade::new(scenario, 4, Some(11));
+    let actions = vec![[3u8, 1u8, 1u8], [5, 1, 1], [7, 1, 1], [9, 1, 1]];
+    let r_a = engine_a.step(&actions).rewards;
+    let r_b = engine_b.step(&actions).rewards;
+    assert_eq!(r_a, r_b);
+}
+
+/// Engine bit-exactness across all pre-#259 SCENARIOS: every scenario in
+/// the registry keeps `action_shaping_alpha == 0` and
+/// `action_shaping_beta == 0`. Guards against a future scenario silently
+/// enabling shaping and breaking the bit-exact baseline.
+#[test]
+fn test_pre_259_scenarios_have_zero_shaping_knobs() {
+    for (name, scenario) in SCENARIOS.iter() {
+        assert_eq!(
+            scenario.action_shaping_alpha, 0.0,
+            "Pre-#259 scenario '{}' must keep action_shaping_alpha=0.0",
+            name
+        );
+        assert_eq!(
+            scenario.action_shaping_beta, 0.0,
+            "Pre-#259 scenario '{}' must keep action_shaping_beta=0.0",
+            name
+        );
+    }
+}
+
+/// `alpha` credit-share invariant: when k workers co-extinguish one fire,
+/// the sum of their action-shaping bonuses equals `alpha` exactly. This is
+/// the core acceptance criterion for the credit-share formulation.
+#[test]
+fn test_alpha_credit_share_sums_to_alpha() {
+    // Custom deterministic scenario: 100% extinguish probability, no
+    // spreading, no spontaneous ignition. Zero all other reward channels
+    // so the per-step reward delta isolates the alpha bonus.
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.prob_solo_agent_extinguishes_fire = 1.0;
+    scenario.prob_fire_spreads_to_neighbor = 0.0;
+    scenario.prob_house_catches_fire = 0.0;
+    scenario.team_reward_house_survives = 0.0;
+    scenario.team_penalty_house_burns = 0.0;
+    scenario.reward_own_house_survives = vec![0.0; 10];
+    scenario.reward_other_house_survives = vec![0.0; 10];
+    scenario.penalty_own_house_burns = vec![0.0; 10];
+    scenario.penalty_other_house_burns = vec![0.0; 10];
+    scenario.cost_to_work_one_night = 0.0;
+    scenario.action_shaping_alpha = 1.5;
+    scenario.action_shaping_beta = 0.0;
+
+    let mut engine = BucketBrigade::new(scenario, 4, Some(2025));
+    // Set up: only house 5 burning at start-of-step. All 4 workers go to
+    // house 5; with kappa=1.0 the fire is guaranteed to extinguish.
+    engine.houses = vec![0; 10];
+    engine.houses[5] = 1;
+
+    let actions = vec![[5u8, 1u8, 1u8], [5, 1, 1], [5, 1, 1], [5, 1, 1]];
+    let rewards = engine.step(&actions).rewards;
+
+    // Sum of bonuses across the 4 co-extinguishers should be exactly 1.5
+    // (work cost is zero, team/ownership/cost are all zero; only alpha
+    // and the implicit beta at non-target houses contribute). Since beta=0
+    // every term except alpha drops out. Each worker should get
+    // alpha/4 = 0.375.
+    let sum: f32 = rewards.iter().sum();
+    assert!(
+        (sum - 1.5).abs() < 1e-5,
+        "Sum of alpha bonuses should equal alpha=1.5 exactly, got {}",
+        sum
+    );
+    // Each worker received the same share.
+    for &r in &rewards {
+        assert!(
+            (r - 0.375).abs() < 1e-5,
+            "Each co-extinguisher should get alpha/4 = 0.375, got {}",
+            r
+        );
+    }
+}
+
+/// REST actions never receive the alpha bonus even if a fire is being
+/// extinguished at the same house by other workers.
+#[test]
+fn test_rest_agents_get_zero_alpha_bonus() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.prob_solo_agent_extinguishes_fire = 1.0;
+    scenario.prob_fire_spreads_to_neighbor = 0.0;
+    scenario.prob_house_catches_fire = 0.0;
+    scenario.team_reward_house_survives = 0.0;
+    scenario.team_penalty_house_burns = 0.0;
+    scenario.reward_own_house_survives = vec![0.0; 10];
+    scenario.reward_other_house_survives = vec![0.0; 10];
+    scenario.penalty_own_house_burns = vec![0.0; 10];
+    scenario.penalty_other_house_burns = vec![0.0; 10];
+    scenario.cost_to_work_one_night = 0.0;
+    scenario.action_shaping_alpha = 2.0;
+    scenario.action_shaping_beta = 0.0;
+
+    let mut engine = BucketBrigade::new(scenario, 4, Some(99));
+    engine.houses = vec![0; 10];
+    engine.houses[3] = 1; // House 3 burning at start-of-step.
+
+    // Agent 0 works house 3, agent 1 rests at house 3 (action[1]=0),
+    // agents 2 and 3 rest elsewhere.
+    let actions = vec![[3u8, 1u8, 1u8], [3, 0, 0], [7, 0, 0], [9, 0, 0]];
+    let rewards = engine.step(&actions).rewards;
+
+    // Agent 0 is the sole worker -> alpha/1 = 2.0.
+    assert!(
+        (rewards[0] - 2.0).abs() < 1e-5,
+        "Sole worker should get full alpha=2.0, got {}",
+        rewards[0]
+    );
+    // Resting agents get rest bonus +0.5, no alpha share.
+    for i in 1..4 {
+        assert!(
+            (rewards[i] - 0.5).abs() < 1e-5,
+            "Resting agent {} should get +0.5 rest bonus only, got {}",
+            i,
+            rewards[i]
+        );
+    }
+}
+
+/// `beta` rewards preventive presence: an agent working at a SAFE house
+/// that stays SAFE receives the flat bonus. Verifies the beta path is
+/// distinct from alpha (which requires a BURNING -> SAFE transition).
+#[test]
+fn test_beta_rewards_preventive_presence() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.prob_fire_spreads_to_neighbor = 0.0;
+    scenario.prob_house_catches_fire = 0.0;
+    scenario.prob_solo_agent_extinguishes_fire = 0.0;
+    scenario.team_reward_house_survives = 0.0;
+    scenario.team_penalty_house_burns = 0.0;
+    scenario.reward_own_house_survives = vec![0.0; 10];
+    scenario.reward_other_house_survives = vec![0.0; 10];
+    scenario.penalty_own_house_burns = vec![0.0; 10];
+    scenario.penalty_other_house_burns = vec![0.0; 10];
+    scenario.cost_to_work_one_night = 0.0;
+    scenario.action_shaping_alpha = 0.0;
+    scenario.action_shaping_beta = 0.3;
+
+    let mut engine = BucketBrigade::new(scenario, 4, Some(7));
+    // All houses safe; no fires; no spread.
+    engine.houses = vec![0; 10];
+
+    // All 4 agents work at distinct safe houses.
+    let actions = vec![[0u8, 1u8, 1u8], [3, 1, 1], [5, 1, 1], [8, 1, 1]];
+    let rewards = engine.step(&actions).rewards;
+
+    // Each working agent gets +0.3 preventive bonus (no cost, no other
+    // reward channels).
+    for (i, &r) in rewards.iter().enumerate() {
+        assert!(
+            (r - 0.3).abs() < 1e-5,
+            "Agent {} working at safe house should get beta=0.3, got {}",
+            i,
+            r
+        );
+    }
+}
+
+/// `beta` does NOT fire on a house that was BURNING at start-of-step
+/// (even if extinguished by end-of-step). Beta requires prev==SAFE and
+/// end==SAFE — strict preventive presence, not an alpha proxy.
+#[test]
+fn test_beta_skips_extinguished_house() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.prob_solo_agent_extinguishes_fire = 1.0;
+    scenario.prob_fire_spreads_to_neighbor = 0.0;
+    scenario.prob_house_catches_fire = 0.0;
+    scenario.team_reward_house_survives = 0.0;
+    scenario.team_penalty_house_burns = 0.0;
+    scenario.reward_own_house_survives = vec![0.0; 10];
+    scenario.reward_other_house_survives = vec![0.0; 10];
+    scenario.penalty_own_house_burns = vec![0.0; 10];
+    scenario.penalty_other_house_burns = vec![0.0; 10];
+    scenario.cost_to_work_one_night = 0.0;
+    scenario.action_shaping_alpha = 0.0;
+    scenario.action_shaping_beta = 0.5;
+
+    let mut engine = BucketBrigade::new(scenario, 4, Some(123));
+    engine.houses = vec![0; 10];
+    engine.houses[5] = 1; // Burning at start-of-step.
+
+    // Agent 0 works house 5 (extinguishes it). Other agents rest.
+    let actions = vec![[5u8, 1u8, 1u8], [0, 0, 0], [0, 0, 0], [0, 0, 0]];
+    let rewards = engine.step(&actions).rewards;
+
+    // alpha=0, so no extinguish bonus. beta=0.5 but prev[5]=BURNING so
+    // beta doesn't fire. Agent 0 gets 0.0 (no cost, no shaping).
+    assert!(
+        rewards[0].abs() < 1e-5,
+        "Agent extinguishing fire must NOT get beta (prev was BURNING), got {}",
+        rewards[0]
+    );
+}
+
+/// Engine smoke test: a scenario with both knobs enabled runs without
+/// panicking and produces finite rewards.
+#[test]
+fn test_action_shaping_engine_smoke() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.action_shaping_alpha = 0.5;
+    scenario.action_shaping_beta = 0.1;
+    let mut engine = BucketBrigade::new(scenario, 4, Some(42));
+    for _ in 0..15 {
+        if engine.done {
+            break;
+        }
+        let actions = vec![[0u8, 1u8, 1u8], [3, 1, 1], [5, 1, 1], [8, 1, 1]];
+        let result = engine.step(&actions);
+        assert_eq!(result.rewards.len(), 4);
+        for &r in &result.rewards {
+            assert!(r.is_finite(), "Per-step reward must be finite, got {}", r);
+        }
+    }
+}
+
+// ==============================================================================
 // Property-Based Tests
 // ==============================================================================
 
@@ -981,6 +1216,10 @@ mod proptests {
                 distance_metric: "ring_arc".to_string(),
                 // Issue #254: pre-#254 fixed-10 ring for these proptests.
                 num_houses: 10,
+                // Issue #259: action shaping off so the existing proptest
+                // invariants (which assume pre-#259 reward semantics) hold.
+                action_shaping_alpha: 0.0,
+                action_shaping_beta: 0.0,
             };
 
             let mut engine = BucketBrigade::new(scenario, 4, Some(42));

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -158,6 +158,11 @@ impl PyScenario {
             // ``bucket_brigade_core.SCENARIOS["v2_minimal"]`` which routes
             // through the JSON path that preserves all fields.
             num_houses: 10,
+            // Issue #259: action-conditioned shaping defaults to off
+            // (both knobs zero -> engine takes the fast-path skip and
+            // existing PyScenario callers see byte-identical rewards).
+            action_shaping_alpha: 0.0,
+            action_shaping_beta: 0.0,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator. The literal above is safe today but the helper keeps the
@@ -251,6 +256,24 @@ impl PyScenario {
     #[getter]
     fn num_houses(&self) -> u8 {
         self.inner.num_houses
+    }
+
+    /// Issue #259: action-conditioned reward shaping knobs. Both default
+    /// to ``0.0`` so existing scenarios behave bit-exactly. When non-zero
+    /// they enable per-step per-agent bonuses tied to extinguish events
+    /// (alpha) and preventive presence (beta) — see
+    /// ``bucket-brigade-core/src/engine/rewards.rs`` for the semantics.
+    /// To use these knobs from Python, prefer pulling the scenario out of
+    /// ``bucket_brigade_core.SCENARIOS[...]`` (the JSON path preserves all
+    /// fields) or construct via the Python ``Scenario`` dataclass.
+    #[getter]
+    fn action_shaping_alpha(&self) -> f32 {
+        self.inner.action_shaping_alpha
+    }
+
+    #[getter]
+    fn action_shaping_beta(&self) -> f32 {
+        self.inner.action_shaping_beta
     }
 }
 

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -63,6 +63,24 @@ fn default_distance_cost_alpha() -> f32 {
     0.0
 }
 
+/// Default for `Scenario::action_shaping_alpha`. Zero preserves bit-exact
+/// backward compatibility with pre-#259 behavior (no action-conditioned
+/// reward shaping). When non-zero, each worker that participates in
+/// extinguishing a fire receives a credit-shared bonus of
+/// `alpha * (1 / workers_at_house_this_step)` (issue #259).
+fn default_action_shaping_alpha() -> f32 {
+    0.0
+}
+
+/// Default for `Scenario::action_shaping_beta`. Zero preserves bit-exact
+/// backward compatibility with pre-#259 behavior. When non-zero, each
+/// agent working at a house that started the step SAFE and is still SAFE
+/// at end-of-step receives a flat `beta` bonus for preventive presence
+/// (issue #259).
+fn default_action_shaping_beta() -> f32 {
+    0.0
+}
+
 /// Allowed values for `Scenario::distance_metric`.
 ///
 /// `engine/rewards.rs` currently consumes `distance_cost_alpha + ring_dist_10(...)`
@@ -167,6 +185,31 @@ pub struct Scenario {
         deserialize_with = "deserialize_distance_metric"
     )]
     pub distance_metric: String,
+
+    // Action-conditioned reward shaping (issue #259, optional, additive).
+    //
+    // Both default to `0.0` so every pre-#259 scenario is bit-exactly
+    // preserved (the engine takes a fast-path skip when both are zero;
+    // see `engine/rewards.rs`).
+    //
+    // `action_shaping_alpha` rewards workers who participated in
+    // extinguishing a fire this step. Credit is split among co-extinguishers:
+    // each worker at house `h` (where `h` transitioned BURNING -> SAFE this
+    // step) receives `alpha * (1 / workers_at_h)`. Strict BURNING(1) -> SAFE(0)
+    // transition only — stricter than the save-event check in the existing
+    // per-house ownership loop, which fires on any non-SAFE -> SAFE
+    // transition (RUINED -> SAFE is impossible in current dynamics but
+    // type-wise covered).
+    //
+    // `action_shaping_beta` rewards agents working at houses that were
+    // SAFE at start-of-step and are still SAFE at end-of-step — preventive
+    // presence. Flat per-agent bonus; not credit-shared.
+    //
+    // REST actions (`action[1] == 0`) never receive either bonus.
+    #[serde(default = "default_action_shaping_alpha")]
+    pub action_shaping_alpha: f32,
+    #[serde(default = "default_action_shaping_beta")]
+    pub action_shaping_beta: f32,
 }
 
 impl Scenario {
@@ -237,6 +280,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -258,6 +303,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -279,6 +326,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -301,6 +350,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -322,6 +373,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -343,6 +396,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -364,6 +419,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -385,6 +442,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -406,6 +465,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -427,6 +488,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -448,6 +511,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -469,6 +534,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -497,6 +564,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -524,6 +593,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: 0.1,
             distance_metric: "ring_arc".to_string(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -554,6 +625,8 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: default_distance_metric(),
             num_houses: 2,
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         },
     );
 
@@ -1124,6 +1197,8 @@ mod tests {
             distance_cost_alpha: default_distance_cost_alpha(),
             distance_metric: "bogus".to_string(),
             num_houses: default_num_houses(),
+            action_shaping_alpha: default_action_shaping_alpha(),
+            action_shaping_beta: default_action_shaping_beta(),
         };
         let err = scenario
             .validate()

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -164,6 +164,14 @@ impl WasmScenario {
             // here so the rest of the constructor path can't accidentally
             // produce a non-10 scenario via the WASM surface.
             num_houses: 10,
+            // Issue #259: action-conditioned shaping defaults to off so
+            // existing JS/TS callers see byte-identical rewards. The
+            // browser UI doesn't expose these knobs yet; to consume a
+            // scenario with shaping enabled, route through the JSON path
+            // (``Scenario::to_json`` / ``from_json``) which preserves all
+            // fields.
+            action_shaping_alpha: 0.0,
+            action_shaping_beta: 0.0,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator so future kwargs additions can't reintroduce silent

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -386,6 +386,63 @@ class BucketBrigadeEnv:
             # Team reward component (full public goods incentive)
             individual_rewards[agent_idx] += team_reward
 
+        # Action-conditioned reward shaping (issue #259).
+        #
+        # When both alpha and beta are zero (the default for every pre-#259
+        # scenario) this loop is skipped entirely so per-step rewards are
+        # byte-identical to pre-#259 behavior. Mirrors the Rust
+        # implementation in ``bucket-brigade-core/src/engine/rewards.rs``.
+        #
+        # alpha: credit-shared bonus for each worker that participated in
+        # extinguishing a fire (BURNING -> SAFE transition this step). Each
+        # worker at house ``h`` receives ``alpha / workers_at_h``. Note
+        # this uses the *strict* BURNING(1) -> SAFE(0) check, which is
+        # stricter than the save-event detection in the per-house ownership
+        # loop above (that loop fires on any non-SAFE -> SAFE).
+        #
+        # beta: flat bonus for each agent working at a house that was SAFE
+        # at start-of-step AND still SAFE at end-of-step (preventive
+        # presence). Not credit-shared.
+        #
+        # REST actions (action[1] == 0) never receive either bonus.
+        action_alpha = float(getattr(self.scenario, "action_shaping_alpha", 0.0))
+        action_beta = float(getattr(self.scenario, "action_shaping_beta", 0.0))
+        if action_alpha != 0.0 or action_beta != 0.0:
+            # Pre-count workers per house (mirrors the vectorized count in
+            # `_extinguish_fires`).
+            workers_per_house = np.zeros(self.num_houses, dtype=np.int32)
+            work_mask = actions[:, 1] == self.WORK
+            for agent_idx in np.nonzero(work_mask)[0]:
+                h = int(actions[agent_idx, 0])
+                if 0 <= h < self.num_houses:
+                    workers_per_house[h] += 1
+
+            for agent_idx in range(self.num_agents):
+                if actions[agent_idx, 1] != self.WORK:
+                    continue  # REST receives no shaping bonus.
+                h = int(actions[agent_idx, 0])
+                if not (0 <= h < self.num_houses):
+                    continue
+                workers_h = int(workers_per_house[h])
+                if workers_h == 0:
+                    continue  # Defensive; should be >= 1 (this agent).
+
+                # alpha: extinguish credit share. Strict BURNING -> SAFE.
+                if (
+                    action_alpha != 0.0
+                    and prev_houses[h] == self.BURNING
+                    and self.houses[h] == self.SAFE
+                ):
+                    individual_rewards[agent_idx] += action_alpha / float(workers_h)
+
+                # beta: preventive presence. SAFE start AND SAFE end.
+                if (
+                    action_beta != 0.0
+                    and prev_houses[h] == self.SAFE
+                    and self.houses[h] == self.SAFE
+                ):
+                    individual_rewards[agent_idx] += action_beta
+
         return individual_rewards
 
     def _check_termination(self) -> bool:

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -85,6 +85,20 @@ class Scenario:
     # (``MultiDiscrete([num_houses, 2, 2])``) and observation arrays.
     num_houses: int = 10
 
+    # Action-conditioned reward shaping (issue #259, optional, additive).
+    # Both default to ``0.0`` so every pre-#259 scenario is bit-exactly
+    # preserved (the env takes a fast-path skip when both knobs are zero).
+    # ``action_shaping_alpha`` rewards workers who participated in
+    # extinguishing a fire (BURNING -> SAFE this step), credit-shared
+    # as ``alpha / workers_at_house``. ``action_shaping_beta`` is a flat
+    # per-agent bonus for working at a SAFE house that stays SAFE
+    # (preventive presence). REST actions never receive either bonus.
+    # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards``
+    # and ``bucket-brigade-core/src/engine/rewards.rs`` for the canonical
+    # implementation.
+    action_shaping_alpha: float = 0.0
+    action_shaping_beta: float = 0.0
+
     def __post_init__(self) -> None:
         """Auto-promote scalar ownership reward fields to per-agent vectors.
 

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -185,6 +185,20 @@ def generate_scenarios(json_path: Path, output_path: Path):
         # (``MultiDiscrete([num_houses, 2, 2])``) and observation arrays.
         num_houses: int = 10
 
+        # Action-conditioned reward shaping (issue #259, optional, additive).
+        # Both default to ``0.0`` so every pre-#259 scenario is bit-exactly
+        # preserved (the env takes a fast-path skip when both knobs are zero).
+        # ``action_shaping_alpha`` rewards workers who participated in
+        # extinguishing a fire (BURNING -> SAFE this step), credit-shared
+        # as ``alpha / workers_at_house``. ``action_shaping_beta`` is a flat
+        # per-agent bonus for working at a SAFE house that stays SAFE
+        # (preventive presence). REST actions never receive either bonus.
+        # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards``
+        # and ``bucket-brigade-core/src/engine/rewards.rs`` for the canonical
+        # implementation.
+        action_shaping_alpha: float = 0.0
+        action_shaping_beta: float = 0.0
+
         def __post_init__(self) -> None:
             """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -333,6 +347,18 @@ def generate_scenarios(json_path: Path, output_path: Path):
         # of 10).
         if "num_houses" in spec:
             code += f"        num_houses={spec['num_houses']},\n"
+        # Issue #259 optional action-shaping fields. Emit only when set in
+        # JSON so every pre-#259 scenario factory is byte-identical to
+        # pre-#259 codegen output (they all keep the dataclass defaults
+        # of 0.0).
+        if "action_shaping_alpha" in spec:
+            code += (
+                f"        action_shaping_alpha={spec['action_shaping_alpha']},\n"
+            )
+        if "action_shaping_beta" in spec:
+            code += (
+                f"        action_shaping_beta={spec['action_shaping_beta']},\n"
+            )
         code += f"    )\n\n\n"
 
     # Generate SCENARIO_REGISTRY

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -952,3 +952,217 @@ class TestV2MinimalScenario:
             env = BucketBrigadeEnv(scenario=scenario)
             assert env.num_houses == 10
             assert env.houses.shape == (10,)
+
+
+class TestActionShaping:
+    """Issue #259: action-conditioned per-step reward shaping.
+
+    The Python env mirrors the Rust core's two new ``Scenario`` fields,
+    ``action_shaping_alpha`` and ``action_shaping_beta``. Both default to
+    ``0.0`` and every pre-#259 scenario keeps them zero, so existing
+    behavior is bit-exactly preserved. Test pattern modeled on
+    ``TestPositionalScenario`` (PR #203 precedent).
+    """
+
+    def test_defaults_are_zero_across_all_scenarios(self):
+        """Every pre-#259 scenario keeps both shaping knobs at 0.0."""
+        from bucket_brigade.envs.scenarios_generated import SCENARIO_REGISTRY
+
+        for name, factory in SCENARIO_REGISTRY.items():
+            s = factory(num_agents=4)
+            assert s.action_shaping_alpha == 0.0, (
+                f"Pre-#259 scenario '{name}' must keep "
+                f"action_shaping_alpha=0.0; got {s.action_shaping_alpha}"
+            )
+            assert s.action_shaping_beta == 0.0, (
+                f"Pre-#259 scenario '{name}' must keep "
+                f"action_shaping_beta=0.0; got {s.action_shaping_beta}"
+            )
+
+    def test_zero_shaping_matches_pre259_full_episode(self):
+        """End-to-end: alpha=0 and beta=0 produce the same per-step reward
+        trace as before — guards against accidental side effects of threading
+        the new fields through ``_compute_rewards``."""
+        from bucket_brigade.envs.scenarios_generated import default_scenario
+
+        env_a = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        env_b = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        env_a.reset(seed=99)
+        env_b.reset(seed=99)
+        rng = np.random.RandomState(0)
+        for _ in range(10):
+            actions = rng.randint(0, 2, size=(4, 2)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+            _, r_a, _, _ = env_a.step(actions)
+            _, r_b, _, _ = env_b.step(actions)
+            np.testing.assert_allclose(r_a, r_b)
+
+    def test_alpha_credit_share_sums_to_alpha(self):
+        """When k workers co-extinguish one fire, the sum of their alpha
+        bonuses equals alpha exactly. Core invariant of the credit-share
+        formulation."""
+        scenario = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,  # deterministic extinguish
+            action_shaping_alpha=1.5,
+            action_shaping_beta=0.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # Set up: only house 5 burning, no other fires, no spread/spark.
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[5] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # All 4 agents work at house 5 -> guaranteed extinguish.
+        actions = np.array(
+            [[5, 1, 1], [5, 1, 1], [5, 1, 1], [5, 1, 1]],
+            dtype=np.int8,
+        )
+        # Drive the engine through a full step so the BURNING -> SAFE
+        # transition actually happens and prev_houses captures the right
+        # start state. We can't call _compute_rewards in isolation because
+        # it depends on self.houses already reflecting end-of-step.
+        _, rewards, _, _ = env.step(actions)
+        # Sum should equal alpha=1.5 (cost is zero, team/ownership are zero).
+        assert abs(float(np.sum(rewards)) - 1.5) < 1e-5, (
+            f"Sum of alpha bonuses should equal alpha=1.5, got {np.sum(rewards)}"
+        )
+        # Each worker should get alpha/4 = 0.375.
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - 0.375) < 1e-5, (
+                f"Worker {i} should get alpha/4=0.375, got {r}"
+            )
+
+    def test_rest_agents_get_zero_shaping_bonus(self):
+        """REST actions never receive alpha or beta, regardless of nearby
+        extinguish events."""
+        scenario = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,
+            action_shaping_alpha=2.0,
+            action_shaping_beta=0.5,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=42)
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[3] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # Agent 0 works house 3 (extinguishes), agents 1-3 rest at house 0.
+        actions = np.array(
+            [[3, 1, 1], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # Agent 0 is sole worker -> alpha/1 = 2.0 (no work cost).
+        assert abs(float(rewards[0]) - 2.0) < 1e-5
+        # Resting agents get +0.5 rest bonus, no shaping.
+        for i in range(1, 4):
+            assert abs(float(rewards[i]) - 0.5) < 1e-5, (
+                f"Resting agent {i} should get +0.5 rest only, got {rewards[i]}"
+            )
+
+    def test_beta_rewards_preventive_presence(self):
+        """An agent working at a SAFE house that stays SAFE gets beta;
+        distinct from alpha (which requires BURNING->SAFE)."""
+        scenario = _make_minimal_scenario(
+            prob_fire_spreads_to_neighbor=0.0,
+            prob_house_catches_fire=0.0,
+            action_shaping_alpha=0.0,
+            action_shaping_beta=0.3,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=7)
+        env.houses = np.zeros(10, dtype=np.int8)
+        env._prev_houses_state = env.houses.copy()
+        # All 4 agents work at distinct safe houses.
+        actions = np.array(
+            [[0, 1, 1], [3, 1, 1], [5, 1, 1], [8, 1, 1]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # Each working agent: +0.3 preventive bonus (no cost, no other rewards).
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - 0.3) < 1e-5, (
+                f"Working agent {i} at safe house should get beta=0.3, got {r}"
+            )
+
+    def test_beta_does_not_fire_on_extinguished_house(self):
+        """Beta requires prev==SAFE; a BURNING->SAFE transition (alpha's
+        domain) does NOT trigger beta."""
+        scenario = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,
+            action_shaping_alpha=0.0,
+            action_shaping_beta=0.5,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[5] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # Agent 0 works house 5 (extinguishes); others rest.
+        actions = np.array(
+            [[5, 1, 1], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # alpha=0 so no extinguish bonus. beta=0.5 but prev[5]=BURNING so
+        # beta doesn't fire. Agent 0 nets 0.0 (no cost, no shaping).
+        assert abs(float(rewards[0])) < 1e-5, (
+            f"Extinguishing agent must not get beta (prev was BURNING), "
+            f"got {rewards[0]}"
+        )
+
+    def test_per_step_reward_variance_increases_with_alpha(self):
+        """Acceptance criterion: non-zero alpha provides a per-agent
+        gradient signal at extinguish events. Comparing alpha=0 vs alpha=2
+        on the same fixed extinguish scenario, the alpha=2 case must
+        produce strictly higher per-agent reward variance (the signal PPO
+        needs for credit assignment)."""
+        # 1 worker (extinguisher), 3 resters at safe houses. With alpha=0
+        # the worker's reward is just -cost=0 and resters get +0.5 (so
+        # rewards are [0, 0.5, 0.5, 0.5], var ~ 0.047). With alpha=2 the
+        # worker gets +2.0 and resters get +0.5 (rewards [2.0, 0.5, 0.5,
+        # 0.5], var ~ 0.42). The variance gap is the PPO signal.
+        variances = {}
+        for alpha in (0.0, 2.0):
+            scenario = _make_minimal_scenario(
+                prob_solo_agent_extinguishes_fire=1.0,
+                action_shaping_alpha=alpha,
+                action_shaping_beta=0.0,
+            )
+            env = BucketBrigadeEnv(scenario=scenario)
+            env.reset(seed=0)
+            env.houses = np.zeros(10, dtype=np.int8)
+            env.houses[5] = env.BURNING
+            env._prev_houses_state = env.houses.copy()
+            actions = np.array(
+                [[5, 1, 1], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+                dtype=np.int8,
+            )
+            _, rewards, _, _ = env.step(actions)
+            variances[alpha] = float(np.var(rewards))
+        assert variances[2.0] > variances[0.0], (
+            f"alpha=2 should produce strictly higher per-agent reward "
+            f"variance than alpha=0; got {variances}"
+        )
+        # And the alpha=2 variance is substantively positive (sanity).
+        assert variances[2.0] > 0.1
+
+    def test_v2_minimal_with_shaping_runs(self):
+        """Action shaping composes with v2_minimal (small ring)."""
+        from bucket_brigade.envs.scenarios_generated import v2_minimal_scenario
+
+        s = v2_minimal_scenario(num_agents=4)
+        # Override shaping (the v2_minimal factory keeps defaults).
+        scenario = dataclasses.replace(
+            s, action_shaping_alpha=0.5, action_shaping_beta=0.1
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=42)
+        rng = np.random.RandomState(0)
+        for _ in range(20):
+            actions = rng.randint(0, 2, size=(4, 3)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 2, size=4)
+            _, rewards, dones, _ = env.step(actions)
+            assert rewards.shape == (4,)
+            assert np.all(np.isfinite(rewards))
+            if dones[0]:
+                break


### PR DESCRIPTION
## Summary

Adds two new optional `Scenario` fields, `action_shaping_alpha` and `action_shaping_beta`, that produce per-step per-agent rewards tied to the local outcome of each agent's chosen action. Targets the credit-assignment gap surfaced by H2 audit data (`frac_steps_ownership_zero = 0.355` on `default` — over a third of steps PPO sees no per-agent gradient). Intervention #2 from #193's candidate list, recommended after PR #257's tier-3 verdict.

## Changes

- `bucket-brigade-core/src/scenarios.rs`: new fields with serde defaults `0.0`; updated 15 SCENARIOS literals + test fixture
- `bucket-brigade-core/src/engine/rewards.rs`: post-loop pass for alpha (credit-shared on `BURNING(1) -> SAFE(0)`) and beta (preventive presence on `SAFE -> SAFE`). Fast-path skip when both knobs are zero -> bit-exact backward compat
- `bucket-brigade-core/src/engine/tests.rs`: 7 new Rust unit tests
- `bucket-brigade-core/src/python.rs`, `wasm.rs`: thread new fields with off-by-default
- `bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards`: Python parity mirror
- `bucket_brigade/envs/scenarios_generated.py`: regenerated; new dataclass fields default `0.0`
- `scripts/generate_python.py`: emit new fields only when set in JSON (mirrors `distance_cost_alpha` pattern at line 305-306)
- `tests/test_environment.py`: 8 new tests in `TestActionShaping` (template from `TestPositionalScenario`, PR #203 precedent)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New scenario fields with serde defaults preserving existing scenarios | done | `test_pre_259_scenarios_have_zero_shaping_knobs` (Rust) + `test_defaults_are_zero_across_all_scenarios` (Python) iterate all 15 scenarios |
| Reward computation updated (Rust core + Python parity) | done | Both `engine/rewards.rs` and `_compute_rewards` updated; existing `test_rust_integration.py::test_rust_vs_python_consistency` still passes |
| Default-off path is bit-identical to current | done | `test_zero_shaping_preserves_default_rewards` (Rust) and `test_zero_shaping_matches_pre259_full_episode` (Python full 10-step rollout) |
| Non-zero alpha produces measurable per-agent gradient | done | `test_per_step_reward_variance_increases_with_alpha` asserts `var(alpha=2.0) > var(alpha=0)` |
| PyO3 + WASM surfaces threaded with defaults | done | Both constructors set `action_shaping_alpha: 0.0` and `action_shaping_beta: 0.0`; getters added in `python.rs` |

Two acceptance criteria from the original issue are intentionally **NOT in this PR**:

1. **Calibration sweep** (`alpha in {0.1, 0.5, 2.0} x beta in {0.0, 0.1, 0.5}`): follow-up issue. Per the curator note, watch for entropy collapse if action-shaping fires on >70% of steps (over-shaping signature analogous to MAPPO's 1874x in #257).
2. **Smoke training on `minimal_specialization`**: follow-up. CLAUDE.md prohibits local training; should run on `$COMPUTE_HOST_PRIMARY` with 50 iter x 3 seeds, comparing `gap_closed` against PR #257's `0.182` obs-fix baseline.

## Test Plan

- [x] `cargo test` in `bucket-brigade-core/`: 121 passed (added 7 new)
- [x] `pytest tests/test_environment.py`: 56 passed, 4 skipped (added 8 new in `TestActionShaping`)
- [x] `pytest tests/test_rust_integration.py`: 4 passed, 1 skipped (Rust/Python parity preserved on `trivial_cooperation`)
- [x] `pytest tests/test_code_generation.py`: 26 passed (codegen structural checks still hold)
- [x] `cargo fmt --check && cargo clippy`: no new warnings introduced
- [x] `ruff check` clean on the three edited Python files

## Notes for follow-up

The strict `BURNING(1) -> SAFE(0)` detection in the new alpha branch is intentionally stricter than the existing save-event check at `rewards.rs:73` (which fires on any non-SAFE -> SAFE, including the impossible RUINED -> SAFE). This pins the alpha to true extinguish events. `test_beta_skips_extinguished_house` (Python) and `test_alpha_credit_share_sums_to_alpha` (both languages) lock in this semantics.

Closes #259