### PR TITLE
exp(p3): action-shaping TIER 3 INSUFFICIENT (#262 verdict, best gap=0.164)

### DIFF
--- a/experiments/p3_specialization/analyze_261_calibration.py
+++ b/experiments/p3_specialization/analyze_261_calibration.py
@@ -68,12 +68,18 @@ OVER_SHAPING_ENTROPY_MULTIPLE = 100.0
 
 
 def _fmt_alpha(alpha: float) -> str:
-    """Match the run-dir naming used by ``run_issue262_sweep.sh``."""
-    return f"{alpha:g}"
+    """Match the run-dir naming used by ``run_issue262_sweep.sh``.
+
+    The sweep script writes literal bash strings ``0.0``, ``0.1``, ``0.5``,
+    ``2.0`` into the path, so we must preserve the trailing ``.0``. Using
+    ``:g`` drops it (``0.0`` → ``0``, ``2.0`` → ``2``), which breaks
+    aggregation of the baseline (alpha=0) and large-alpha (alpha=2) cells.
+    """
+    return f"{alpha:.1f}"
 
 
 def _fmt_beta(beta: float) -> str:
-    return f"{beta:g}"
+    return f"{beta:.1f}"
 
 
 def _cell_dir(root: Path, alpha: float, beta: float, seed: int) -> Path:

--- a/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.json
+++ b/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.json
@@ -1,0 +1,545 @@
+{
+  "cells": [
+    {
+      "alpha": 0.0,
+      "beta": 0.0,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.0/seed_42",
+          "trailing5_team_reward": -74.866015625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 1.1065943054996277,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.0/seed_43",
+          "trailing5_team_reward": -79.40693359375,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.8693445398013607,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.0/seed_44",
+          "trailing5_team_reward": -86.67060546875,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.769735602882343,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -80.31451822916667,
+      "team_reward_std": 5.95439902489115,
+      "team_reward_per_seed": [
+        -74.866015625,
+        -79.40693359375,
+        -86.67060546875
+      ],
+      "mean_entropy_final_mean": 0.9152248160611105,
+      "gap_closed_mean": 0.11280246414064482,
+      "gap_closed_per_seed": [
+        0.19579564927646603,
+        0.12662705873952781,
+        0.015984684405940617
+      ],
+      "entropy_collapse_multiple": 1.0
+    },
+    {
+      "alpha": 0.0,
+      "beta": 0.1,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.1/seed_42",
+          "trailing5_team_reward": -76.42732391357421,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.43841958086486227,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.1/seed_43",
+          "trailing5_team_reward": -77.54248962402343,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.7896652482449467,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.1/seed_44",
+          "trailing5_team_reward": -86.86358184814453,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.632465853025232,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -80.27779846191406,
+      "team_reward_std": 5.730646189410269,
+      "team_reward_per_seed": [
+        -76.42732391357421,
+        -77.54248962402343,
+        -86.86358184814453
+      ],
+      "mean_entropy_final_mean": 0.6201835607116802,
+      "gap_closed_mean": 0.11336179037450021,
+      "gap_closed_per_seed": [
+        0.1720133448046578,
+        0.15502681456171463,
+        0.013045211757128175
+      ],
+      "entropy_collapse_multiple": 1.4757321445458198
+    },
+    {
+      "alpha": 0.0,
+      "beta": 0.5,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.5/seed_42",
+          "trailing5_team_reward": -73.5494140625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5199763082559827,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.5/seed_43",
+          "trailing5_team_reward": -76.92470703125,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.3700499544898985,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.0/beta_0.5/seed_44",
+          "trailing5_team_reward": -83.463037109375,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.6010290852652235,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -77.979052734375,
+      "team_reward_std": 5.040209730274758,
+      "team_reward_per_seed": [
+        -73.5494140625,
+        -76.92470703125,
+        -83.463037109375
+      ],
+      "mean_entropy_final_mean": 0.4970184493370349,
+      "gap_closed_mean": 0.1483769575875856,
+      "gap_closed_per_seed": [
+        0.215850509329779,
+        0.16443705969154612,
+        0.06484330374143189
+      ],
+      "entropy_collapse_multiple": 1.8414302673913103
+    },
+    {
+      "alpha": 0.1,
+      "beta": 0.0,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.0/seed_42",
+          "trailing5_team_reward": -76.58468933105469,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.7422268502793558,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.0/seed_43",
+          "trailing5_team_reward": -72.1117950439453,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.6474673203632565,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.0/seed_44",
+          "trailing5_team_reward": -82.23033142089844,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.865719479088697,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -76.97560526529948,
+      "team_reward_std": 5.070582417599166,
+      "team_reward_per_seed": [
+        -76.58468933105469,
+        -72.1117950439453,
+        -82.23033142089844
+      ],
+      "mean_entropy_final_mean": 0.7518045499104363,
+      "gap_closed_mean": 0.16366176290480608,
+      "gap_closed_per_seed": [
+        0.16961630874250277,
+        0.23774874266648424,
+        0.08362023730543124
+      ],
+      "entropy_collapse_multiple": 1.2173706798796877
+    },
+    {
+      "alpha": 0.1,
+      "beta": 0.1,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.1/seed_42",
+          "trailing5_team_reward": -74.25939178466797,
+          "final_iter": 49,
+          "mean_action_entropy_final": 1.1187843421579247,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.1/seed_43",
+          "trailing5_team_reward": -78.84423828125,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.4241953604184282,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.1/seed_44",
+          "trailing5_team_reward": -92.38620147705078,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.14704310868815773,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -81.82994384765625,
+      "team_reward_std": 9.425027092954043,
+      "team_reward_per_seed": [
+        -74.25939178466797,
+        -78.84423828125,
+        -92.38620147705078
+      ],
+      "mean_entropy_final_mean": 0.5633409370881702,
+      "gap_closed_mean": 0.08971905791841196,
+      "gap_closed_per_seed": [
+        0.20503592102562115,
+        0.13519819830540744,
+        -0.07107694557579249
+      ],
+      "entropy_collapse_multiple": 1.624637507779531
+    },
+    {
+      "alpha": 0.1,
+      "beta": 0.5,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.5/seed_42",
+          "trailing5_team_reward": -78.69723510742188,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.6419300192482104,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.5/seed_43",
+          "trailing5_team_reward": -77.24384460449218,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.24290114212765188,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.1/beta_0.5/seed_44",
+          "trailing5_team_reward": -83.97728576660157,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5918550548160361,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -79.97278849283855,
+      "team_reward_std": 3.543315509545148,
+      "team_reward_per_seed": [
+        -78.69723510742188,
+        -77.24384460449218,
+        -83.97728576660157
+      ],
+      "mean_entropy_final_mean": 0.4922287387306328,
+      "gap_closed_mean": 0.11800779142667862,
+      "gap_closed_per_seed": [
+        0.1374373936417079,
+        0.1595758628409416,
+        0.0570101177973866
+      ],
+      "entropy_collapse_multiple": 1.859348599639482
+    },
+    {
+      "alpha": 0.5,
+      "beta": 0.0,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.0/seed_42",
+          "trailing5_team_reward": -74.3765625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5887307008573569,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.0/seed_43",
+          "trailing5_team_reward": -79.11298828125,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5225814082730916,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.0/seed_44",
+          "trailing5_team_reward": -87.42744140625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5376899586640242,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -80.3056640625,
+      "team_reward_std": 6.606679702829967,
+      "team_reward_per_seed": [
+        -74.3765625,
+        -79.11298828125,
+        -87.42744140625
+      ],
+      "mean_entropy_final_mean": 0.549667355931491,
+      "gap_closed_mean": 0.11293733339680119,
+      "gap_closed_per_seed": [
+        0.20325114242193437,
+        0.1311045197067784,
+        0.00445633806169081
+      ],
+      "entropy_collapse_multiple": 1.665052155971914
+    },
+    {
+      "alpha": 0.5,
+      "beta": 0.1,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.1/seed_42",
+          "trailing5_team_reward": -73.8551025390625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5544220686577789,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.1/seed_43",
+          "trailing5_team_reward": -76.30135650634766,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.6098260103876614,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.1/seed_44",
+          "trailing5_team_reward": -91.18952178955078,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.32358740085746956,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -80.4486602783203,
+      "team_reward_std": 9.381930458103419,
+      "team_reward_per_seed": [
+        -73.8551025390625,
+        -76.30135650634766,
+        -91.18952178955078
+      ],
+      "mean_entropy_final_mean": 0.49594515996763655,
+      "gap_closed_mean": 0.11075917321675087,
+      "gap_closed_per_seed": [
+        0.21119417305312257,
+        0.1739321171919625,
+        -0.052848770594832936
+      ],
+      "entropy_collapse_multiple": 1.8454153602806296
+    },
+    {
+      "alpha": 0.5,
+      "beta": 0.5,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.5/seed_42",
+          "trailing5_team_reward": -74.262548828125,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.3918061181826785,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.5/seed_43",
+          "trailing5_team_reward": -75.888525390625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.37245909622201234,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_0.5/beta_0.5/seed_44",
+          "trailing5_team_reward": -82.91201171875,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.8904640785309756,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -77.6876953125,
+      "team_reward_std": 4.5968534216254335,
+      "team_reward_per_seed": [
+        -74.262548828125,
+        -75.888525390625,
+        -82.91201171875
+      ],
+      "mean_entropy_final_mean": 0.5515764309785555,
+      "gap_closed_mean": 0.15281499904798174,
+      "gap_closed_per_seed": [
+        0.2049878320163746,
+        0.18022048148324435,
+        0.07323668364432603
+      ],
+      "entropy_collapse_multiple": 1.6592892021100394
+    },
+    {
+      "alpha": 2.0,
+      "beta": 0.0,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.0/seed_42",
+          "trailing5_team_reward": -73.69482421875,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.3077995493944097,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.0/seed_43",
+          "trailing5_team_reward": -77.038671875,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.2561583560314964,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.0/seed_44",
+          "trailing5_team_reward": -87.38515625,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.2468863380009475,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -79.37288411458333,
+      "team_reward_std": 7.137416049666213,
+      "team_reward_per_seed": [
+        -73.69482421875,
+        -77.038671875,
+        -87.38515625
+      ],
+      "mean_entropy_final_mean": 0.2702814144756179,
+      "gap_closed_mean": 0.1271457103643057,
+      "gap_closed_per_seed": [
+        0.21363557930312257,
+        0.16270111386138603,
+        0.005100437928408294
+      ],
+      "entropy_collapse_multiple": 3.3861921946678026
+    },
+    {
+      "alpha": 2.0,
+      "beta": 0.1,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.1/seed_42",
+          "trailing5_team_reward": -78.37764434814453,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.9468240761961135,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.1/seed_43",
+          "trailing5_team_reward": -74.5107307434082,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.6082023871285994,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.1/seed_44",
+          "trailing5_team_reward": -89.56576995849609,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.8224269113458902,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -80.81804835001628,
+      "team_reward_std": 7.818582365827085,
+      "team_reward_per_seed": [
+        -78.37764434814453,
+        -74.5107307434082,
+        -89.56576995849609
+      ],
+      "mean_entropy_final_mean": 0.7924844582235343,
+      "gap_closed_mean": 0.10513254607743663,
+      "gap_closed_per_seed": [
+        0.14230549355453875,
+        0.2012074524994942,
+        -0.028115307821722647
+      ],
+      "entropy_collapse_multiple": 1.1548804605111322
+    },
+    {
+      "alpha": 2.0,
+      "beta": 0.5,
+      "seeds": [
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.5/seed_42",
+          "trailing5_team_reward": -74.50224609375,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.7577202960630647,
+          "seed": 42
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.5/seed_43",
+          "trailing5_team_reward": -79.401708984375,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.14037778394057818,
+          "seed": 43
+        },
+        {
+          "cell": "experiments/p3_specialization/runs/issue261_calibration/alpha_2.0/beta_0.5/seed_44",
+          "trailing5_team_reward": -81.549658203125,
+          "final_iter": 49,
+          "mean_action_entropy_final": 0.5980089382988052,
+          "seed": 44
+        }
+      ],
+      "n_seeds": 3,
+      "team_reward_mean": -78.48453776041667,
+      "team_reward_std": 3.6121194125311358,
+      "team_reward_per_seed": [
+        -74.50224609375,
+        -79.401708984375,
+        -81.549658203125
+      ],
+      "mean_entropy_final_mean": 0.4987023394341494,
+      "gap_closed_mean": 0.1406772618367605,
+      "gap_closed_per_seed": [
+        0.20133669316450867,
+        0.126706641517517,
+        0.09398845082825578
+      ],
+      "entropy_collapse_multiple": 1.8352125981593883
+    }
+  ],
+  "verdict": {
+    "best_cell": {
+      "alpha": 0.1,
+      "beta": 0.0,
+      "gap_closed_mean": 0.16366176290480608,
+      "team_reward_mean": -76.97560526529948,
+      "mean_entropy_final_mean": 0.7518045499104363,
+      "entropy_collapse_multiple": 1.2173706798796877,
+      "n_seeds": 3
+    },
+    "tier": "tier_3_insufficient",
+    "headline": "ACTION_SHAPING_INSUFFICIENT",
+    "baseline_entropy": 0.9152248160611105,
+    "over_shaping_flagged": []
+  },
+  "baselines": {
+    "random": -87.72,
+    "specialist": -22.07,
+    "denominator": 65.65
+  },
+  "thresholds": {
+    "tier_1": 0.5,
+    "tier_2": 0.25,
+    "over_shaping_entropy_multiple": 100.0
+  }
+}

