### PR TITLE
feat(p3): BC-init specialist + IPPO continuation (basin-trap probe) (#270)

### DIFF
--- a/experiments/p3_specialization/analyze_270.py
+++ b/experiments/p3_specialization/analyze_270.py
@@ -1,0 +1,222 @@
+"""Analysis for issue #270 — basin trap vs anti-attractor verdict.
+
+Compares per-iteration team rewards from:
+
+- **BC-init PPO continuation** (this issue): cells under
+  ``experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0/seed_{42,43,44}/``.
+- **Random-init IPPO baseline** (PR #257-ish equivalent): cells under
+  ``experiments/p3_specialization/runs/issue231/ippo/minimal_specialization/seed_{42,43,44}/``.
+
+Emits a markdown summary + JSON to
+``experiments/p3_specialization/diagnostics/results/issue270_bc_continuation/`` and
+applies the verdict matrix from the issue body:
+
+| BC-init PPO trajectory | Verdict |
+|---|---|
+| gap_closed > 0.5 throughout the 50 iters | basin trap (specialist stable) |
+| gap_closed decays back toward random (≤ 0.2 by iter 49) | anti-attractor |
+| gap_closed sits above baseline but below 0.5 | partial basin |
+
+Operationalized thresholds (see body of ``classify_verdict``):
+
+- ``basin_trap`` ⟺ trailing-5 gap_closed (mean over seeds) > 0.5 AND
+  min over iterations of mean gap_closed > 0.3 (i.e., no deep dip).
+- ``anti_attractor`` ⟺ trailing-5 gap_closed < 0.2 AND iter-0 gap_closed > 0.5
+  (BC took, then PPO erased it).
+- ``partial`` ⟺ anything in between.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# Hardcoded references (mirror analyze_220.py:59-60).
+MINSPEC_RANDOM = -96.07
+MINSPEC_SPECIALIST = -22.07
+TRAILING_N = 5
+
+
+def gap_closed(per_step_team: float) -> float:
+    return (per_step_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+def _load_metrics(path: Path) -> Optional[List[dict]]:
+    f = path / "metrics.json"
+    if not f.exists():
+        return None
+    return json.loads(f.read_text())
+
+
+def _trajectory(metrics: List[dict]) -> np.ndarray:
+    """Per-iteration mean_step_reward_team as a 1-D array."""
+    return np.asarray(
+        [row["mean_step_reward_team"] for row in metrics], dtype=np.float64
+    )
+
+
+def aggregate_arm(cells: List[Path], label: str) -> Dict:
+    seeds_data = []
+    trajectories = []
+    for cell in cells:
+        metrics = _load_metrics(cell)
+        if metrics is None:
+            seeds_data.append({"cell": str(cell), "missing": True})
+            continue
+        traj = _trajectory(metrics)
+        seeds_data.append(
+            {
+                "cell": str(cell),
+                "n_iters": int(traj.size),
+                "iter0_team": float(traj[0]),
+                "iter0_gap_closed": float(gap_closed(float(traj[0]))),
+                "trailing5_team": float(traj[-TRAILING_N:].mean()),
+                "trailing5_gap_closed": float(gap_closed(float(traj[-TRAILING_N:].mean()))),
+                "min_iter_team": float(traj.min()),
+            }
+        )
+        trajectories.append(traj)
+
+    if not trajectories:
+        return {"label": label, "seeds": seeds_data, "n_seeds": 0}
+    # Align by min length so heterogeneous seed runs don't crash the analysis.
+    min_len = min(t.size for t in trajectories)
+    stacked = np.stack([t[:min_len] for t in trajectories], axis=0)  # [S, T]
+    mean_traj_step = stacked.mean(axis=0)  # mean per-step team reward per iter
+    mean_traj_gc = (mean_traj_step - MINSPEC_RANDOM) / (
+        MINSPEC_SPECIALIST - MINSPEC_RANDOM
+    )
+
+    return {
+        "label": label,
+        "seeds": seeds_data,
+        "n_seeds": len(trajectories),
+        "n_iters": int(min_len),
+        "iter0_team_mean": float(mean_traj_step[0]),
+        "iter0_gap_closed_mean": float(mean_traj_gc[0]),
+        "trailing5_team_mean": float(mean_traj_step[-TRAILING_N:].mean()),
+        "trailing5_gap_closed_mean": float(mean_traj_gc[-TRAILING_N:].mean()),
+        "min_iter_gap_closed_mean": float(mean_traj_gc.min()),
+        "mean_traj_step_reward": mean_traj_step.tolist(),
+        "mean_traj_gap_closed": mean_traj_gc.tolist(),
+    }
+
+
+def classify_verdict(bc_arm: Dict) -> Tuple[str, str]:
+    """Apply the verdict matrix to the BC-init arm. Returns (label, reasoning)."""
+    if bc_arm.get("n_seeds", 0) == 0:
+        return "no_data", "BC-init arm has no completed seeds"
+    iter0_gc = bc_arm["iter0_gap_closed_mean"]
+    trail_gc = bc_arm["trailing5_gap_closed_mean"]
+    min_gc = bc_arm["min_iter_gap_closed_mean"]
+    if iter0_gc < 0.5:
+        return "bc_did_not_take", (
+            f"BC eval at iter 0 only closed {iter0_gc:.3f} of the gap "
+            "(< 0.5). The probe is uninterpretable — BC pre-training failed "
+            "to land in the specialist region. Re-run BC with more demos, "
+            "more epochs, or a larger hidden size, or characterize "
+            "architecture first (issue #272)."
+        )
+    if trail_gc > 0.5 and min_gc > 0.3:
+        return "basin_trap", (
+            f"trailing-5 gap_closed = {trail_gc:.3f} > 0.5 AND min over "
+            f"iters {min_gc:.3f} > 0.3. PPO holds the specialist region. "
+            "Specialist is stable under PPO updates and unreachable from "
+            "random init — implies path-finding intervention (PBT, "
+            "neuroevolution, BC-init as production technique)."
+        )
+    if trail_gc < 0.2 and iter0_gc > 0.5:
+        return "anti_attractor", (
+            f"trailing-5 gap_closed = {trail_gc:.3f} < 0.2 AND iter0 gap_closed = "
+            f"{iter0_gc:.3f} > 0.5. BC took but PPO actively erased it. "
+            "Something in the reward/dynamics repels specialist-like behavior — "
+            "examine reward gradient structure near specialist."
+        )
+    return "partial", (
+        f"trailing-5 gap_closed = {trail_gc:.3f} sits between 0.2 and 0.5 "
+        f"(or showed a dip: min={min_gc:.3f}). PPO partially holds "
+        "specialist; local minimum nearby. Hybrid intervention: BC-init + "
+        "mild reward shaping."
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--bc-runs-root",
+        type=Path,
+        default=Path("experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0"),
+        help="Root containing seed_{42,43,44} cells from the BC-init PPO continuation.",
+    )
+    p.add_argument(
+        "--baseline-runs-root",
+        type=Path,
+        default=Path("experiments/p3_specialization/runs/issue231/ippo/minimal_specialization"),
+        help="Root containing seed_{42,43,44} cells from the random-init IPPO baseline.",
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("experiments/p3_specialization/diagnostics/results/issue270_bc_continuation"),
+    )
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    bc_cells = [args.bc_runs_root / f"seed_{s}" for s in args.seeds]
+    baseline_cells = [args.baseline_runs_root / f"seed_{s}" for s in args.seeds]
+
+    bc_arm = aggregate_arm(bc_cells, "bc_init_ppo")
+    baseline_arm = aggregate_arm(baseline_cells, "random_init_ippo")
+
+    verdict, reasoning = classify_verdict(bc_arm)
+
+    out = {
+        "issue": 270,
+        "verdict": verdict,
+        "reasoning": reasoning,
+        "bc_init_arm": bc_arm,
+        "random_init_arm": baseline_arm,
+        "references": {
+            "minspec_random": MINSPEC_RANDOM,
+            "minspec_specialist": MINSPEC_SPECIALIST,
+            "trailing_n": TRAILING_N,
+        },
+    }
+    (args.output_dir / "analysis.json").write_text(json.dumps(out, indent=2))
+
+    md = [
+        "# Issue #270 — BC-init then PPO: basin trap vs anti-attractor verdict",
+        "",
+        f"**Verdict**: `{verdict}`",
+        "",
+        f"**Reasoning**: {reasoning}",
+        "",
+        "## BC-init PPO arm",
+        f"- n_seeds: {bc_arm.get('n_seeds', 0)}",
+        f"- iter 0 gap_closed (BC-only): {bc_arm.get('iter0_gap_closed_mean', float('nan')):.3f}",
+        f"- trailing-5 gap_closed (after PPO continuation): {bc_arm.get('trailing5_gap_closed_mean', float('nan')):.3f}",
+        f"- min over iters gap_closed: {bc_arm.get('min_iter_gap_closed_mean', float('nan')):.3f}",
+        "",
+        "## Random-init IPPO baseline",
+        f"- n_seeds: {baseline_arm.get('n_seeds', 0)}",
+        f"- iter 0 gap_closed: {baseline_arm.get('iter0_gap_closed_mean', float('nan')):.3f}",
+        f"- trailing-5 gap_closed: {baseline_arm.get('trailing5_gap_closed_mean', float('nan')):.3f}",
+        "",
+        "## References",
+        f"- random baseline: {MINSPEC_RANDOM:.2f}",
+        f"- specialist baseline: {MINSPEC_SPECIALIST:.2f}",
+    ]
+    (args.output_dir / "verdict.md").write_text("\n".join(md))
+
+    print(f"\nverdict: {verdict}")
+    print(f"reasoning: {reasoning}")
+    print(f"\nartifacts written to {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/analyze_270.py
+++ b/experiments/p3_specialization/analyze_270.py
@@ -75,7 +75,9 @@ def aggregate_arm(cells: List[Path], label: str) -> Dict:
                 "iter0_team": float(traj[0]),
                 "iter0_gap_closed": float(gap_closed(float(traj[0]))),
                 "trailing5_team": float(traj[-TRAILING_N:].mean()),
-                "trailing5_gap_closed": float(gap_closed(float(traj[-TRAILING_N:].mean()))),
+                "trailing5_gap_closed": float(
+                    gap_closed(float(traj[-TRAILING_N:].mean()))
+                ),
                 "min_iter_team": float(traj.min()),
             }
         )
@@ -149,20 +151,26 @@ def main() -> None:
     p.add_argument(
         "--bc-runs-root",
         type=Path,
-        default=Path("experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0"),
+        default=Path(
+            "experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0"
+        ),
         help="Root containing seed_{42,43,44} cells from the BC-init PPO continuation.",
     )
     p.add_argument(
         "--baseline-runs-root",
         type=Path,
-        default=Path("experiments/p3_specialization/runs/issue231/ippo/minimal_specialization"),
+        default=Path(
+            "experiments/p3_specialization/runs/issue231/ippo/minimal_specialization"
+        ),
         help="Root containing seed_{42,43,44} cells from the random-init IPPO baseline.",
     )
     p.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
     p.add_argument(
         "--output-dir",
         type=Path,
-        default=Path("experiments/p3_specialization/diagnostics/results/issue270_bc_continuation"),
+        default=Path(
+            "experiments/p3_specialization/diagnostics/results/issue270_bc_continuation"
+        ),
     )
     args = p.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/experiments/p3_specialization/bc_init.py
+++ b/experiments/p3_specialization/bc_init.py
@@ -196,7 +196,9 @@ def evaluate_policies(
     return {
         "n_episodes": int(per_step.size),
         "mean_step_reward_team": float(per_step.mean()) if per_step.size > 0 else 0.0,
-        "std_step_reward_team": float(per_step.std(ddof=1)) if per_step.size > 1 else 0.0,
+        "std_step_reward_team": float(per_step.std(ddof=1))
+        if per_step.size > 1
+        else 0.0,
         "mean_episode_length": float(np.mean(ep_lengths)) if ep_lengths else 0.0,
         "gap_closed": float(gc),
         "minspec_random_ref": MINSPEC_RANDOM,
@@ -256,7 +258,9 @@ def main() -> None:
     )
 
     # ----- Phase 1: gather demos -----
-    print(f"[1/3] Gathering specialist demos (target={args.num_pairs_per_agent}/agent)...")
+    print(
+        f"[1/3] Gathering specialist demos (target={args.num_pairs_per_agent}/agent)..."
+    )
     obs_per_agent, act_per_agent = gather_demos(
         scenario_name=args.scenario,
         num_agents=args.num_agents,
@@ -264,7 +268,9 @@ def main() -> None:
         seed=args.seed,
     )
     obs_dim = int(obs_per_agent[0].shape[1])
-    print(f"  collected per-agent obs shape: {obs_per_agent[0].shape}, obs_dim={obs_dim}")
+    print(
+        f"  collected per-agent obs shape: {obs_per_agent[0].shape}, obs_dim={obs_dim}"
+    )
 
     # Sanity: at least some non-trivial action distribution. Specialist WORK
     # fraction should be > 0 on minimal_specialization (fires do ignite).
@@ -295,9 +301,7 @@ def main() -> None:
         policies.append(policy)
         per_agent_loss_history.append(losses)
         print(
-            f"  agent {i}: epoch_losses=["
-            + ", ".join(f"{x:.4f}" for x in losses)
-            + "]"
+            f"  agent {i}: epoch_losses=[" + ", ".join(f"{x:.4f}" for x in losses) + "]"
         )
 
     # ----- Phase 3: save + eval gate -----
@@ -347,7 +351,9 @@ def main() -> None:
             f"< {args.min_gap_closed}). PPO continuation should NOT be launched."
         )
         raise SystemExit(2)
-    print(f"OK: BC took (gap_closed={eval_stats['gap_closed']:.3f}). Safe for PPO continuation.")
+    print(
+        f"OK: BC took (gap_closed={eval_stats['gap_closed']:.3f}). Safe for PPO continuation."
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/p3_specialization/bc_init.py
+++ b/experiments/p3_specialization/bc_init.py
@@ -1,0 +1,354 @@
+"""Behaviorally clone the specialist policy and save per-agent checkpoints.
+
+Issue #270 — Phase 1 discriminator between basin trap and anti-attractor.
+
+This script does three things end-to-end:
+
+1. **Demo gathering** — roll out the hand-coded specialist
+   (:func:`bucket_brigade.baselines.specialist_action_joint`) on a scenario
+   (default: ``minimal_specialization``) until we have ``--num-pairs`` per-agent
+   ``(flat_obs, action)`` tuples. Observations are flattened with
+   :func:`bucket_brigade.training.joint_trainer.flatten_dict_obs` using the
+   per-agent identity one-hot tail (#204), so the trained policy is shape-
+   compatible with :class:`JointPPOTrainer.policies[i]` at load time.
+
+2. **Supervised fit** — instantiate one :class:`PolicyNetwork` per agent and
+   train it with summed cross-entropy across the three action heads
+   (``[house, mode, signal]``). Adam, batch 64, 10 epochs by default.
+
+3. **Eval gate** — run ``--eval-episodes`` deterministic-argmax episodes and
+   compute ``gap_closed = (mean_step_team − MINSPEC_RANDOM) / (MINSPEC_SPECIALIST
+   − MINSPEC_RANDOM)`` using the constants from
+   :mod:`experiments.p3_specialization.analyze_220`. The script exits non-zero
+   when ``gap_closed < --min-gap-closed`` so a bad BC fit blocks the PPO
+   continuation.
+
+Per-agent state dicts are saved to ``<output_dir>/agent_{i}.pt``, the exact
+filename layout :func:`train_one_cell` expects when loading from
+``--bc-init-checkpoint-dir``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+from bucket_brigade.baselines import specialist_action_joint
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.training.joint_trainer import flatten_dict_obs
+from bucket_brigade.training.networks import PolicyNetwork
+
+# Verdict reference constants (post-#236 re-derived under #238, mirrored from
+# experiments/p3_specialization/analyze_220.py:59-60). Hardcoded rather than
+# imported because analyze_220.py is a script module, not a library.
+MINSPEC_RANDOM = -96.07
+MINSPEC_SPECIALIST = -22.07
+
+
+def _gap_closed(mean_step_team: float) -> float:
+    """Fraction of specialist−random gap closed (minimal_specialization)."""
+    return (mean_step_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+def gather_demos(
+    scenario_name: str,
+    num_agents: int,
+    num_pairs_per_agent: int,
+    seed: int,
+    num_houses: int = 10,
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Roll the specialist until we have ``num_pairs_per_agent`` per-agent
+    ``(flat_obs, action)`` tuples per agent.
+
+    Returns:
+        ``(obs_per_agent, act_per_agent)`` where ``obs_per_agent[i]`` is a
+        ``[num_pairs_per_agent, obs_dim]`` float32 array of agent i's
+        observations (with the identity one-hot tail set for agent i) and
+        ``act_per_agent[i]`` is a ``[num_pairs_per_agent, 3]`` int64 array of
+        the specialist's actions for agent i at those observations.
+    """
+    scenario = get_scenario_by_name(scenario_name, num_agents=num_agents)
+    env = BucketBrigadeEnv(scenario=scenario)
+    rng = np.random.default_rng(seed)
+
+    obs_buf: List[List[np.ndarray]] = [[] for _ in range(num_agents)]
+    act_buf: List[List[np.ndarray]] = [[] for _ in range(num_agents)]
+
+    # The specialist is deterministic from (obs, agent_id), so each step
+    # contributes exactly one (obs, action) pair per agent. Tally on
+    # `obs_buf[0]` and stop when we've reached the per-agent target.
+    while len(obs_buf[0]) < num_pairs_per_agent:
+        obs = env.reset(seed=int(rng.integers(0, 2**31 - 1)))
+        while not env.done:
+            joint = specialist_action_joint(obs, num_agents, num_houses=num_houses)
+            for i in range(num_agents):
+                obs_buf[i].append(
+                    flatten_dict_obs(obs, agent_id=i, num_agents=num_agents)
+                )
+                act_buf[i].append(joint[i])
+            obs, _, _, _ = env.step(joint)
+            if len(obs_buf[0]) >= num_pairs_per_agent:
+                break
+
+    obs_per_agent = [np.stack(buf, axis=0).astype(np.float32) for buf in obs_buf]
+    act_per_agent = [np.stack(buf, axis=0).astype(np.int64) for buf in act_buf]
+    return obs_per_agent, act_per_agent
+
+
+def bc_fit_one_agent(
+    obs: np.ndarray,
+    acts: np.ndarray,
+    obs_dim: int,
+    action_dims: List[int],
+    hidden_size: int,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    device: str,
+    seed: int,
+) -> Tuple[PolicyNetwork, List[float]]:
+    """Supervised fit of one PolicyNetwork to (obs, acts) by summing
+    cross-entropy on each of ``len(action_dims)`` heads.
+
+    Returns the trained policy plus per-epoch mean training losses (for
+    inspection only — convergence is verified by the eval gate, not the loss
+    value).
+    """
+    # Reproducible per-agent fits: seed both the model init and the dataloader
+    # shuffle by tying torch's RNG to the same seed used for the broader run.
+    torch.manual_seed(seed)
+    policy = PolicyNetwork(
+        obs_dim=obs_dim, action_dims=action_dims, hidden_size=hidden_size
+    ).to(device)
+    opt = torch.optim.Adam(policy.parameters(), lr=lr)
+
+    x_t = torch.from_numpy(obs).float().to(device)
+    a_t = torch.from_numpy(acts).long().to(device)
+    ds = TensorDataset(x_t, a_t)
+    dl = DataLoader(ds, batch_size=batch_size, shuffle=True)
+
+    epoch_losses: List[float] = []
+    n_heads = len(action_dims)
+    for ep in range(epochs):
+        batch_losses: List[float] = []
+        for x, a in dl:
+            logits, _ = policy(x)
+            # Sum of CE on each independent action head. PolicyNetwork emits
+            # `n_heads` raw logits tensors of shape (batch, action_dims[k]).
+            loss = sum(F.cross_entropy(logits[k], a[:, k]) for k in range(n_heads))
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            batch_losses.append(float(loss.item()))
+        epoch_losses.append(float(np.mean(batch_losses)))
+    return policy, epoch_losses
+
+
+def evaluate_policies(
+    policies: List[PolicyNetwork],
+    scenario_name: str,
+    num_agents: int,
+    num_episodes: int,
+    device: str,
+    seed: int = 0,
+) -> dict:
+    """Roll the per-agent policies (argmax) for ``num_episodes`` episodes and
+    return per-step team reward statistics plus gap_closed."""
+    scenario = get_scenario_by_name(scenario_name, num_agents=num_agents)
+    env = BucketBrigadeEnv(scenario=scenario)
+
+    for p in policies:
+        p.eval()
+
+    ep_per_step: List[float] = []
+    ep_lengths: List[int] = []
+    with torch.no_grad():
+        for ep in range(num_episodes):
+            obs = env.reset(seed=seed + ep)
+            total = 0.0
+            nights = 0
+            while not env.done:
+                joint_rows: List[List[int]] = []
+                for i in range(num_agents):
+                    x = flatten_dict_obs(obs, agent_id=i, num_agents=num_agents)
+                    xt = torch.from_numpy(x).float().to(device).unsqueeze(0)
+                    actions, _, _ = policies[i].get_action(xt, deterministic=True)
+                    joint_rows.append([int(a.item()) for a in actions])
+                joint = np.asarray(joint_rows, dtype=np.int64)
+                obs, rewards, _, _ = env.step(joint)
+                total += float(rewards.sum())
+                nights = int(env.night)
+            # ``env.night`` is the night count at termination; treat 0 defensively.
+            if nights > 0:
+                ep_per_step.append(total / nights)
+                ep_lengths.append(nights)
+
+    per_step = np.asarray(ep_per_step, dtype=np.float64)
+    gc = _gap_closed(float(per_step.mean())) if per_step.size > 0 else float("nan")
+    return {
+        "n_episodes": int(per_step.size),
+        "mean_step_reward_team": float(per_step.mean()) if per_step.size > 0 else 0.0,
+        "std_step_reward_team": float(per_step.std(ddof=1)) if per_step.size > 1 else 0.0,
+        "mean_episode_length": float(np.mean(ep_lengths)) if ep_lengths else 0.0,
+        "gap_closed": float(gc),
+        "minspec_random_ref": MINSPEC_RANDOM,
+        "minspec_specialist_ref": MINSPEC_SPECIALIST,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--scenario",
+        default="minimal_specialization",
+        help="Scenario name to gather demos from and evaluate on.",
+    )
+    p.add_argument("--num-agents", type=int, default=4)
+    p.add_argument(
+        "--num-pairs-per-agent",
+        type=int,
+        default=10000,
+        help="Per-agent (obs, action) pair count for BC training (#270 brief).",
+    )
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--batch-size", type=int, default=64)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--hidden-size", type=int, default=64)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--eval-episodes",
+        type=int,
+        default=20,
+        help="Number of deterministic-argmax episodes for the gap_closed gate.",
+    )
+    p.add_argument(
+        "--min-gap-closed",
+        type=float,
+        default=0.7,
+        help=(
+            "Gate threshold from issue #270: if BC eval gap_closed < this, "
+            "exit non-zero so the PPO continuation isn't launched from a bad init."
+        ),
+    )
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory to save agent_{i}.pt and bc_summary.json.",
+    )
+    p.add_argument("--device", default="cpu")
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"== BC-init #270: scenario={args.scenario} num_agents={args.num_agents} "
+        f"num_pairs_per_agent={args.num_pairs_per_agent} epochs={args.epochs} "
+        f"batch_size={args.batch_size} lr={args.lr} seed={args.seed} =="
+    )
+
+    # ----- Phase 1: gather demos -----
+    print(f"[1/3] Gathering specialist demos (target={args.num_pairs_per_agent}/agent)...")
+    obs_per_agent, act_per_agent = gather_demos(
+        scenario_name=args.scenario,
+        num_agents=args.num_agents,
+        num_pairs_per_agent=args.num_pairs_per_agent,
+        seed=args.seed,
+    )
+    obs_dim = int(obs_per_agent[0].shape[1])
+    print(f"  collected per-agent obs shape: {obs_per_agent[0].shape}, obs_dim={obs_dim}")
+
+    # Sanity: at least some non-trivial action distribution. Specialist WORK
+    # fraction should be > 0 on minimal_specialization (fires do ignite).
+    work_frac = float((act_per_agent[0][:, 1] == 1).mean())
+    print(f"  agent 0 specialist WORK fraction: {work_frac:.3f}")
+
+    # ----- Phase 2: BC fit per agent -----
+    print(f"[2/3] Fitting {args.num_agents} per-agent policies...")
+    policies: List[PolicyNetwork] = []
+    per_agent_loss_history: List[List[float]] = []
+    action_dims = [10, 2, 2]  # MultiDiscrete([num_houses, mode, signal])
+    for i in range(args.num_agents):
+        policy, losses = bc_fit_one_agent(
+            obs=obs_per_agent[i],
+            acts=act_per_agent[i],
+            obs_dim=obs_dim,
+            action_dims=action_dims,
+            hidden_size=args.hidden_size,
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            device=args.device,
+            # Per-agent seed nudge so the 4 nets don't init identically. The
+            # supervised target is per-agent (identity one-hot differs), so the
+            # init nudge is purely a numerical-stability nicety.
+            seed=args.seed + i,
+        )
+        policies.append(policy)
+        per_agent_loss_history.append(losses)
+        print(
+            f"  agent {i}: epoch_losses=["
+            + ", ".join(f"{x:.4f}" for x in losses)
+            + "]"
+        )
+
+    # ----- Phase 3: save + eval gate -----
+    print(f"[3/3] Saving policies and evaluating ({args.eval_episodes} episodes)...")
+    for i, policy in enumerate(policies):
+        torch.save(policy.state_dict(), args.output_dir / f"agent_{i}.pt")
+
+    eval_stats = evaluate_policies(
+        policies=policies,
+        scenario_name=args.scenario,
+        num_agents=args.num_agents,
+        num_episodes=args.eval_episodes,
+        device=args.device,
+        seed=args.seed + 1000,  # disjoint from demo-gen seed stream
+    )
+
+    summary = {
+        "issue": 270,
+        "scenario": args.scenario,
+        "num_agents": args.num_agents,
+        "num_pairs_per_agent": args.num_pairs_per_agent,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "lr": args.lr,
+        "hidden_size": args.hidden_size,
+        "obs_dim": obs_dim,
+        "action_dims": action_dims,
+        "seed": args.seed,
+        "per_agent_loss_history": per_agent_loss_history,
+        "agent_0_work_fraction_in_demos": work_frac,
+        "eval": eval_stats,
+        "min_gap_closed_gate": args.min_gap_closed,
+        "gate_passed": bool(eval_stats["gap_closed"] >= args.min_gap_closed),
+    }
+    with (args.output_dir / "bc_summary.json").open("w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(
+        f"  BC eval: mean_step_team={eval_stats['mean_step_reward_team']:.3f} "
+        f"gap_closed={eval_stats['gap_closed']:.3f} "
+        f"(gate >= {args.min_gap_closed})"
+    )
+
+    if not summary["gate_passed"]:
+        print(
+            f"FAIL: BC did not take (gap_closed={eval_stats['gap_closed']:.3f} "
+            f"< {args.min_gap_closed}). PPO continuation should NOT be launched."
+        )
+        raise SystemExit(2)
+    print(f"OK: BC took (gap_closed={eval_stats['gap_closed']:.3f}). Safe for PPO continuation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue270_ppo_continuation.sh
+++ b/experiments/p3_specialization/run_issue270_ppo_continuation.sh
@@ -8,34 +8,19 @@
 #   experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0/seed_<S>/
 set -euo pipefail
 
-BC_DIR=${1:?"missing BC checkpoint dir (e.g., experiments/p3_specialization/runs/issue270_bc_init/specialist_bc)"}
-shift
-SEEDS=( "${@:-42 43 44}" )
-if [ "${#SEEDS[@]}" -eq 0 ]; then SEEDS=(42 43 44); fi
+BC_DIR=${1:?"missing BC checkpoint dir (e.g., experiments/p3_specialization/runs/issue270_bc_init/specialist_bc_v2)"}
+shift || true
+if [ "$#" -eq 0 ]; then
+  set -- 42 43 44
+fi
 
 OUT_ROOT="experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0"
 mkdir -p "$OUT_ROOT"
-
-cmd_for_seed() {
-  local s="$1"
-  echo python experiments/p3_specialization/train.py \
-    --scenario minimal_specialization \
-    --lambda-red 0.0 \
-    --seed "$s" \
-    --num-iterations 50 \
-    --rollout-steps 2048 \
-    --num-agents 4 \
-    --bc-init-checkpoint-dir "$BC_DIR" \
-    --output-dir "$OUT_ROOT/seed_$s"
-}
-
-export -f cmd_for_seed
 export BC_DIR OUT_ROOT
 
-# Run two seeds at a time to share CPU with parallel builders on this host.
-printf "%s\n" "${SEEDS[@]}" | xargs -P 2 -I{} bash -c '
-  s="{}"
-  out="'"$OUT_ROOT"'/seed_$s"
+run_one() {
+  local s="$1"
+  local out="$OUT_ROOT/seed_$s"
   mkdir -p "$out"
   python experiments/p3_specialization/train.py \
     --scenario minimal_specialization \
@@ -44,8 +29,12 @@ printf "%s\n" "${SEEDS[@]}" | xargs -P 2 -I{} bash -c '
     --num-iterations 50 \
     --rollout-steps 2048 \
     --num-agents 4 \
-    --bc-init-checkpoint-dir "'"$BC_DIR"'" \
+    --bc-init-checkpoint-dir "$BC_DIR" \
     --output-dir "$out" 2>&1 | tee "$out/train.log"
-'
+}
+export -f run_one
+
+# Run two seeds at a time to share CPU with parallel builders on this host.
+printf "%s\n" "$@" | xargs -P 2 -I{} bash -c 'run_one "$@"' _ {}
 
 echo "All seeds finished."

--- a/experiments/p3_specialization/run_issue270_ppo_continuation.sh
+++ b/experiments/p3_specialization/run_issue270_ppo_continuation.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Issue #270: 50-iter IPPO continuation from BC-pretrained init, 3 seeds.
+#
+# Usage:
+#   ./run_issue270_ppo_continuation.sh <bc_checkpoint_dir> [seed1 seed2 ...]
+#
+# Defaults seeds: 42 43 44. Cells land at
+#   experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0/seed_<S>/
+set -euo pipefail
+
+BC_DIR=${1:?"missing BC checkpoint dir (e.g., experiments/p3_specialization/runs/issue270_bc_init/specialist_bc)"}
+shift
+SEEDS=( "${@:-42 43 44}" )
+if [ "${#SEEDS[@]}" -eq 0 ]; then SEEDS=(42 43 44); fi
+
+OUT_ROOT="experiments/p3_specialization/runs/issue270_bc_continuation/minimal_specialization/lambda_0e0"
+mkdir -p "$OUT_ROOT"
+
+cmd_for_seed() {
+  local s="$1"
+  echo python experiments/p3_specialization/train.py \
+    --scenario minimal_specialization \
+    --lambda-red 0.0 \
+    --seed "$s" \
+    --num-iterations 50 \
+    --rollout-steps 2048 \
+    --num-agents 4 \
+    --bc-init-checkpoint-dir "$BC_DIR" \
+    --output-dir "$OUT_ROOT/seed_$s"
+}
+
+export -f cmd_for_seed
+export BC_DIR OUT_ROOT
+
+# Run two seeds at a time to share CPU with parallel builders on this host.
+printf "%s\n" "${SEEDS[@]}" | xargs -P 2 -I{} bash -c '
+  s="{}"
+  out="'"$OUT_ROOT"'/seed_$s"
+  mkdir -p "$out"
+  python experiments/p3_specialization/train.py \
+    --scenario minimal_specialization \
+    --lambda-red 0.0 \
+    --seed "$s" \
+    --num-iterations 50 \
+    --rollout-steps 2048 \
+    --num-agents 4 \
+    --bc-init-checkpoint-dir "'"$BC_DIR"'" \
+    --output-dir "$out" 2>&1 | tee "$out/train.log"
+'
+
+echo "All seeds finished."

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -676,7 +676,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
                 raise FileNotFoundError(
                     f"BC checkpoint missing for agent {i}: expected {ckpt_path}"
                 )
-            sd = torch.load(ckpt_path, map_location=cfg.device)
+            sd = torch.load(ckpt_path, map_location=cfg.device, weights_only=True)
             # ``load_state_dict`` is strict by default; a shape mismatch (e.g.,
             # the BC fit used a different hidden_size) will raise here instead
             # of silently shifting the obs encoding mid-training.

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -33,7 +33,7 @@ import json
 import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import torch
@@ -109,6 +109,13 @@ class CellConfig:
     # the ``--action-shaping-alpha`` / ``--action-shaping-beta`` flags.
     action_shaping_alpha: float = 0.0
     action_shaping_beta: float = 0.0
+    # Issue #270: optional BC-pretrained init. Directory containing per-agent
+    # ``agent_{i}.pt`` state dicts produced by
+    # ``experiments/p3_specialization/bc_init.py``. ``None`` (default)
+    # preserves bit-identical pre-#270 random-init behavior. When set, the
+    # state dicts are loaded into ``trainer.policies[i]`` immediately after
+    # trainer construction, before the first PPO iteration.
+    bc_init_checkpoint_dir: Optional[str] = None
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -649,6 +656,36 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         seed=cfg.seed,
     )
 
+    # Issue #270: optionally warm-start the actor weights from a BC-pretrained
+    # checkpoint directory produced by ``experiments/p3_specialization/bc_init.py``.
+    # Loaded after the trainer is constructed (which sets the random-init
+    # baseline) so the per-agent state dict overwrites only the actor; the
+    # value head, optimizer state, and (when ``centralized_critic=True``)
+    # the critic remain freshly initialized. This is the basin-trap vs
+    # anti-attractor probe — BC sets the actor near specialist, then PPO
+    # continues from there.
+    if cfg.bc_init_checkpoint_dir is not None:
+        bc_dir = Path(cfg.bc_init_checkpoint_dir)
+        if not bc_dir.is_dir():
+            raise FileNotFoundError(
+                f"bc_init_checkpoint_dir does not exist or is not a directory: {bc_dir}"
+            )
+        for i, policy in enumerate(trainer.policies):
+            ckpt_path = bc_dir / f"agent_{i}.pt"
+            if not ckpt_path.exists():
+                raise FileNotFoundError(
+                    f"BC checkpoint missing for agent {i}: expected {ckpt_path}"
+                )
+            sd = torch.load(ckpt_path, map_location=cfg.device)
+            # ``load_state_dict`` is strict by default; a shape mismatch (e.g.,
+            # the BC fit used a different hidden_size) will raise here instead
+            # of silently shifting the obs encoding mid-training.
+            policy.load_state_dict(sd)
+        print(
+            f"  BC-init (#270): loaded {cfg.num_agents} per-agent state dicts "
+            f"from {bc_dir}"
+        )
+
     # Shared random projection matrix for MI measurement. Seeded from cfg.seed
     # so the metric is reproducible and comparable across iterations.
     rng = np.random.default_rng(cfg.seed)
@@ -811,6 +848,19 @@ def main() -> None:
             "behavior. Use 0.0/0.1/0.5 in the calibration sweep."
         ),
     )
+    p.add_argument(
+        "--bc-init-checkpoint-dir",
+        type=str,
+        default=None,
+        help=(
+            "Issue #270: directory containing per-agent BC-pretrained "
+            "state dicts (agent_{i}.pt) produced by "
+            "experiments/p3_specialization/bc_init.py. When set, the actor "
+            "weights are loaded into trainer.policies[i] after trainer "
+            "construction, before the first PPO iteration. Default None "
+            "preserves bit-identical pre-#270 random-init behavior."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -828,6 +878,7 @@ def main() -> None:
         curriculum=args.curriculum,
         action_shaping_alpha=args.action_shaping_alpha,
         action_shaping_beta=args.action_shaping_beta,
+        bc_init_checkpoint_dir=args.bc_init_checkpoint_dir,
         device=args.device,
     )
     print(

--- a/resources
+++ b/resources
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/bucket-brigade/.loom/worktrees/issue-270/.venv/lib/python3.12/site-packages/pufferlib/resources

--- a/resources
+++ b/resources
@@ -1,0 +1,1 @@
+/Users/rwalters/GitHub/bucket-brigade/.loom/worktrees/issue-270/.venv/lib/python3.12/site-packages/pufferlib/resources

--- a/tests/test_bc_init.py
+++ b/tests/test_bc_init.py
@@ -68,7 +68,12 @@ def small_bc_run(tmp_path_factory):
         policies.append(p)
         torch.save(p.state_dict(), out / f"agent_{i}.pt")
 
-    return {"out": out, "obs_dim": obs_dim, "policies": policies, "num_agents": num_agents}
+    return {
+        "out": out,
+        "obs_dim": obs_dim,
+        "policies": policies,
+        "num_agents": num_agents,
+    }
 
 
 def test_demos_have_correct_identity_one_hot():

--- a/tests/test_bc_init.py
+++ b/tests/test_bc_init.py
@@ -24,8 +24,8 @@ import torch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "experiments" / "p3_specialization"))
 
-import bc_init  # type: ignore[import-not-found]
-from bucket_brigade.training.networks import PolicyNetwork
+import bc_init  # type: ignore[import-not-found]  # noqa: E402
+from bucket_brigade.training.networks import PolicyNetwork  # noqa: E402
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_bc_init.py
+++ b/tests/test_bc_init.py
@@ -1,0 +1,152 @@
+"""Tests for ``experiments/p3_specialization/bc_init.py`` (issue #270).
+
+Covers:
+
+- Demo gathering yields the requested per-agent pair counts and shape.
+- Saved checkpoints round-trip into a fresh ``PolicyNetwork`` (the load
+  target inside ``train_one_cell``).
+- ``train_one_cell`` raises a clear error when ``bc_init_checkpoint_dir``
+  points at a directory with a missing or malformed checkpoint.
+
+Pure-CPU, deliberately small (``num_pairs_per_agent=64`` / ``epochs=1``) so
+the suite finishes in seconds.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "experiments" / "p3_specialization"))
+
+import bc_init  # type: ignore[import-not-found]
+from bucket_brigade.training.networks import PolicyNetwork
+
+
+@pytest.fixture(scope="module")
+def small_bc_run(tmp_path_factory):
+    """Run a tiny BC fit end-to-end and return the output directory + summary."""
+    out = tmp_path_factory.mktemp("bc_init_smoke")
+    num_agents = 4
+    obs_per_agent, act_per_agent = bc_init.gather_demos(
+        scenario_name="minimal_specialization",
+        num_agents=num_agents,
+        num_pairs_per_agent=64,
+        seed=0,
+    )
+
+    assert len(obs_per_agent) == num_agents
+    obs_dim = obs_per_agent[0].shape[1]
+    # Per-agent obs and actions must have aligned row counts.
+    for i in range(num_agents):
+        assert obs_per_agent[i].shape == (64, obs_dim)
+        assert act_per_agent[i].shape == (64, 3)
+        # Action dimensions must be in-bounds for [10, 2, 2].
+        assert act_per_agent[i][:, 0].max() < 10
+        assert act_per_agent[i][:, 1].max() < 2
+        assert act_per_agent[i][:, 2].max() < 2
+
+    policies = []
+    for i in range(num_agents):
+        p, _ = bc_init.bc_fit_one_agent(
+            obs=obs_per_agent[i],
+            acts=act_per_agent[i],
+            obs_dim=obs_dim,
+            action_dims=[10, 2, 2],
+            hidden_size=64,
+            epochs=1,
+            batch_size=32,
+            lr=1e-3,
+            device="cpu",
+            seed=i,
+        )
+        policies.append(p)
+        torch.save(p.state_dict(), out / f"agent_{i}.pt")
+
+    return {"out": out, "obs_dim": obs_dim, "policies": policies, "num_agents": num_agents}
+
+
+def test_demos_have_correct_identity_one_hot():
+    """Each agent's flattened obs must carry its own one-hot identity tail."""
+    num_agents = 4
+    obs_per_agent, _ = bc_init.gather_demos(
+        scenario_name="minimal_specialization",
+        num_agents=num_agents,
+        num_pairs_per_agent=16,
+        seed=0,
+    )
+    # The identity one-hot is the last `num_agents` entries.
+    for i in range(num_agents):
+        tail = obs_per_agent[i][:, -num_agents:]
+        # All rows must encode the correct identity (one-hot at slot i).
+        np.testing.assert_array_equal(tail.argmax(axis=1), np.full(16, i))
+        np.testing.assert_allclose(tail.sum(axis=1), np.ones(16))
+
+
+def test_checkpoint_round_trip(small_bc_run):
+    """Saved per-agent state dicts must load into a fresh PolicyNetwork."""
+    obs_dim = small_bc_run["obs_dim"]
+    for i in range(small_bc_run["num_agents"]):
+        ckpt = torch.load(small_bc_run["out"] / f"agent_{i}.pt", map_location="cpu")
+        fresh = PolicyNetwork(obs_dim=obs_dim, action_dims=[10, 2, 2], hidden_size=64)
+        fresh.load_state_dict(ckpt)
+        # Sanity: round-tripped policy must produce the same logits on a probe
+        # obs as the source policy. (Both share the same state dict.)
+        x = torch.zeros(1, obs_dim, dtype=torch.float32)
+        x[0, -small_bc_run["num_agents"] + i] = 1.0  # identity slot
+        with torch.no_grad():
+            l1, _ = small_bc_run["policies"][i](x)
+            l2, _ = fresh(x)
+        for lhs, rhs in zip(l1, l2):
+            torch.testing.assert_close(lhs, rhs)
+
+
+def test_train_one_cell_rejects_missing_checkpoint(small_bc_run, tmp_path):
+    """train_one_cell must raise FileNotFoundError when an agent_*.pt is missing."""
+    # Import locally so the train.py module-level imports are deferred until
+    # the rest of the suite verifies bc_init.py works.
+    sys.path.insert(0, str(REPO_ROOT / "experiments" / "p3_specialization"))
+    import train  # type: ignore[import-not-found]
+
+    # Build a bogus checkpoint dir with only 3 of the 4 required state dicts.
+    incomplete_dir = tmp_path / "incomplete"
+    incomplete_dir.mkdir()
+    for i in range(small_bc_run["num_agents"] - 1):
+        # Copy the existing checkpoints.
+        sd = torch.load(small_bc_run["out"] / f"agent_{i}.pt", map_location="cpu")
+        torch.save(sd, incomplete_dir / f"agent_{i}.pt")
+
+    cfg = train.CellConfig(
+        scenario="minimal_specialization",
+        lambda_red=0.0,
+        seed=0,
+        num_iterations=1,  # we should never actually iterate
+        rollout_steps=8,
+        num_agents=small_bc_run["num_agents"],
+        bc_init_checkpoint_dir=str(incomplete_dir),
+    )
+    with pytest.raises(FileNotFoundError, match="agent_3.pt"):
+        train.train_one_cell(cfg, tmp_path / "cell_out")
+
+
+def test_train_one_cell_rejects_nonexistent_dir(tmp_path):
+    """train_one_cell must raise FileNotFoundError when the dir does not exist."""
+    sys.path.insert(0, str(REPO_ROOT / "experiments" / "p3_specialization"))
+    import train  # type: ignore[import-not-found]
+
+    cfg = train.CellConfig(
+        scenario="minimal_specialization",
+        lambda_red=0.0,
+        seed=0,
+        num_iterations=1,
+        rollout_steps=8,
+        num_agents=4,
+        bc_init_checkpoint_dir=str(tmp_path / "does_not_exist"),
+    )
+    with pytest.raises(FileNotFoundError, match="bc_init_checkpoint_dir"):
+        train.train_one_cell(cfg, tmp_path / "cell_out")


### PR DESCRIPTION
## Summary

Phase 1 discriminator (issue #270) for the bucket-brigade PPO failure mode: behaviorally clone the hand-coded specialist, load it as the actor warm-start, then continue independent-PPO for 50 iterations × 3 seeds on `minimal_specialization`. Compare against the random-init IPPO baseline (`runs/issue231/ippo/minimal_specialization/seed_{42,43,44}`) to classify the failure mode:

- **basin trap** — PPO holds the specialist region: path-finding intervention needed
- **anti-attractor** — PPO erases BC: reward/dynamics actively repels specialist
- **partial** — somewhere in between

## Changes

- `experiments/p3_specialization/bc_init.py` (new) — gather specialist demos, supervised-fit per-agent `PolicyNetwork` (sum CE across `[house, mode, signal]` heads), save `agent_{i}.pt`, gate on `gap_closed ≥ --min-gap-closed`.
- `experiments/p3_specialization/train.py` — `CellConfig.bc_init_checkpoint_dir` + CLI flag `--bc-init-checkpoint-dir`; load per-agent state dicts into `trainer.policies[i]` after construction. `None` preserves bit-identical pre-#270 behavior.
- `experiments/p3_specialization/analyze_270.py` (new) — aggregate the BC-init PPO arm vs random-init IPPO baseline and emit the verdict per the matrix above.
- `experiments/p3_specialization/run_issue270_ppo_continuation.sh` (new) — 2-way parallel xargs over 3 seeds.
- `tests/test_bc_init.py` (new) — identity-tail correctness, checkpoint round-trip into a fresh `PolicyNetwork`, `FileNotFoundError` on missing / nonexistent BC dirs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| BC pretraining script in `experiments/p3_specialization/bc_init.py` | done | File present; passes round-trip tests |
| Verified BC policy approximates specialist before PPO | done | `bc_summary.json`: gap_closed = **0.934** ≥ 0.7 gate (40k pairs/agent, 30 epochs, lr 1e-3, batch 64) |
| 50-iter PPO continuation, 3 seeds | running | tmux `issue270-ppo` on `COMPUTE_HOST_PRIMARY`; seeds 42/43 active, 44 queued. Verdict comment to follow. |
| Notebook/analyzer with verdict matrix | done | `analyze_270.py` emits `basin_trap` / `anti_attractor` / `partial` / `bc_did_not_take` |
| Project memory updated based on outcome | pending | Will update `project_ppo_failure_mode.md` once verdict lands |

## BC Stage Findings

- Initial BC run (10k pairs/agent, 10 epochs) gave gap_closed = 0.368 (well below 0.7 gate). Per-head autopsy: house accuracy on `mode == WORK` rows was 31.5%, only marginally above chance — the model trivially memorized REST → lowest-owned but never learned to route to the burning-owned argmin. **Same pattern issue #272 reported with the same budget.**
- Increased budget run (40k pairs/agent, 30 epochs) reached gap_closed = **0.934** with the *identical* `PolicyNetwork(hidden_size=64)` architecture. The capacity is sufficient; the original 10k/10ep budget was the bottleneck. This is an important contextual note for #272's INDUCTIVE_BIAS_GAP verdict — that label may be a training-budget artifact, not a fundamental representational limit.

## Test Plan

- `tests/test_bc_init.py` — 4 passed (identity tail correctness, checkpoint round-trip, FileNotFoundError on missing + nonexistent dirs).
- BC pretrain end-to-end on `minimal_specialization`: gate passes at gap_closed 0.934.
- PPO continuation: in flight; verdict will be appended as a PR comment.

Closes #270