### PR TITLE
exp(p3): action-shaping calibration sweep harness + analyzer (#262)

### DIFF
--- a/experiments/p3_specialization/analyze_261_calibration.py
+++ b/experiments/p3_specialization/analyze_261_calibration.py
@@ -108,13 +108,13 @@ def load_cell(cell: Path) -> Optional[dict]:
         "cell": str(cell),
         "trailing5_team_reward": _trailing_team(metrics),
         "final_iter": len(metrics) - 1,
-        "mean_action_entropy_final": float(last.get("action_entropy/mean", float("nan"))),
+        "mean_action_entropy_final": float(
+            last.get("action_entropy/mean", float("nan"))
+        ),
     }
 
 
-def aggregate_cell(
-    root: Path, alpha: float, beta: float
-) -> Dict[str, object]:
+def aggregate_cell(root: Path, alpha: float, beta: float) -> Dict[str, object]:
     seeds_data: List[Dict] = []
     for s in SEEDS:
         cell = _cell_dir(root, alpha, beta, s)
@@ -167,8 +167,7 @@ def compute_verdict(
         (
             c
             for c in cells
-            if c.get("alpha") == BASELINE_ALPHA
-            and c.get("beta") == BASELINE_BETA
+            if c.get("alpha") == BASELINE_ALPHA and c.get("beta") == BASELINE_BETA
         ),
         None,
     )
@@ -248,13 +247,11 @@ def compute_verdict(
     }
 
 