--- a/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.md
@@ -1,0 +1,36 @@
+# Issue #261/#262 — Action-shaping calibration sweep
+
+Scenario: ``minimal_specialization``  
+References (per-step mean team reward): random=-87.72, specialist=-22.07 (denominator=+65.65).
+
+## Per-cell results
+
+| alpha | beta | n | team_reward (mean±std) | gap_closed_mean | mean_action_entropy_final | entropy_collapse_x |
+|---|---|---|---|---|---|---|
+| 0.0 | 0.0 | 3 | -80.31 ± 5.95 | +0.113 | 0.915 | 1.0 |
+| 0.0 | 0.1 | 3 | -80.28 ± 5.73 | +0.113 | 0.620 | 1.5 |
+| 0.0 | 0.5 | 3 | -77.98 ± 5.04 | +0.148 | 0.497 | 1.8 |
+| 0.1 | 0.0 | 3 | -76.98 ± 5.07 | +0.164 | 0.752 | 1.2 |
+| 0.1 | 0.1 | 3 | -81.83 ± 9.43 | +0.090 | 0.563 | 1.6 |
+| 0.1 | 0.5 | 3 | -79.97 ± 3.54 | +0.118 | 0.492 | 1.9 |
+| 0.5 | 0.0 | 3 | -80.31 ± 6.61 | +0.113 | 0.550 | 1.7 |
+| 0.5 | 0.1 | 3 | -80.45 ± 9.38 | +0.111 | 0.496 | 1.8 |
+| 0.5 | 0.5 | 3 | -77.69 ± 4.60 | +0.153 | 0.552 | 1.7 |
+| 2.0 | 0.0 | 3 | -79.37 ± 7.14 | +0.127 | 0.270 | 3.4 |
+| 2.0 | 0.1 | 3 | -80.82 ± 7.82 | +0.105 | 0.792 | 1.2 |
+| 2.0 | 0.5 | 3 | -78.48 ± 3.61 | +0.141 | 0.499 | 1.8 |
+
+## Verdict
+
+**Headline**: ``ACTION_SHAPING_INSUFFICIENT``
+**Tier**: ``tier_3_insufficient``
+
+Best cell:
+- alpha = ``0.1``, beta = ``0.0``
+- gap_closed_mean = ``+0.164``
+- team_reward_mean = ``-76.976``
+- mean_action_entropy_final = ``0.752``
+- n_seeds = ``3``
+
+_No over-shaping flagged at the 100× threshold._
+

--- a/research_notebook/2026-05-17_issue261_action_shaping_verdict.md
+++ b/research_notebook/2026-05-17_issue261_action_shaping_verdict.md
@@ -41,19 +41,72 @@ Gap closed uses the `minimal_specialization` PR #244/#243 references:
 
 ## Status
 
-**Results pending.** Sweep launched in tmux session
-`issue261_calibration` on `COMPUTE_HOST_PRIMARY`. The aggregator
-(`experiments/p3_specialization/analyze_261_calibration.py`) and
-summary outputs (`experiments/p3_specialization/diagnostics/results/
-issue261_calibration/summary.{json,md}`) will be committed in a
-follow-up once the sweep completes (per PR #248/#227 precedent).
+**Sweep complete.** 36/36 cells finished on `COMPUTE_HOST_PRIMARY`
+overnight; results harvested locally and aggregated in this follow-up.
 
-## Verdict (to be filled in)
+Note: the analyzer committed in PR #263 used `f"{alpha:g}"` to rebuild
+the run-dir path, which silently drops the trailing `.0` and skipped 8
+of 12 cells (baseline and `alpha=2.0` rows came back as "missing").
+Fixed to `f"{alpha:.1f}"` in this PR so all 12 cells aggregate.
 
-- _Best cell_: (alpha, beta) = …
-- _Best gap_closed_mean_: …
-- _Tier_: …
-- _Over-shaping flagged_: …
+## Verdict
+
+- **Best cell**: `(alpha, beta) = (0.1, 0.0)`
+- **Best gap_closed_mean**: **`+0.164`** (mean over 3 seeds)
+- **Tier**: **`tier_3_insufficient`** — best cell is well below the
+  pre-registered `0.25` tier-2 boundary.
+- **Over-shaping flagged**: No. Max entropy collapse multiple was
+  `3.4×` at `(alpha=2.0, beta=0.0)`; well under the conservative `100×`
+  threshold. Action shaping at the swept magnitudes does **not**
+  collapse the policy.
+
+### Per-cell numbers
+
+All 12 `(alpha, beta)` cells × 3 seeds (n_seeds=3 everywhere):
+
+| alpha | beta | team_reward (mean ± std) | gap_closed_mean | entropy | collapse_x |
+|---|---|---|---|---|---|
+| 0.0 | 0.0 | -80.31 ± 5.95 | +0.113 | 0.915 | 1.0 |
+| 0.0 | 0.1 | -80.28 ± 5.73 | +0.113 | 0.620 | 1.5 |
+| 0.0 | 0.5 | -77.98 ± 5.04 | +0.148 | 0.497 | 1.8 |
+| 0.1 | 0.0 | -76.98 ± 5.07 | **+0.164** | 0.752 | 1.2 |
+| 0.1 | 0.1 | -81.83 ± 9.43 | +0.090 | 0.563 | 1.6 |
+| 0.1 | 0.5 | -79.97 ± 3.54 | +0.118 | 0.492 | 1.9 |
+| 0.5 | 0.0 | -80.31 ± 6.61 | +0.113 | 0.550 | 1.7 |
+| 0.5 | 0.1 | -80.45 ± 9.38 | +0.111 | 0.496 | 1.8 |
+| 0.5 | 0.5 | -77.69 ± 4.60 | +0.153 | 0.552 | 1.7 |
+| 2.0 | 0.0 | -79.37 ± 7.14 | +0.127 | 0.270 | 3.4 |
+| 2.0 | 0.1 | -80.82 ± 7.82 | +0.105 | 0.792 | 1.2 |
+| 2.0 | 0.5 | -78.48 ± 3.61 | +0.141 | 0.499 | 1.8 |
+
+Gap-closed range across cells: `[+0.090, +0.164]`. The grid is essentially
+flat — action shaping moves the trailing-5 team reward by ~3 reward
+units (out of a 65.65 random→specialist span), regardless of magnitude.
+
+### Interpretation
+
+1. **Baseline anchor**: `(α=0, β=0)` lands at gap_closed `+0.113`, near
+   (slightly under) the PR #257 IPPO obs-fix verdict of `~0.182`. Same
+   plateau, no surprise.
+2. **No interior peak**: Increasing α (credit-shared extinguish bonus)
+   or β (preventive-presence bonus) does not produce a monotonic or
+   even directional improvement. The best cell (`α=0.1, β=0`) beats
+   the baseline by only `+0.051`, well within seed noise (std ≈ 5–9).
+3. **No over-shaping**: Even `α=2.0` produces only a 3.4× entropy
+   collapse — orders of magnitude below MAPPO's 1874× signature.
+   Action shaping is not "too strong"; it is **not strong enough to
+   matter**.
+4. **Plateau is robust to per-step shaping**: This is the **4th of
+   5 interventions** to fail to break the plateau on
+   `minimal_specialization` (after #197 magnitudes, #198 per-agent
+   ownership-reward vectors, #225 MAPPO, and #236 signal-channel
+   work that motivated the post-#236 re-derivation).
+
+### Next steps per the verdict ladder
+
+Tier-3 outcome promotes **intervention #4 (dense progress reward)** or
+rules-level interventions (#251/#253) per the #193 decision frame.
+Action shaping is **not** the lever that breaks the IPPO plateau.
 
 ## Implementation artifacts
 


### PR DESCRIPTION
## Headline

**Tier**: ``tier_3_insufficient`` — action-shaping does NOT break the IPPO plateau.

**Best cell**: ``(alpha=0.1, beta=0.0)`` → ``gap_closed_mean = +0.164`` (well below 0.25 tier-2 boundary).

**Over-shaping**: None flagged. Max entropy collapse ``3.4×`` at ``(alpha=2.0, beta=0.0)`` — orders of magnitude under MAPPO's known 1874× and conservative 100× threshold.

## Summary

Harvests the 36-cell action-shaping calibration sweep launched on `$COMPUTE_HOST_PRIMARY` overnight (issue #262), aggregates per-cell metrics, applies the pre-registered verdict ladder, and updates the research notebook + project memory. **No new training.**

## Changes

- **`experiments/p3_specialization/analyze_261_calibration.py`**: fix run-dir formatter from ``f"{x:g}"`` to ``f"{x:.1f}"``. The ``:g`` spec silently drops trailing ``.0`` (``0.0 → "0"``, ``2.0 → "2"``), so the original analyzer was missing 8/12 cells (baseline α=0 and large-α α=2 rows). Sweep harness writes literal ``"0.0"`` and ``"2.0"`` into path strings.
- **`experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.{md,json}`**: NEW — aggregator output from all 36 cells (12 cells × 3 seeds).
- **`research_notebook/2026-05-17_issue261_action_shaping_verdict.md`**: fill in verdict section with per-cell table, headline tier, and next-step recommendation.

## Verdict ladder application

| Outcome | Best cell | Action taken |
|---|---|---|
| Tier 1 (≥ 0.50) | — | n/a |
| Tier 2 (0.25–0.50) | — | n/a |
| **Tier 3 (< 0.25)** | **α=0.1, β=0.0 → 0.164** | **Selected**: action-shaping insufficient. Project memory updated. Next intervention: dense progress reward (#265) or rules-level (#251/#253). |
| Over-shaping (> 100× entropy collapse) | — | None flagged (max 3.4×) |

## Per-cell gap_closed (all n=3)

| α \\ β | 0.0 | 0.1 | 0.5 |
|---|---|---|---|
| 0.0 | +0.113 | +0.113 | +0.148 |
| 0.1 | **+0.164** | +0.090 | +0.118 |
| 0.5 | +0.113 | +0.111 | +0.153 |
| 2.0 | +0.127 | +0.105 | +0.141 |

Range: ``[+0.090, +0.164]``. The grid is flat — action-shaping moves the trailing-5 team reward by ~3 reward units (out of a 65.65 random→specialist span) regardless of the shaping magnitude. Baseline cell ``(0, 0)`` at 0.113 lands slightly under PR #257's IPPO obs-fix verdict of ~0.182 (within 3-seed noise; same plateau).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| All 36 cells complete | OK | 36/36 ``metrics.json`` present on remote, all rsynced locally |
| Per-cell metrics committed | OK | ``diagnostics/results/issue261_calibration/summary.{md,json}`` |
| Aggregator computes gap_closed + entropy collapse | OK | ``analyze_261_calibration.py`` runs, picks best, applies ladder |
| Verdict applied per ladder | OK | Tier 3 → memory updated, follow-up recommendation noted |
| Dated research_notebook entry | OK | ``research_notebook/2026-05-17_issue261_action_shaping_verdict.md`` |
| Project memory updated | OK | ``memory/project_ppo_failure_mode.md`` (4-of-5 interventions failed) |

## Test Plan

- Ran ``uv run python experiments/p3_specialization/analyze_261_calibration.py``; output matches the per-cell numbers in the notebook + summary.md.
- Spot-checked baseline cell ``metrics.json`` (n=50 iterations, ``mean_step_reward_team`` near -67 at final iter, trailing-5 mean -80.31).
- Spot-checked over-shaping cell ``(α=2.0, β=0.0)``: entropy 0.270 (vs baseline 0.915 → 3.4× collapse, well under 100× flag).
- AST parse of analyzer passes.

## Parent / references

- Parent issue: **#262** (the calibration sweep that produced this data)
- Sweep harness committed in PR #263 (merged)
- Pre-registered verdict ladder: issue body of #262
- Anchor: PR #257 obs-fix verdict (0.182 on minimal_specialization)
- Decision frame: #193

Closes #267