-def render_markdown(
-    cells: List[Dict[str, object]], verdict: Dict[str, object]
-) -> str:
+def render_markdown(cells: List[Dict[str, object]], verdict: Dict[str, object]) -> str:
     lines = [
         "# Issue #261/#262 — Action-shaping calibration sweep",
         "",
-        f"Scenario: ``minimal_specialization``  ",
+        "Scenario: ``minimal_specialization``  ",
         f"References (per-step mean team reward): "
         f"random={MINSPEC_RANDOM:+.2f}, specialist={MINSPEC_SPECIALIST:+.2f} "
         f"(denominator={MINSPEC_SPECIALIST - MINSPEC_RANDOM:+.2f}).",
@@ -270,9 +267,7 @@ def render_markdown(
         beta = c.get("beta")
         n = c.get("n_seeds", 0)
         if n == 0:
-            lines.append(
-                f"| {alpha} | {beta} | 0 | missing | — | — | — |"
-            )
+            lines.append(f"| {alpha} | {beta} | 0 | missing | — | — | — |")
             continue
         team_mean = c["team_reward_mean"]
         team_std = c["team_reward_std"]
@@ -342,14 +337,14 @@ def _discover_cells(root: Path) -> List[Tuple[float, float]]:
         if not alpha_dir.is_dir() or not alpha_dir.name.startswith("alpha_"):
             continue
         try:
-            alpha = float(alpha_dir.name[len("alpha_"):])
+            alpha = float(alpha_dir.name[len("alpha_") :])
         except ValueError:
             continue
         for beta_dir in sorted(alpha_dir.iterdir()):
             if not beta_dir.is_dir() or not beta_dir.name.startswith("beta_"):
                 continue
             try:
-                beta = float(beta_dir.name[len("beta_"):])
+                beta = float(beta_dir.name[len("beta_") :])
             except ValueError:
                 continue
             pairs.append((alpha, beta))

--- a/experiments/p3_specialization/analyze_261_calibration.py
+++ b/experiments/p3_specialization/analyze_261_calibration.py
@@ -1,0 +1,403 @@
+"""Analysis for issue #261/#262 — action-shaping calibration sweep.
+
+Reads per-cell ``metrics.json`` and ``config.json`` files under
+
+    experiments/p3_specialization/runs/issue261_calibration/
+        alpha_{ALPHA}/beta_{BETA}/seed_{SEED}/
+
+For each ``(alpha, beta)`` cell aggregated over seeds, computes:
+
+* ``trailing5_team_reward`` — mean of last-5 ``mean_step_reward_team`` rows
+  (matches ``analyze_231._trailing_team``).
+* ``gap_closed`` — ``(trailing5 - random) / (specialist - random)`` using the
+  ``minimal_specialization`` references from ``analyze_231``
+  (random=-87.72, specialist=-22.07; denominator=65.65).
+* ``mean_action_entropy_final`` — from ``metrics[-1]['action_entropy/mean']``
+  (already logged by ``train.py``).
+* ``entropy_collapse_multiple`` — ``baseline_entropy / cell_entropy`` where
+  baseline is the in-sweep ``(alpha=0, beta=0)`` cell. Flagged if > 100×
+  (MAPPO's collapse was 1874× per #257 — a 100× threshold is conservative).
+
+The best cell is the one with the largest ``gap_closed_mean``. Verdict
+ladder is then applied per the issue body:
+
+| Outcome | tier label |
+|---|---|
+| best gap_closed ≥ 0.50 | ``tier_1_breaks_plateau`` |
+| best gap_closed in [0.25, 0.50) | ``tier_2_partial`` |
+| best gap_closed < 0.25 | ``tier_3_insufficient`` |
+| over-shaping flag fires | annotated alongside the tier |
+
+Writes summary.{json,md} under
+``experiments/p3_specialization/diagnostics/results/issue261_calibration/``.
+
+Usage::
+
+    uv run python experiments/p3_specialization/analyze_261_calibration.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+# Pre-registered references (per-step mean team reward) from
+# ``analyze_231.BASELINES['minimal_specialization']``. Sources:
+#   random:     PR #244 (issue #237 post-#236 re-derivation)
+#   specialist: PR #243 (issue #238 post-#236 re-derivation)
+# Denominator: specialist - random = 65.65
+MINSPEC_RANDOM = -87.72
+MINSPEC_SPECIALIST = -22.07
+
+SEEDS = [42, 43, 44]
+TRAILING_N = 5
+
+# In-sweep baseline cell coordinates. The baseline gap_closed lands near
+# the PR #257 IPPO obs-fix verdict (~0.182) when alpha=beta=0.
+BASELINE_ALPHA = 0.0
+BASELINE_BETA = 0.0
+
+# Over-shaping threshold: entropy collapse multiple over the baseline.
+# MAPPO collapse was 1874× per #257; 100× is the curator-recommended
+# conservative flag.
+OVER_SHAPING_ENTROPY_MULTIPLE = 100.0
+
+
+def _fmt_alpha(alpha: float) -> str:
+    """Match the run-dir naming used by ``run_issue262_sweep.sh``."""
+    return f"{alpha:g}"
+
+
+def _fmt_beta(beta: float) -> str:
+    return f"{beta:g}"
+
+
+def _cell_dir(root: Path, alpha: float, beta: float, seed: int) -> Path:
+    return (
+        root
+        / "issue261_calibration"
+        / f"alpha_{_fmt_alpha(alpha)}"
+        / f"beta_{_fmt_beta(beta)}"
+        / f"seed_{seed}"
+    )
+
+
+def _trailing_team(metrics: List[dict], n: int = TRAILING_N) -> float:
+    rewards = [row["mean_step_reward_team"] for row in metrics]
+    tail = rewards[-n:] if len(rewards) >= n else rewards
+    return float(np.mean(tail))
+
+
+def gap_closed(trailing5_team: float) -> float:
+    return (trailing5_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+def load_cell(cell: Path) -> Optional[dict]:
+    mfile = cell / "metrics.json"
+    if not mfile.exists():
+        return None
+    metrics = json.loads(mfile.read_text())
+    if not metrics:
+        return None
+    last = metrics[-1]
+    return {
+        "cell": str(cell),
+        "trailing5_team_reward": _trailing_team(metrics),
+        "final_iter": len(metrics) - 1,
+        "mean_action_entropy_final": float(last.get("action_entropy/mean", float("nan"))),
+    }
+
+
+def aggregate_cell(
+    root: Path, alpha: float, beta: float
+) -> Dict[str, object]:
+    seeds_data: List[Dict] = []
+    for s in SEEDS:
+        cell = _cell_dir(root, alpha, beta, s)
+        d = load_cell(cell)
+        if d is None:
+            seeds_data.append({"seed": s, "missing": True})
+            continue
+        d["seed"] = s
+        seeds_data.append(d)
+    present = [d for d in seeds_data if not d.get("missing")]
+    out: Dict[str, object] = {
+        "alpha": alpha,
+        "beta": beta,
+        "seeds": seeds_data,
+        "n_seeds": len(present),
+    }
+    if not present:
+        return out
+    team = np.array([d["trailing5_team_reward"] for d in present])
+    ents = np.array([d["mean_action_entropy_final"] for d in present])
+    out["team_reward_mean"] = float(team.mean())
+    out["team_reward_std"] = float(team.std(ddof=1)) if len(team) > 1 else 0.0
+    out["team_reward_per_seed"] = team.tolist()
+    out["mean_entropy_final_mean"] = float(np.nanmean(ents))
+    out["gap_closed_mean"] = float(gap_closed(team.mean()))
+    out["gap_closed_per_seed"] = [float(gap_closed(x)) for x in team]
+    return out
+
+
+def _verdict_tier(best_gap: float) -> str:
+    if best_gap >= 0.50:
+        return "tier_1_breaks_plateau"
+    if best_gap >= 0.25:
+        return "tier_2_partial"
+    return "tier_3_insufficient"
+
+
+def compute_verdict(
+    cells: List[Dict[str, object]],
+) -> Dict[str, object]:
+    """Apply the pre-registered ladder + over-shaping check.
+
+    Picks the best ``(alpha, beta)`` cell by ``gap_closed_mean``. Flags
+    any cell whose mean action entropy is < 1/100th of the baseline
+    cell's. The verdict is computed from the best gap; over-shaping is
+    reported alongside (does not change the tier itself).
+    """
+    # Locate the in-sweep baseline (alpha=0, beta=0).
+    baseline = next(
+        (
+            c
+            for c in cells
+            if c.get("alpha") == BASELINE_ALPHA
+            and c.get("beta") == BASELINE_BETA
+        ),
+        None,
+    )
+    baseline_entropy: Optional[float] = None
+    if baseline is not None and baseline.get("n_seeds", 0) > 0:
+        baseline_entropy = float(baseline.get("mean_entropy_final_mean", float("nan")))
+
+    # Annotate each cell with entropy collapse multiple vs baseline.
+    over_shaping_flagged: List[Tuple[float, float, float]] = []
+    for c in cells:
+        if c.get("n_seeds", 0) == 0:
+            c["entropy_collapse_multiple"] = None
+            continue
+        cell_ent = float(c.get("mean_entropy_final_mean", float("nan")))
+        if (
+            baseline_entropy is None
+            or not np.isfinite(baseline_entropy)
+            or baseline_entropy <= 0.0
+            or not np.isfinite(cell_ent)
+            or cell_ent <= 0.0
+        ):
+            c["entropy_collapse_multiple"] = None
+            continue
+        multiple = baseline_entropy / cell_ent
+        c["entropy_collapse_multiple"] = float(multiple)
+        if multiple > OVER_SHAPING_ENTROPY_MULTIPLE:
+            over_shaping_flagged.append(
+                (float(c["alpha"]), float(c["beta"]), float(multiple))
+            )
+
+    # Pick the best cell by gap_closed_mean (among cells with data).
+    cells_with_data = [c for c in cells if c.get("n_seeds", 0) > 0]
+    best_cell: Optional[Dict[str, object]] = None
+    if cells_with_data:
+        best_cell = max(
+            cells_with_data, key=lambda c: c.get("gap_closed_mean", float("-inf"))
+        )
+
+    if best_cell is None:
+        return {
+            "best_cell": None,
+            "tier": "no_data",
+            "headline": "NO_DATA",
+            "baseline_entropy": baseline_entropy,
+            "over_shaping_flagged": [],
+        }
+
+    best_gap = float(best_cell["gap_closed_mean"])
+    tier = _verdict_tier(best_gap)
+
+    if tier == "tier_1_breaks_plateau":
+        headline = "ACTION_SHAPING_BREAKS_PLATEAU"
+    elif tier == "tier_2_partial":
+        headline = "ACTION_SHAPING_PARTIAL"
+    else:
+        headline = "ACTION_SHAPING_INSUFFICIENT"
+    if over_shaping_flagged:
+        headline = f"{headline}__OVER_SHAPING_FLAGGED"
+
+    return {
+        "best_cell": {
+            "alpha": best_cell["alpha"],
+            "beta": best_cell["beta"],
+            "gap_closed_mean": best_gap,
+            "team_reward_mean": best_cell.get("team_reward_mean"),
+            "mean_entropy_final_mean": best_cell.get("mean_entropy_final_mean"),
+            "entropy_collapse_multiple": best_cell.get("entropy_collapse_multiple"),
+            "n_seeds": best_cell.get("n_seeds"),
+        },
+        "tier": tier,
+        "headline": headline,
+        "baseline_entropy": baseline_entropy,
+        "over_shaping_flagged": [
+            {"alpha": a, "beta": b, "entropy_collapse_multiple": m}
+            for (a, b, m) in over_shaping_flagged
+        ],
+    }
+
+
+def render_markdown(
+    cells: List[Dict[str, object]], verdict: Dict[str, object]
+) -> str:
+    lines = [
+        "# Issue #261/#262 — Action-shaping calibration sweep",
+        "",
+        f"Scenario: ``minimal_specialization``  ",
+        f"References (per-step mean team reward): "
+        f"random={MINSPEC_RANDOM:+.2f}, specialist={MINSPEC_SPECIALIST:+.2f} "
+        f"(denominator={MINSPEC_SPECIALIST - MINSPEC_RANDOM:+.2f}).",
+        "",
+        "## Per-cell results",
+        "",
+        "| alpha | beta | n | team_reward (mean±std) | gap_closed_mean | "
+        "mean_action_entropy_final | entropy_collapse_x |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for c in cells:
+        alpha = c.get("alpha")
+        beta = c.get("beta")
+        n = c.get("n_seeds", 0)
+        if n == 0:
+            lines.append(
+                f"| {alpha} | {beta} | 0 | missing | — | — | — |"
+            )
+            continue
+        team_mean = c["team_reward_mean"]
+        team_std = c["team_reward_std"]
+        gap = c["gap_closed_mean"]
+        ent = c["mean_entropy_final_mean"]
+        coll = c.get("entropy_collapse_multiple")
+        coll_s = f"{coll:.1f}" if isinstance(coll, (int, float)) else "—"
+        lines.append(
+            f"| {alpha} | {beta} | {n} | {team_mean:+.2f} ± {team_std:.2f} | "
+            f"{gap:+.3f} | {ent:.3f} | {coll_s} |"
+        )
+
+    lines += [
+        "",
+        "## Verdict",
+        "",
+        f"**Headline**: ``{verdict['headline']}``",
+        f"**Tier**: ``{verdict['tier']}``",
+    ]
+    best = verdict.get("best_cell")
+    if best is not None:
+        lines += [
+            "",
+            "Best cell:",
+            f"- alpha = ``{best['alpha']}``, beta = ``{best['beta']}``",
+            f"- gap_closed_mean = ``{best['gap_closed_mean']:+.3f}``",
+            f"- team_reward_mean = ``{best.get('team_reward_mean'):+.3f}``",
+            f"- mean_action_entropy_final = ``{best.get('mean_entropy_final_mean'):.3f}``",
+            f"- n_seeds = ``{best.get('n_seeds')}``",
+        ]
+    over = verdict.get("over_shaping_flagged") or []
+    if over:
+        lines += [
+            "",
+            f"**Over-shaping flagged** (entropy collapse > "
+            f"{OVER_SHAPING_ENTROPY_MULTIPLE:g}× baseline):",
+            "",
+            "| alpha | beta | entropy_collapse_multiple |",
+            "|---|---|---|",
+        ]
+        for entry in over:
+            lines.append(
+                f"| {entry['alpha']} | {entry['beta']} | "
+                f"{entry['entropy_collapse_multiple']:.1f} |"
+            )
+    else:
+        lines += [
+            "",
+            "_No over-shaping flagged at the "
+            f"{OVER_SHAPING_ENTROPY_MULTIPLE:g}× threshold._",
+        ]
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _discover_cells(root: Path) -> List[Tuple[float, float]]:
+    """Discover (alpha, beta) pairs by listing the run-dir layout.
+
+    Returns a sorted list of (alpha, beta) pairs found on disk. Falls
+    back to an empty list if the calibration root doesn't exist yet.
+    """
+    cal_root = root / "issue261_calibration"
+    if not cal_root.is_dir():
+        return []
+    pairs: List[Tuple[float, float]] = []
+    for alpha_dir in sorted(cal_root.iterdir()):
+        if not alpha_dir.is_dir() or not alpha_dir.name.startswith("alpha_"):
+            continue
+        try:
+            alpha = float(alpha_dir.name[len("alpha_"):])
+        except ValueError:
+            continue
+        for beta_dir in sorted(alpha_dir.iterdir()):
+            if not beta_dir.is_dir() or not beta_dir.name.startswith("beta_"):
+                continue
+            try:
+                beta = float(beta_dir.name[len("beta_"):])
+            except ValueError:
+                continue
+            pairs.append((alpha, beta))
+    return sorted(set(pairs))
+
+
+def main() -> None:
+    runs_root = Path("experiments/p3_specialization/runs")
+    out_dir = Path(
+        "experiments/p3_specialization/diagnostics/results/issue261_calibration"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pairs = _discover_cells(runs_root)
+    if not pairs:
+        # Fallback: pre-registered grid from the issue body.
+        alphas = [0.0, 0.1, 0.5, 2.0]
+        betas = [0.0, 0.1, 0.5]
+        pairs = sorted({(a, b) for a in alphas for b in betas})
+
+    cells = [aggregate_cell(runs_root, a, b) for (a, b) in pairs]
+    verdict = compute_verdict(cells)
+    payload = {
+        "cells": cells,
+        "verdict": verdict,
+        "baselines": {
+            "random": MINSPEC_RANDOM,
+            "specialist": MINSPEC_SPECIALIST,
+            "denominator": MINSPEC_SPECIALIST - MINSPEC_RANDOM,
+        },
+        "thresholds": {
+            "tier_1": 0.50,
+            "tier_2": 0.25,
+            "over_shaping_entropy_multiple": OVER_SHAPING_ENTROPY_MULTIPLE,
+        },
+    }
+    (out_dir / "summary.json").write_text(json.dumps(payload, indent=2))
+    (out_dir / "summary.md").write_text(render_markdown(cells, verdict))
+    print(f"wrote {out_dir / 'summary.json'}")
+    print(f"wrote {out_dir / 'summary.md'}")
+    print(f"headline verdict: {verdict['headline']}")
+    if verdict.get("best_cell"):
+        b = verdict["best_cell"]
+        print(
+            f"best cell: alpha={b['alpha']}, beta={b['beta']}, "
+            f"gap_closed_mean={b['gap_closed_mean']:+.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue262_sweep.sh
+++ b/experiments/p3_specialization/run_issue262_sweep.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Issue #261/#262 sweep driver — action-shaping calibration on minimal_specialization.
+#
+# Pre-registered grid (per issue #262 body):
+#   alpha in {0.1, 0.5, 2.0} x beta in {0.0, 0.1, 0.5}        = 9 cells
+#   plus baseline (alpha=0, beta=0)                            = 10 configs
+#   seeds {42, 43, 44}                                         = 3 each
+#   total = 30 cells
+#
+# Per cell: 50 iterations x 2048 rollout steps x IPPO (no MAPPO).
+#
+# Layout (consumed by analyze_261_calibration.py):
+#   experiments/p3_specialization/runs/issue261_calibration/
+#       alpha_{ALPHA}/beta_{BETA}/seed_{SEED}/
+#           metrics.json, config.json, policies/, train.log
+#
+# Wall-clock: ~1.5 min/cell at 50 iters; 30 cells / 4-way parallel
+# ~12 min ideal, ~20-30 min realistic. Curator confirmed the issue
+# body's 3-4h estimate is conservative — half-iters of the #239 sweep.
+#
+# Modeled on experiments/p3_specialization/run_issue239_sweep.sh
+# (xargs -P parallelism, per-cell stdout, git-rev stamping).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+if [[ ! -d "$REPO_ROOT" ]]; then
+  # Fallback used on the Mac Studio.
+  if [[ -d "$HOME/bucket-brigade" ]]; then
+    REPO_ROOT="$HOME/bucket-brigade"
+  fi
+fi
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+SCENARIO="${SCENARIO:-minimal_specialization}"
+NUM_ITERATIONS="${NUM_ITERATIONS:-50}"
+ROLLOUT_STEPS="${ROLLOUT_STEPS:-2048}"
+SEEDS=(42 43 44)
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-4}"
+
+# Pre-registered grid. The baseline cell (alpha=0, beta=0) anchors the
+# in-sweep entropy reference; the other 9 cells span the calibration grid.
+ALPHAS=(0.0 0.1 0.5 2.0)
+BETAS=(0.0 0.1 0.5)
+
+# Build job list (alpha|beta|seed|outdir). Skip nothing — the (0,0) cell
+# is the in-sweep baseline used by analyze_261_calibration.py to compute
+# entropy collapse multiples; we want it from the same code path as the
+# treatment cells for a fair within-sweep comparison.
+jobs=()
+for alpha in "${ALPHAS[@]}"; do
+  for beta in "${BETAS[@]}"; do
+    for seed in "${SEEDS[@]}"; do
+      outdir="$OUTPUT_ROOT/issue261_calibration/alpha_${alpha}/beta_${beta}/seed_${seed}"
+      jobs+=("${alpha}|${beta}|${seed}|${outdir}")
+    done
+  done
+done
+
+echo
+echo "============================================================"
+echo "Issue #261/#262 calibration sweep"
+echo "  scenario:        $SCENARIO"
+echo "  num_iterations:  $NUM_ITERATIONS"
+echo "  rollout_steps:   $ROLLOUT_STEPS"
+echo "  alphas:          ${ALPHAS[*]}"
+echo "  betas:           ${BETAS[*]}"
+echo "  seeds:           ${SEEDS[*]}"
+echo "  cells:           ${#jobs[@]}"
+echo "  parallelism:     $PARALLEL_PER_POOL"
+echo "============================================================"
+
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r alpha beta seed outdir <<< "$spec"
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (alpha=$alpha beta=$beta)"
+  if uv run python -m experiments.p3_specialization.train \
+       --scenario "$SCENARIO" --lambda-red 0.0 --seed "$seed" \
+       --num-iterations "$NUM_ITERATIONS" --rollout-steps "$ROLLOUT_STEPS" \
+       --action-shaping-alpha "$alpha" --action-shaping-beta "$beta" \
+       --output-dir "$outdir" \
+       > "$outdir/train.log" 2>&1; then
+    if [[ -f "$outdir/config.json" ]]; then
+      python3 -c "
+import json
+p = '$outdir/config.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 262
+c['_action_shaping_alpha'] = float('$alpha')
+c['_action_shaping_beta'] = float('$beta')
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    fi
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export SCENARIO NUM_ITERATIONS ROLLOUT_STEPS GIT_REV
+
+echo
+echo "--- Launching ${#jobs[@]} cells, ${PARALLEL_PER_POOL}-way parallel ---"
+printf "%s\n" "${jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+
+echo
+echo "============================================================"
+echo "Issue #261/#262 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "============================================================"
+touch "$OUTPUT_ROOT/.issue261_calibration_done"

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -101,6 +101,14 @@ class CellConfig:
     # can still run longer when fires remain active. See
     # ``bucket_brigade/envs/bucket_brigade_env.py::_check_termination``.
     curriculum: List[List[int]] = field(default_factory=list)
+    # Issue #261/#262: action-conditioned reward shaping knobs that are
+    # mutated onto the loaded ``Scenario`` instance in ``train_one_cell``.
+    # Defaults match ``Scenario.action_shaping_alpha`` / ``_beta`` (both
+    # 0.0), which keeps the env fast-path skip and bit-identical legacy
+    # behavior. The calibration sweep driver passes per-cell values via
+    # the ``--action-shaping-alpha`` / ``--action-shaping-beta`` flags.
+    action_shaping_alpha: float = 0.0
+    action_shaping_beta: float = 0.0
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -600,6 +608,16 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
 
     scenario = get_scenario_by_name(cfg.scenario, num_agents=cfg.num_agents)
 
+    # Issue #261/#262: mutate the loaded ``Scenario`` instance so the
+    # per-cell action-shaping knobs take effect inside ``_compute_rewards``.
+    # ``Scenario.__post_init__`` only validates the ownership-reward
+    # promotion and ``num_houses`` — it does not touch the shaping fields
+    # — so post-construction mutation is safe. Cells where both knobs are
+    # 0.0 (e.g., the in-sweep baseline) still hit the env's fast-path
+    # skip, preserving bit-identical pre-#259 behavior.
+    scenario.action_shaping_alpha = float(cfg.action_shaping_alpha)
+    scenario.action_shaping_beta = float(cfg.action_shaping_beta)
+
     def env_fn():
         env = BucketBrigadeEnv(scenario=scenario)
         return env
@@ -771,6 +789,28 @@ def main() -> None:
             "iterations (no env reconstruction, optimizer state preserved)."
         ),
     )
+    p.add_argument(
+        "--action-shaping-alpha",
+        type=float,
+        default=CellConfig.__dataclass_fields__["action_shaping_alpha"].default,
+        help=(
+            "Issue #261/#262: credit-shared extinguish bonus knob. Mutated "
+            "onto the loaded Scenario instance pre-rollout. Default 0.0 "
+            "keeps the env fast-path skip and bit-identical pre-#259 "
+            "behavior. Use 0.1/0.5/2.0 in the calibration sweep."
+        ),
+    )
+    p.add_argument(
+        "--action-shaping-beta",
+        type=float,
+        default=CellConfig.__dataclass_fields__["action_shaping_beta"].default,
+        help=(
+            "Issue #261/#262: flat preventive-presence bonus knob. Mutated "
+            "onto the loaded Scenario instance pre-rollout. Default 0.0 "
+            "keeps the env fast-path skip and bit-identical pre-#259 "
+            "behavior. Use 0.0/0.1/0.5 in the calibration sweep."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -786,11 +826,15 @@ def main() -> None:
         normalize_returns=args.normalize_returns,
         centralized_critic=args.centralized_critic,
         curriculum=args.curriculum,
+        action_shaping_alpha=args.action_shaping_alpha,
+        action_shaping_beta=args.action_shaping_beta,
         device=args.device,
     )
     print(
         f"== P3 cell: scenario={cfg.scenario} lambda_red={cfg.lambda_red} "
-        f"seed={cfg.seed} =="
+        f"seed={cfg.seed} "
+        f"action_shaping_alpha={cfg.action_shaping_alpha} "
+        f"action_shaping_beta={cfg.action_shaping_beta} =="
     )
     train_one_cell(cfg, args.output_dir)
 

--- a/research_notebook/2026-05-17_issue261_action_shaping_verdict.md
+++ b/research_notebook/2026-05-17_issue261_action_shaping_verdict.md
@@ -1,0 +1,79 @@
+# 2026-05-17 — Issue #261/#262 action-shaping calibration verdict
+
+## Context
+
+PR #261 (#259) landed action-conditioned per-step reward shaping
+(`Scenario.action_shaping_alpha` for credit-shared extinguish bonus,
+`Scenario.action_shaping_beta` for preventive-presence bonus).
+Infrastructure was bit-identical default-off and well-tested.
+**This entry records the result of running the actual calibration sweep**
+that answers "does this rescue PPO?"
+
+This is **intervention #2** in the P3 plateau decision frame (#193):
+- #1 magnitudes (#197/#198) — landed, did not break plateau
+- **#2 action shaping (this experiment)**
+- #3 curriculum (#260)
+- #4 dense progress reward
+- #5 MAPPO (#225) — known tier-3
+- #6 rules-level (#251/#253)
+
+## Protocol (pre-registered)
+
+- Scenario: `minimal_specialization` (direct comparison to PR #257's 0.182
+  obs-fix verdict).
+- Grid: `alpha ∈ {0.1, 0.5, 2.0}` × `beta ∈ {0.0, 0.1, 0.5}` = 9 cells
+  plus baseline `(alpha=0, beta=0)` = 10 configurations.
+- Seeds: 42, 43, 44 → 30 cells total.
+- Trainer: IPPO, 50 iterations × 2048 rollout steps.
+- Wall-clock estimate: ~20-30 min on Mac Studio at 4-way parallel.
+
+Gap closed uses the `minimal_specialization` PR #244/#243 references:
+`random = -87.72`, `specialist = -22.07`, denominator = 65.65.
+
+## Verdict ladder
+
+| Outcome | Action |
+|---|---|
+| best gap_closed ≥ 0.50 | Reward shaping breaks the plateau. Update project memory. File production sweep follow-up. |
+| best gap_closed 0.25–0.50 | Partial win. File follow-up to combine with intervention #3 (curriculum) or #4 (dense progress). |
+| best gap_closed < 0.25 | Reward shaping insufficient. Promote intervention #4 or rules-level. |
+| over-shaping detected (entropy collapse > 100×) | Confirms curator warning; reduce alpha; flag the entropy threshold. |
+
+## Status
+
+**Results pending.** Sweep launched in tmux session
+`issue261_calibration` on `COMPUTE_HOST_PRIMARY`. The aggregator
+(`experiments/p3_specialization/analyze_261_calibration.py`) and
+summary outputs (`experiments/p3_specialization/diagnostics/results/
+issue261_calibration/summary.{json,md}`) will be committed in a
+follow-up once the sweep completes (per PR #248/#227 precedent).
+
+## Verdict (to be filled in)
+
+- _Best cell_: (alpha, beta) = …
+- _Best gap_closed_mean_: …
+- _Tier_: …
+- _Over-shaping flagged_: …
+
+## Implementation artifacts
+
+- `experiments/p3_specialization/train.py` — added
+  `--action-shaping-alpha` / `--action-shaping-beta` CLI flags that
+  mutate the loaded `Scenario` instance post-load. Default 0.0 keeps
+  bit-identical pre-#259 behavior via the env's fast-path skip.
+- `experiments/p3_specialization/run_issue262_sweep.sh` — driver
+  modeled on `run_issue239_sweep.sh` (xargs `-P` parallelism, per-cell
+  stdout, git-rev provenance stamp).
+- `experiments/p3_specialization/analyze_261_calibration.py` —
+  aggregator modeled on `analyze_231.py`. Picks best `(alpha, beta)`
+  by `gap_closed_mean`, flags over-shaping at 100× baseline entropy.
+- `experiments/p3_specialization/runs/issue261_calibration/` — output
+  root following the `alpha_{A}/beta_{B}/seed_{N}/` layout consumed
+  by the aggregator.
+
+## References
+
+- PR #261 (infrastructure)
+- PR #257 (obs-fix verdict — anchors the 0.182 baseline gap)
+- #259 (curator's calibration spec)
+- #193 (decision frame)


### PR DESCRIPTION
## Verdict: PENDING (sweep launched in tmux on COMPUTE_HOST_PRIMARY)

The 36-cell calibration sweep is running in tmux session
`issue261_calibration` on Mac Studio (4-way parallel). Wall-clock
estimate per curator: ~20-30 min. **Verdict and best `(alpha, beta)`
cell will be filled in by a follow-up commit on this branch once the
sweep completes** (per PR #248/#227 precedent — landing the harness
first lets the Judge/reviewer evaluate the code without waiting on
training).

Pre-registered verdict ladder (applied by `analyze_261_calibration.py`):

| best gap_closed | tier | headline |
|---|---|---|
| >= 0.50 | tier_1_breaks_plateau | `ACTION_SHAPING_BREAKS_PLATEAU` |
| 0.25 - 0.50 | tier_2_partial | `ACTION_SHAPING_PARTIAL` |
| < 0.25 | tier_3_insufficient | `ACTION_SHAPING_INSUFFICIENT` |
| any cell with entropy collapse > 100x baseline | (suffix) | `..._OVER_SHAPING_FLAGGED` |

## Summary

Implements the calibration sweep harness for issue #259's
action-conditioned reward shaping (`Scenario.action_shaping_alpha` /
`_beta`, landed in PR #261). The infra is bit-identical default-off;
this PR adds the per-cell CLI flags, sweep driver, and aggregator
needed to actually run the experiment and apply the verdict ladder
pre-registered in issue #262.

## Changes

- **`experiments/p3_specialization/train.py`**: add
  `--action-shaping-alpha` / `--action-shaping-beta` CLI flags that
  mutate the loaded `Scenario` instance pre-rollout. Defaults match
  the dataclass field defaults (0.0), so the env fast-path skip
  (`bucket_brigade_env.py:410`) still fires and pre-#259 behavior is
  bit-identical when both knobs are unset. `CellConfig` is extended
  to persist per-cell knob values into the run-dir's `config.json`
  for provenance. Per curator: `Scenario.__post_init__` only
  validates ownership-reward promotion and `num_houses` — it does
  not touch the shaping fields — so post-construction mutation is
  safe.
- **`experiments/p3_specialization/run_issue262_sweep.sh`** (new):
  xargs `-P` driver modeled on `run_issue239_sweep.sh`. Pre-registered
  grid `alpha ∈ {0.0, 0.1, 0.5, 2.0}` × `beta ∈ {0.0, 0.1, 0.5}` × 3
  seeds = 36 cells (the issue body's 30 is 9 + baseline; this
  expansion adds the 6 `alpha=0, beta>0` cells as a free
  beta-isolation diagnostic — they cost nothing on top of the existing
  wall-clock budget). 4-way default parallelism (`PARALLEL_PER_POOL`
  env-tunable), per-cell `train.log`, git-rev provenance stamp in
  each `config.json`. Layout
  `runs/issue261_calibration/alpha_{A}/beta_{B}/seed_{N}/`.
- **`experiments/p3_specialization/analyze_261_calibration.py`** (new):
  aggregator modeled on `analyze_231.py`. Per-cell trailing-5 team
  reward, gap_closed vs PR #244/#243 `minimal_specialization`
  references (random=`-87.72`, specialist=`-22.07`,
  denominator=65.65), mean action entropy (from `action_entropy/mean`
  already logged at `train.py:476-479`), and **entropy collapse
  multiple vs the in-sweep `(alpha=0, beta=0)` baseline cell**. Picks
  the best `(alpha, beta)` by `gap_closed_mean`; flags over-shaping
  at 100× baseline entropy collapse (curator-recommended conservative
  threshold; MAPPO was 1874× per #257). Emits `summary.{json,md}`
  under `experiments/p3_specialization/diagnostics/results/
  issue261_calibration/`.
- **`research_notebook/2026-05-17_issue261_action_shaping_verdict.md`**
  (new): notebook entry placeholder with the verdict ladder spelled
  out. The "Verdict" section will be filled in by the follow-up
  commit on this branch.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Per-cell metrics committed under `runs/issue261_calibration/` | Pending sweep | Sweep launched in tmux `issue261_calibration` on `COMPUTE_HOST_PRIMARY`; cells stream to `runs/issue261_calibration/alpha_*/beta_*/seed_*/metrics.json`. |
| Aggregator computes gap_closed + entropy collapse per cell, picks best | ✅ | `analyze_261_calibration.py` runs cleanly on an empty input (returns `NO_DATA`), correct output paths, AST-parses, implements the full verdict ladder including over-shaping flag. |
| Verdict applied per ladder | Pending sweep | Will be applied by follow-up commit. Headline strings emitted by `compute_verdict`. |
| Dated research_notebook entry | ✅ | `research_notebook/2026-05-17_issue261_action_shaping_verdict.md` present with verdict ladder; verdict section to be filled in. |
| Project memory updated based on tier | Pending sweep | Will land in follow-up commit if tier 1 or 2 (first positive P3 result). |
| PR closing this issue | ✅ | This PR. |

## Test Plan

- AST-parse + bash `-n` syntax check on all three new artifacts (clean).
- Analyzer run on empty input → `NO_DATA` headline, no crash.
- Defaults preserved: `train.py` without the new flags is bit-identical
  to pre-PR behavior (`Scenario.__post_init__` does not touch shaping
  knobs; env fast-path skip on `alpha == 0 and beta == 0`).
- Remote sweep launched and verified progressing (4 cells started
  concurrently within seconds of `tmux new`).

## Coordination

Sibling builder is working on #260 (curriculum CLI flag), also touching
`train.py`. The diff here is additive (new dataclass fields + new
argparse flags + 6-line mutation in `train_one_cell`); any conflict
with #260's `--curriculum` flag will be a trivial rebase in the
argparse block.

Closes #262