### PR TITLE
feat(env): macro-action wrapper around BucketBrigadeEnv

### DIFF
--- a/bucket_brigade/envs/__init__.py
+++ b/bucket_brigade/envs/__init__.py
@@ -5,6 +5,13 @@ Environment implementations for Bucket Brigade.
 from typing import TYPE_CHECKING, Optional, Type, Callable, Any
 
 from .bucket_brigade_env import BucketBrigadeEnv
+from .macro_action_env import (
+    MacroActionEnv,
+    OPT_DEFEND_OWN,
+    OPT_FOLLOW_BASE,
+    OPT_PATROL,
+    OPT_REST_UNTIL_FIRE,
+)
 
 # Optional PufferLib imports (only available if gymnasium is installed)
 if TYPE_CHECKING:
@@ -48,6 +55,11 @@ from .scenarios_random import random_scenario
 
 __all__ = [
     "BucketBrigadeEnv",
+    "MacroActionEnv",
+    "OPT_PATROL",
+    "OPT_DEFEND_OWN",
+    "OPT_REST_UNTIL_FIRE",
+    "OPT_FOLLOW_BASE",
     "PufferBucketBrigade",
     "PufferBucketBrigadeVectorized",
     "make_env",

--- a/bucket_brigade/envs/macro_action_env.py
+++ b/bucket_brigade/envs/macro_action_env.py
@@ -104,9 +104,7 @@ class MacroActionEnv:
         discount_gamma: Optional[float] = None,
     ) -> None:
         if commit_steps < 1:
-            raise ValueError(
-                f"commit_steps must be >= 1; got {commit_steps}"
-            )
+            raise ValueError(f"commit_steps must be >= 1; got {commit_steps}")
         if discount_gamma is not None and not (0.0 < discount_gamma <= 1.0):
             raise ValueError(
                 f"discount_gamma must be None or in (0, 1]; got {discount_gamma}"
@@ -221,7 +219,7 @@ class MacroActionEnv:
             if self.discount_gamma is None:
                 accumulated_rewards += rewards.astype(np.float32)
             else:
-                accumulated_rewards += (self.discount_gamma ** k) * rewards.astype(
+                accumulated_rewards += (self.discount_gamma**k) * rewards.astype(
                     np.float32
                 )
 
@@ -283,7 +281,9 @@ class MacroActionEnv:
                     or houses[left] == BucketBrigadeEnv.BURNING
                     or houses[right] == BucketBrigadeEnv.BURNING
                 )
-                mode = BucketBrigadeEnv.WORK if burning_nearby else BucketBrigadeEnv.REST
+                mode = (
+                    BucketBrigadeEnv.WORK if burning_nearby else BucketBrigadeEnv.REST
+                )
                 primitive[i, 0] = target
                 primitive[i, 1] = mode
                 primitive[i, 2] = mode

--- a/bucket_brigade/envs/macro_action_env.py
+++ b/bucket_brigade/envs/macro_action_env.py
@@ -1,0 +1,383 @@
+"""Macro-action wrapper around :class:`BucketBrigadeEnv` (issue #286).
+
+The PPO basin-trap reading from #270/#271/#272 motivates coarsening the
+decision horizon: instead of choosing a primitive ``[house, mode, signal]``
+each base step, the agent commits to a multi-step **option** for
+``commit_steps`` base steps (or until the env terminates). Macro-actions
+shrink the effective horizon ``T_eff = T / N`` and change the search
+neighborhood — a single macro-step is N primitive steps, potentially
+crossing basin boundaries that primitive-action gradients can't traverse.
+
+This is Sutton's options framework specialized to the credit-assignment
+failure described in
+``research_notebook/2026-05-17_thesis_misaligned_gradients.md`` (item 4).
+
+Wrapper placement
+-----------------
+
+``BucketBrigadeEnv`` is *not* a Gym/Gymnasium/PettingZoo env at the base
+layer — it exposes a custom dict-obs / numpy-action contract. There is a
+Gymnasium-style wrapper at :mod:`bucket_brigade.envs.puffer_env` for
+single-agent PufferLib training, but the joint multi-agent trainer
+:class:`bucket_brigade.training.joint_trainer.JointPPOTrainer` drives
+``BucketBrigadeEnv`` directly. The macro-action wrapper therefore sits at
+the ``BucketBrigadeEnv`` level (wrap, don't subclass), exposing the same
+``reset()`` and ``step(actions)`` contract so it is a drop-in replacement
+in ``env_fn``.
+
+Action space
+------------
+
+Each agent emits a single discrete macro-action index per macro-step. With
+``num_agents=N`` the option set is::
+
+    0: PATROL           — rotate around the ring; WORK at fires.
+    1: DEFEND_OWN       — park at agent_home_positions[i]; WORK if needed.
+    2: REST_UNTIL_FIRE  — REST in place; switch to PATROL on first fire.
+    3..3+(N-2): FOLLOW_j — copy agent j's previous primitive action.
+
+There are ``num_options = 3 + (num_agents - 1)`` options total (self is
+excluded from FOLLOW). ``action_dims=[num_options]`` is what the trainer
+should pass to ``JointPPOTrainer``.
+
+Reward accumulation
+-------------------
+
+The undiscounted sum of per-agent rewards across the committed window is
+returned as the macro-step reward. Discounted accumulation is available
+via ``discount_gamma`` (default ``None`` = undiscounted, per the issue
+spec).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .bucket_brigade_env import BucketBrigadeEnv
+
+
+# Option indices. Keep these in sync with ``MacroActionEnv.option_index_*``
+# helpers below.
+OPT_PATROL = 0
+OPT_DEFEND_OWN = 1
+OPT_REST_UNTIL_FIRE = 2
+# FOLLOW options start at index 3 and bundle the (num_agents - 1) other
+# agents in ascending order (self is skipped).
+OPT_FOLLOW_BASE = 3
+
+
+class MacroActionEnv:
+    """Wrap :class:`BucketBrigadeEnv` with a discrete macro-action space.
+
+    Args:
+        base_env: An instantiated :class:`BucketBrigadeEnv`.
+        commit_steps: How many base-env steps each macro-action commits to
+            (subject to early termination on env-done).
+        discount_gamma: If ``None`` (default), reward accumulation is
+            undiscounted. If a float in ``(0, 1]``, the reward returned at
+            macro-step boundary k is ``sum_{t=0..n-1} gamma^t * r_t``
+            where ``n`` is the actual number of base steps executed
+            (``<= commit_steps``).
+
+    Attributes mirror :class:`BucketBrigadeEnv` where useful:
+
+    - ``num_agents``: forwarded.
+    - ``num_houses``: forwarded.
+    - ``num_options``: ``3 + (num_agents - 1)``.
+    - ``done``: forwarded from the base env (so existing callers that
+      poll ``trainer.env.done`` keep working).
+    """
+
+    # Re-export base-env constants for callers that want them off the wrapper.
+    SAFE = BucketBrigadeEnv.SAFE
+    BURNING = BucketBrigadeEnv.BURNING
+    RUINED = BucketBrigadeEnv.RUINED
+    REST = BucketBrigadeEnv.REST
+    WORK = BucketBrigadeEnv.WORK
+
+    def __init__(
+        self,
+        base_env: BucketBrigadeEnv,
+        commit_steps: int = 5,
+        discount_gamma: Optional[float] = None,
+    ) -> None:
+        if commit_steps < 1:
+            raise ValueError(
+                f"commit_steps must be >= 1; got {commit_steps}"
+            )
+        if discount_gamma is not None and not (0.0 < discount_gamma <= 1.0):
+            raise ValueError(
+                f"discount_gamma must be None or in (0, 1]; got {discount_gamma}"
+            )
+
+        self.base_env = base_env
+        self.commit_steps = int(commit_steps)
+        self.discount_gamma = discount_gamma
+
+        self.num_agents = base_env.num_agents
+        self.num_houses = base_env.num_houses
+        # 3 fixed options (PATROL, DEFEND_OWN, REST_UNTIL_FIRE) + (N - 1)
+        # FOLLOW_j options bundled in ascending j-order (skipping self at
+        # action time). When num_agents == 1, there are no FOLLOW options.
+        # Issue #286 spec: ``num_options = 3 + (num_agents - 1)``.
+        self.num_options = 3 + max(0, self.num_agents - 1)
+
+        # Per-option-execution state: tracks whether REST_UNTIL_FIRE has
+        # seen a fire yet within the *current* commit window. Indexed by
+        # agent. Reset at the start of every macro-step.
+        self._fire_seen: np.ndarray = np.zeros(self.num_agents, dtype=bool)
+
+    # ------------------------------------------------------------------
+    # Public API mirroring BucketBrigadeEnv
+    # ------------------------------------------------------------------
+
+    @property
+    def done(self) -> bool:
+        return bool(self.base_env.done)
+
+    @property
+    def scenario(self):
+        return self.base_env.scenario
+
+    @property
+    def night(self) -> int:
+        return int(self.base_env.night)
+
+    def reset(self, seed: Optional[int] = None) -> Dict[str, np.ndarray]:
+        """Reset the wrapped env. Returns the base env's obs dict unchanged."""
+        obs = self.base_env.reset(seed=seed)
+        self._fire_seen = np.zeros(self.num_agents, dtype=bool)
+        return obs
+
+    def step(
+        self, macro_actions: np.ndarray
+    ) -> Tuple[Dict[str, np.ndarray], np.ndarray, np.ndarray, Dict]:
+        """Execute one macro-step.
+
+        Args:
+            macro_actions: Integer array of shape ``(num_agents,)`` or
+                ``(num_agents, 1)``. Each entry is an option index in
+                ``[0, num_options)``. The trainer passes ``[N, A]`` with
+                ``A=1`` (single discrete head); shape ``(N,)`` is also
+                accepted for direct callers.
+
+        Returns:
+            ``(obs, rewards, dones, info)`` matching the base env contract.
+            ``rewards`` is the undiscounted (or discounted) sum across the
+            commit window. ``info["base_steps"]`` reports the actual
+            number of base steps executed within the macro-step (``<=
+            commit_steps``); ``info["primitive_actions"]`` is a list of
+            the ``[N, 3]`` primitive arrays emitted (for tests/debug).
+        """
+        macro_actions = np.asarray(macro_actions)
+        if macro_actions.ndim == 2 and macro_actions.shape[1] == 1:
+            macro_actions = macro_actions[:, 0]
+        if macro_actions.ndim != 1 or macro_actions.shape[0] != self.num_agents:
+            raise ValueError(
+                f"macro_actions must have shape ({self.num_agents},) or "
+                f"({self.num_agents}, 1); got {macro_actions.shape}"
+            )
+        # Validate option indices.
+        bad = (macro_actions < 0) | (macro_actions >= self.num_options)
+        if bad.any():
+            raise ValueError(
+                f"macro_actions contains out-of-range option indices "
+                f"(num_options={self.num_options}): {macro_actions.tolist()}"
+            )
+        macro_actions = macro_actions.astype(np.int64)
+
+        # Reset per-window REST_UNTIL_FIRE state for agents holding that option.
+        # (Agents that are not running REST_UNTIL_FIRE this window will not
+        # consult ``_fire_seen``; resetting for all is cheap and harmless.)
+        self._fire_seen = np.zeros(self.num_agents, dtype=bool)
+
+        # Reward accumulator across the commit window.
+        accumulated_rewards = np.zeros(self.num_agents, dtype=np.float32)
+        primitive_log: List[np.ndarray] = []
+        base_steps_done = 0
+        last_obs: Optional[Dict[str, np.ndarray]] = None
+        last_dones: Optional[np.ndarray] = None
+        last_info: Dict = {}
+
+        for k in range(self.commit_steps):
+            # Update REST_UNTIL_FIRE bookkeeping *before* building the
+            # primitive for this step: if any house is BURNING right now,
+            # REST_UNTIL_FIRE agents should already start PATROL this step.
+            # Also keep ``_fire_seen`` sticky once flipped (so transient
+            # burn-out -> RUINED transitions still leave the seen flag set
+            # for the rest of the window).
+            if np.any(self.base_env.houses == BucketBrigadeEnv.BURNING):
+                self._fire_seen[:] = True
+
+            # Build primitive [N, 3] action from current obs + option indices.
+            primitive = self._build_primitive_actions(macro_actions)
+            primitive_log.append(primitive.copy())
+
+            obs, rewards, dones, info = self.base_env.step(primitive)
+
+            # Accumulate reward (undiscounted by default; discounted optional).
+            if self.discount_gamma is None:
+                accumulated_rewards += rewards.astype(np.float32)
+            else:
+                accumulated_rewards += (self.discount_gamma ** k) * rewards.astype(
+                    np.float32
+                )
+
+            base_steps_done += 1
+            last_obs = obs
+            last_dones = dones
+            last_info = info
+
+            # Also re-check post-step: a fire that ignited via spread or
+            # spontaneous ignition is visible on the next iteration's obs.
+            if np.any(obs["houses"] == BucketBrigadeEnv.BURNING):
+                self._fire_seen[:] = True
+
+            # Early termination: if the base env is done, stop the commit
+            # window here. Remaining option steps are dropped.
+            if bool(np.asarray(dones).any()):
+                break
+
+        # ``last_obs`` is guaranteed set because commit_steps >= 1.
+        assert last_obs is not None and last_dones is not None
+        info_out = dict(last_info)
+        info_out["base_steps"] = base_steps_done
+        info_out["primitive_actions"] = primitive_log
+        return last_obs, accumulated_rewards, last_dones, info_out
+
+    # ------------------------------------------------------------------
+    # Option -> primitive action translation
+    # ------------------------------------------------------------------
+
+    def _build_primitive_actions(self, macro_actions: np.ndarray) -> np.ndarray:
+        """Translate per-agent option indices into a ``[N, 3]`` primitive."""
+        # ``last_actions`` is [N, 2]; ``locations`` is [N]; ``houses`` is [H].
+        last_actions = self.base_env.last_actions  # [N, 2]
+        locations = self.base_env.locations  # [N]
+        houses = self.base_env.houses  # [H]
+        home_positions = self.base_env.agent_home_positions  # [N]
+
+        primitive = np.zeros((self.num_agents, 3), dtype=np.int64)
+
+        for i in range(self.num_agents):
+            opt = int(macro_actions[i])
+            if opt == OPT_PATROL:
+                target = (int(locations[i]) + 1) % self.num_houses
+                mode = (
+                    BucketBrigadeEnv.WORK
+                    if houses[target] == BucketBrigadeEnv.BURNING
+                    else BucketBrigadeEnv.REST
+                )
+                primitive[i, 0] = target
+                primitive[i, 1] = mode
+                primitive[i, 2] = mode  # honest signal mirrors mode bit.
+            elif opt == OPT_DEFEND_OWN:
+                target = int(home_positions[i])
+                # WORK if home or either neighbor is burning, else REST.
+                left = (target - 1) % self.num_houses
+                right = (target + 1) % self.num_houses
+                burning_nearby = (
+                    houses[target] == BucketBrigadeEnv.BURNING
+                    or houses[left] == BucketBrigadeEnv.BURNING
+                    or houses[right] == BucketBrigadeEnv.BURNING
+                )
+                mode = BucketBrigadeEnv.WORK if burning_nearby else BucketBrigadeEnv.REST
+                primitive[i, 0] = target
+                primitive[i, 1] = mode
+                primitive[i, 2] = mode
+            elif opt == OPT_REST_UNTIL_FIRE:
+                if not self._fire_seen[i]:
+                    # No fire observed yet inside this commit window: REST
+                    # at current location.
+                    primitive[i, 0] = int(locations[i])
+                    primitive[i, 1] = BucketBrigadeEnv.REST
+                    primitive[i, 2] = BucketBrigadeEnv.REST
+                else:
+                    # Transitioned to PATROL after first fire was seen.
+                    target = (int(locations[i]) + 1) % self.num_houses
+                    mode = (
+                        BucketBrigadeEnv.WORK
+                        if houses[target] == BucketBrigadeEnv.BURNING
+                        else BucketBrigadeEnv.REST
+                    )
+                    primitive[i, 0] = target
+                    primitive[i, 1] = mode
+                    primitive[i, 2] = mode
+            else:
+                # FOLLOW_j options: bundled in ascending j-order, skipping
+                # self. opt - OPT_FOLLOW_BASE indexes into the (num_agents - 1)
+                # "other agents" list for agent i.
+                j = self._follow_target(agent_i=i, opt=opt)
+                # Copy j's previous primitive [house, mode]; honest signal.
+                target = int(last_actions[j, 0])
+                mode = int(last_actions[j, 1])
+                # Defensive clamps: ``last_actions`` may have out-of-range
+                # entries at the very first step (zeros), which are valid
+                # primitive actions; nothing to do.
+                primitive[i, 0] = target
+                primitive[i, 1] = mode
+                primitive[i, 2] = mode
+
+        return primitive
+
+    # ------------------------------------------------------------------
+    # FOLLOW bundle index <-> target agent
+    # ------------------------------------------------------------------
+
+    def _follow_target(self, agent_i: int, opt: int) -> int:
+        """Resolve a FOLLOW option index to a target agent j (j != i).
+
+        FOLLOW options 3..3+(N-2) bundle the (N-1) other agents in ascending
+        agent-id order, skipping ``agent_i``.
+
+        Example with N=4, agent_i=2:
+          opt=3 -> j=0, opt=4 -> j=1, opt=5 -> j=3
+        """
+        bundle_idx = opt - OPT_FOLLOW_BASE
+        if bundle_idx < 0 or bundle_idx >= self.num_agents - 1:
+            raise ValueError(
+                f"FOLLOW bundle index {bundle_idx} out of range for "
+                f"num_agents={self.num_agents}"
+            )
+        # The bundle skips ``agent_i``. So bundle_idx maps to the
+        # bundle_idx-th element of ``[0..N-1] \ {agent_i}``.
+        j = bundle_idx if bundle_idx < agent_i else bundle_idx + 1
+        return int(j)
+
+    # ------------------------------------------------------------------
+    # Pass-throughs (for callers that probe the env directly)
+    # ------------------------------------------------------------------
+
+    @property
+    def houses(self) -> np.ndarray:
+        return self.base_env.houses
+
+    @property
+    def locations(self) -> np.ndarray:
+        return self.base_env.locations
+
+    @property
+    def signals(self) -> np.ndarray:
+        return self.base_env.signals
+
+    @property
+    def last_actions(self) -> np.ndarray:
+        return self.base_env.last_actions
+
+    @property
+    def agent_home_positions(self) -> np.ndarray:
+        return self.base_env.agent_home_positions
+
+    def render(self) -> None:
+        self.base_env.render()
+
+
+__all__ = [
+    "MacroActionEnv",
+    "OPT_PATROL",
+    "OPT_DEFEND_OWN",
+    "OPT_REST_UNTIL_FIRE",
+    "OPT_FOLLOW_BASE",
+]

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -46,6 +46,7 @@ from bucket_brigade.analysis.info_theory import (
     quantize_uniform,
 )
 from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.macro_action_env import MacroActionEnv
 from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
 from bucket_brigade.training.joint_trainer import (
     JointPPOTrainer,
@@ -147,6 +148,14 @@ class CellConfig:
     # misalignment source — see
     # ``research_notebook/2026-05-17_thesis_misaligned_gradients.md``).
     gae_lambda: float = 0.95
+    # Issue #286: macro-action wrapper. When ``macro_actions=True`` the
+    # env_fn returns a :class:`MacroActionEnv` instead of a raw
+    # :class:`BucketBrigadeEnv`, the action space collapses to a single
+    # ``Discrete(num_options)`` head, and the trainer is constructed with
+    # ``action_dims=[num_options]`` instead of ``[10, 2, 2]``. Default
+    # ``False`` preserves bit-identical pre-#286 behavior.
+    macro_actions: bool = False
+    commit_steps: int = 3
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -279,12 +288,16 @@ def _other_agent_action_codes(rollout, agent_j: int, lag: int = 1) -> np.ndarray
         packed = (
             a[:, 0] * _ACTION_PACK_BASE + a[:, 1] * _ACTION_PACK_BASE_SIGNAL + a[:, 2]
         ).astype(np.int64)
-    else:
+    elif a.shape[-1] == 2:
         # Legacy 2-element actions (pre-#235): pretend the agent was honest
         # (signal == mode) so the packed code remains well-defined.
         packed = (
             a[:, 0] * _ACTION_PACK_BASE + a[:, 1] * _ACTION_PACK_BASE_SIGNAL + a[:, 1]
         ).astype(np.int64)
+    else:
+        # Issue #286: single-column macro-action — option index is already a
+        # well-defined scalar label. Use it directly as the packed code.
+        packed = a[:, 0].astype(np.int64)
     T = packed.shape[0]
     codes = np.full(T, _ACTION_NO_PRIOR_SENTINEL, dtype=np.int64)
     if T > lag:
@@ -524,12 +537,16 @@ def _measure_information(
                 + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
                 + a[:, 2]
             )
-        else:
+        elif a.shape[-1] == 2:
             packed = (
                 a[:, 0] * _ACTION_PACK_BASE
                 + a[:, 1] * _ACTION_PACK_BASE_SIGNAL
                 + a[:, 1]
             )
+        else:
+            # Issue #286: single-column macro-action — option index serves
+            # as the packed action code directly.
+            packed = a[:, 0].astype(np.int64)
         out[f"action_entropy/agent_{i}"] = entropy_discrete(packed)
     out["action_entropy/mean"] = float(
         np.mean([out[f"action_entropy/agent_{i}"] for i in range(n)])
@@ -670,9 +687,20 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
     scenario.team_welfare_gamma = float(cfg.team_welfare_gamma)
     scenario.team_welfare_kind = str(cfg.team_welfare_kind)
 
-    def env_fn():
-        env = BucketBrigadeEnv(scenario=scenario)
-        return env
+    # Issue #286: when macro_actions is on, wrap the base env in
+    # ``MacroActionEnv``. The wrapper preserves the dict-obs / numpy-action
+    # contract so it is a drop-in for ``JointPPOTrainer.env_fn``; only
+    # ``action_dims`` changes (collapses to ``[num_options]``).
+    if cfg.macro_actions:
+
+        def env_fn():
+            base = BucketBrigadeEnv(scenario=scenario)
+            return MacroActionEnv(base, commit_steps=cfg.commit_steps)
+    else:
+
+        def env_fn():
+            env = BucketBrigadeEnv(scenario=scenario)
+            return env
 
     # Probe obs_dim from a single reset. Issue #204: include the per-agent
     # identity one-hot tail so obs_dim matches what JointPPOTrainer actually
@@ -683,11 +711,22 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         0
     ]
 
+    # Issue #286: action_dims comes from the wrapper when macro-actions are
+    # on (single Discrete head with num_options values); otherwise use the
+    # configured ``cfg.action_dims`` (default ``[num_houses, 2, 2]``).
+    # Mutate ``cfg.action_dims`` to the runtime value so the on-disk
+    # ``config.json`` reflects what the trainer actually saw.
+    if cfg.macro_actions:
+        action_dims = [int(probe.num_options)]
+        cfg.action_dims = action_dims
+    else:
+        action_dims = cfg.action_dims
+
     trainer = JointPPOTrainer(
         env_fn=env_fn,
         num_agents=cfg.num_agents,
         obs_dim=obs_dim,
-        action_dims=cfg.action_dims,
+        action_dims=action_dims,
         hidden_size=cfg.hidden_size,
         lr=cfg.lr,
         gae_lambda=cfg.gae_lambda,
@@ -996,6 +1035,28 @@ def main() -> None:
             "bootstrap)."
         ),
     )
+    p.add_argument(
+        "--macro-actions",
+        action="store_true",
+        help=(
+            "Issue #286: wrap the env in MacroActionEnv. Action space "
+            "becomes a single Discrete head over 3+(num_agents-1) options "
+            "(PATROL, DEFEND_OWN, REST_UNTIL_FIRE, FOLLOW_j). Each option "
+            "commits the agent for --commit-steps base steps (or until "
+            "env-done). Default off preserves bit-identical pre-#286 "
+            "behavior."
+        ),
+    )
+    p.add_argument(
+        "--commit-steps",
+        type=int,
+        default=CellConfig.__dataclass_fields__["commit_steps"].default,
+        help=(
+            "Issue #286: number of base-env steps each macro-action commits "
+            "to (subject to early termination on env-done). Only used when "
+            "--macro-actions is set. Default 3. Sweep grid is {3, 5, 8}."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -1021,6 +1082,8 @@ def main() -> None:
         team_welfare_kind=args.team_welfare_kind,
         bc_init_checkpoint_dir=args.bc_init_checkpoint_dir,
         gae_lambda=args.gae_lambda,
+        macro_actions=args.macro_actions,
+        commit_steps=args.commit_steps,
         device=args.device,
     )
     print(
@@ -1031,7 +1094,8 @@ def main() -> None:
         f"action_shaping_beta={cfg.action_shaping_beta} "
         f"progress_shaping_coef={cfg.progress_shaping_coef} "
         f"team_welfare_lambda={cfg.team_welfare_lambda} "
-        f"team_welfare_kind={cfg.team_welfare_kind} =="
+        f"team_welfare_kind={cfg.team_welfare_kind} "
+        f"macro_actions={cfg.macro_actions} commit_steps={cfg.commit_steps} =="
     )
     train_one_cell(cfg, args.output_dir)
 

--- a/tests/test_macro_action_env.py
+++ b/tests/test_macro_action_env.py
@@ -1,0 +1,330 @@
+"""Tests for the MacroActionEnv wrapper (issue #286).
+
+The wrapper coarsens the decision frequency by committing each agent to a
+multi-step option (PATROL, DEFEND_OWN, REST_UNTIL_FIRE, FOLLOW_j) for
+``commit_steps`` base-env steps. These tests verify the contract,
+per-option primitive semantics, reward accumulation, and edge cases.
+"""
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from bucket_brigade.envs import (
+    BucketBrigadeEnv,
+    MacroActionEnv,
+    OPT_DEFEND_OWN,
+    OPT_FOLLOW_BASE,
+    OPT_PATROL,
+    OPT_REST_UNTIL_FIRE,
+    trivial_cooperation_scenario,
+)
+from bucket_brigade.envs.scenarios_generated import minimal_specialization_scenario
+
+
+def _make_env(num_agents: int = 4, commit_steps: int = 3) -> MacroActionEnv:
+    scenario = minimal_specialization_scenario(num_agents=num_agents)
+    base = BucketBrigadeEnv(scenario=scenario)
+    return MacroActionEnv(base, commit_steps=commit_steps)
+
+
+def _make_env_no_fire(num_agents: int = 4, commit_steps: int = 3) -> MacroActionEnv:
+    """Build an env with ignition probability zeroed out (for REST_UNTIL_FIRE)."""
+    scenario = minimal_specialization_scenario(num_agents=num_agents)
+    scenario = dataclasses.replace(scenario, prob_house_catches_fire=0.0)
+    base = BucketBrigadeEnv(scenario=scenario)
+    return MacroActionEnv(base, commit_steps=commit_steps)
+
+
+class TestMacroActionEnvContract:
+    """Wrapper preserves the BucketBrigadeEnv contract."""
+
+    def test_step_contract_matches_base(self):
+        env = _make_env(num_agents=4, commit_steps=3)
+        obs = env.reset(seed=42)
+
+        # Same obs dict structure as BucketBrigadeEnv.
+        for key in ("signals", "locations", "houses", "last_actions", "scenario_info"):
+            assert key in obs, f"missing obs key: {key}"
+        assert obs["signals"].shape == (4,)
+        assert obs["locations"].shape == (4,)
+        assert obs["houses"].shape == (env.num_houses,)
+        assert obs["last_actions"].shape == (4, 2)
+
+        # Step with all PATROL.
+        macro_actions = np.zeros(4, dtype=np.int64)  # OPT_PATROL
+        obs2, rewards, dones, info = env.step(macro_actions)
+
+        # Return shapes match the base env.
+        assert rewards.shape == (4,)
+        assert dones.shape == (4,)
+        assert isinstance(info, dict)
+        assert "base_steps" in info
+        assert info["base_steps"] <= 3
+        # The base env returns one boolean for done broadcast across agents
+        # so all four entries agree.
+        assert bool(dones[0]) == bool(dones[1]) == bool(dones[2]) == bool(dones[3])
+
+    def test_accepts_2d_macro_action_shape(self):
+        """Trainer passes ``[N, 1]`` for a single Discrete head — accept it."""
+        env = _make_env(num_agents=4, commit_steps=2)
+        env.reset(seed=0)
+        macro_actions = np.zeros((4, 1), dtype=np.int64)  # all PATROL
+        obs, rewards, dones, info = env.step(macro_actions)
+        assert rewards.shape == (4,)
+
+    def test_action_space_size(self):
+        env = _make_env(num_agents=4)
+        # num_options = 3 + (num_agents - 1) = 3 + 3 = 6.
+        assert env.num_options == 6
+
+
+class TestPatrolOption:
+    def test_patrol_advances_position(self):
+        """After PATROL for N=3 steps, location = (start + 3) mod num_houses."""
+        env = _make_env(num_agents=4, commit_steps=3)
+        env.reset(seed=42)
+        start_locations = env.locations.copy()
+
+        macro_actions = np.full(4, OPT_PATROL, dtype=np.int64)
+        _, _, _, info = env.step(macro_actions)
+
+        # If the episode early-terminated, base_steps may be < commit_steps;
+        # use that as the ground truth for the position advance.
+        n_steps = int(info["base_steps"])
+        expected = (start_locations.astype(np.int64) + n_steps) % env.num_houses
+        np.testing.assert_array_equal(env.locations, expected.astype(np.int8))
+
+
+class TestDefendOwnOption:
+    def test_defend_own_parks_at_home(self):
+        """DEFEND_OWN sets target house to agent_home_positions[i] every step."""
+        env = _make_env(num_agents=4, commit_steps=3)
+        env.reset(seed=42)
+        home_positions = env.agent_home_positions.copy()
+
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        _, _, _, info = env.step(macro_actions)
+
+        # After the macro-step, every agent's location should be its home.
+        np.testing.assert_array_equal(env.locations, home_positions.astype(np.int8))
+
+        # Each primitive action emitted should also park at home.
+        for prim in info["primitive_actions"]:
+            np.testing.assert_array_equal(prim[:, 0], home_positions.astype(np.int64))
+
+
+class TestRestUntilFireOption:
+    def test_rest_until_fire_stays_rest_with_no_fires(self):
+        """With prob_house_catches_fire=0 and no initial fires, REST_UNTIL_FIRE
+        emits only REST primitives."""
+        env = _make_env_no_fire(num_agents=4, commit_steps=3)
+        env.reset(seed=42)
+
+        # Sanity: no houses are burning at the start of the window.
+        # (The wrapper checks burning *after* the first base step, but
+        # ignition probability is zero so this stays the case.)
+        assert not np.any(env.houses == BucketBrigadeEnv.BURNING)
+
+        macro_actions = np.full(4, OPT_REST_UNTIL_FIRE, dtype=np.int64)
+        _, _, _, info = env.step(macro_actions)
+
+        # Every primitive emitted should have mode=REST (=0).
+        for prim in info["primitive_actions"]:
+            np.testing.assert_array_equal(
+                prim[:, 1], np.zeros(env.num_agents, dtype=np.int64)
+            )
+
+    def test_rest_until_fire_transitions_to_patrol(self):
+        """When a fire is visible at the start of a step, REST_UNTIL_FIRE
+        switches to the PATROL primitive (target = (loc+1) % H) for the
+        remainder of the commit window."""
+        env = _make_env_no_fire(num_agents=4, commit_steps=4)
+        env.reset(seed=42)
+
+        # Force-inject a fire BEFORE the first step. The wrapper checks
+        # ``base_env.houses`` for BURNING *before* building each primitive,
+        # so step 0 should already emit the PATROL primitive.
+        env.base_env.houses[0] = BucketBrigadeEnv.BURNING
+
+        macro_actions = np.full(4, OPT_REST_UNTIL_FIRE, dtype=np.int64)
+        _, _, _, info = env.step(macro_actions)
+
+        prims = info["primitive_actions"]
+        # Step 0 must use the PATROL branch: target = (loc+1) % H. Initial
+        # loc is 0, so target = 1.
+        assert np.all(prims[0][:, 0] == 1), (
+            f"Expected PATROL target=(loc+1)%H=1 on step 0, got {prims[0][:, 0]}"
+        )
+
+        # Sticky: the fire-seen flag stays True after burn-out. Even after
+        # house 0 -> RUINED, subsequent steps still PATROL.
+        if len(prims) >= 2:
+            # After step 0, agents are at location 1. Step 1's PATROL
+            # target = (1 + 1) % H = 2.
+            assert np.all(prims[1][:, 0] == 2), (
+                f"Expected PATROL target=2 on step 1, got {prims[1][:, 0]}"
+            )
+
+
+class TestFollowOption:
+    def test_follow_copies_target_primitive_action(self):
+        """FOLLOW_j emits obs['last_actions'][j] as its primitive [house, mode]."""
+        env = _make_env(num_agents=4, commit_steps=2)
+        env.reset(seed=42)
+
+        # Drive one base step directly to seed last_actions with non-zero values.
+        # Use the base env: agent 0 -> house 3 work, agent 1 -> house 5 rest, etc.
+        seed_primitive = np.array(
+            [
+                [3, BucketBrigadeEnv.WORK, BucketBrigadeEnv.WORK],
+                [5, BucketBrigadeEnv.REST, BucketBrigadeEnv.REST],
+                [7, BucketBrigadeEnv.WORK, BucketBrigadeEnv.WORK],
+                [9, BucketBrigadeEnv.REST, BucketBrigadeEnv.REST],
+            ],
+            dtype=np.int64,
+        )
+        env.base_env.step(seed_primitive)
+
+        # Now ask agent 0 to FOLLOW agent 1 (j=1). bundle_idx = 1 for agent 0
+        # because the FOLLOW bundle for agent 0 lists [1, 2, 3] -> opts [3, 4, 5].
+        # So FOLLOW_1 from agent 0 is opt = OPT_FOLLOW_BASE + 0 = 3? No:
+        # bundle[0] = agent 1 -> opt 3. bundle[1] = agent 2 -> opt 4.
+        # bundle[2] = agent 3 -> opt 5. So FOLLOW_1 from agent 0 = opt 3.
+        follow_1_from_0 = OPT_FOLLOW_BASE + 0  # agent 1 is bundle index 0
+
+        macro_actions = np.array(
+            [follow_1_from_0, OPT_PATROL, OPT_PATROL, OPT_PATROL],
+            dtype=np.int64,
+        )
+        _, _, _, info = env.step(macro_actions)
+
+        # First primitive emitted by agent 0 should equal agent 1's seeded
+        # last_action: [house=5, mode=REST, signal=REST].
+        first_prim = info["primitive_actions"][0]
+        assert int(first_prim[0, 0]) == 5
+        assert int(first_prim[0, 1]) == int(BucketBrigadeEnv.REST)
+
+    def test_follow_skips_self(self):
+        """FOLLOW bundle for agent i never targets j == i."""
+        env = _make_env(num_agents=4)
+        # For agent 2, the bundle is [agent 0, agent 1, agent 3] (skipping self).
+        # opt 3 -> j=0, opt 4 -> j=1, opt 5 -> j=3.
+        assert env._follow_target(agent_i=2, opt=OPT_FOLLOW_BASE + 0) == 0
+        assert env._follow_target(agent_i=2, opt=OPT_FOLLOW_BASE + 1) == 1
+        assert env._follow_target(agent_i=2, opt=OPT_FOLLOW_BASE + 2) == 3
+        # And for agent 0, the bundle is [1, 2, 3].
+        assert env._follow_target(agent_i=0, opt=OPT_FOLLOW_BASE + 0) == 1
+        assert env._follow_target(agent_i=0, opt=OPT_FOLLOW_BASE + 2) == 3
+
+
+class TestRewardAggregation:
+    def test_reward_aggregation_undiscounted(self):
+        """Macro-step reward equals the sum of per-base-step rewards over the
+        commit window.
+
+        Compare against driving ``BucketBrigadeEnv`` directly with the same
+        primitive sequence the wrapper emits."""
+        # Wrapper-driven rollout.
+        env_w = _make_env(num_agents=4, commit_steps=3)
+        env_w.reset(seed=123)
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        _, macro_rewards, _, info = env_w.step(macro_actions)
+        primitives = info["primitive_actions"]
+        n_steps = info["base_steps"]
+
+        # Replay the same primitive sequence against a freshly-seeded base env.
+        scenario = minimal_specialization_scenario(num_agents=4)
+        base = BucketBrigadeEnv(scenario=scenario)
+        base.reset(seed=123)
+        sum_rewards = np.zeros(4, dtype=np.float32)
+        for k in range(n_steps):
+            _, rewards, _, _ = base.step(primitives[k])
+            sum_rewards += rewards.astype(np.float32)
+
+        np.testing.assert_allclose(macro_rewards, sum_rewards, atol=1e-5)
+
+
+class TestEarlyTermination:
+    def test_early_termination_done_short_circuits(self):
+        """If base env terminates at step k < commit_steps, macro-step returns
+        at that boundary with dones=True."""
+        # Trivial cooperation scenario terminates fast with all-fire / all-safe.
+        # Force termination by using min_nights=1 via dataclasses.replace.
+        scenario = trivial_cooperation_scenario(num_agents=4)
+        scenario = dataclasses.replace(scenario, min_nights=1)
+        base = BucketBrigadeEnv(scenario=scenario)
+        env = MacroActionEnv(base, commit_steps=20)
+        env.reset(seed=42)
+
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        _, _, dones, info = env.step(macro_actions)
+
+        # With commit_steps=20 and short min_nights, episode must end
+        # before the window closes — wrapper short-circuits.
+        assert info["base_steps"] < 20
+        assert bool(dones.any())
+
+    def test_commit_steps_one_collapses_to_primitive_behavior(self):
+        """commit_steps=1 means each macro-action is exactly one base step."""
+        env = _make_env(num_agents=4, commit_steps=1)
+        env.reset(seed=7)
+        macro_actions = np.full(4, OPT_PATROL, dtype=np.int64)
+        _, _, _, info = env.step(macro_actions)
+        assert info["base_steps"] == 1
+        assert len(info["primitive_actions"]) == 1
+
+
+class TestEdgeCases:
+    def test_invalid_option_raises(self):
+        env = _make_env(num_agents=4, commit_steps=3)
+        env.reset(seed=0)
+        # num_options=6 for N=4, so 6 is out of range.
+        bad = np.array([6, 0, 0, 0], dtype=np.int64)
+        with pytest.raises(ValueError):
+            env.step(bad)
+
+    def test_commit_steps_must_be_positive(self):
+        base = BucketBrigadeEnv(scenario=minimal_specialization_scenario(num_agents=4))
+        with pytest.raises(ValueError):
+            MacroActionEnv(base, commit_steps=0)
+
+    def test_commit_steps_exceeds_min_nights_no_state_leak(self):
+        """Episode ends mid-commit; verify no IndexError and _prev_houses_state
+        is reset cleanly across reset (regression check for
+        bucket_brigade_env.py:130-132)."""
+        scenario = minimal_specialization_scenario(num_agents=4)
+        scenario = dataclasses.replace(scenario, min_nights=2)
+        base = BucketBrigadeEnv(scenario=scenario)
+        env = MacroActionEnv(base, commit_steps=30)
+
+        # Run several macro-steps with auto-resets to check state hygiene.
+        env.reset(seed=42)
+        for _ in range(3):
+            macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+            _, _, dones, _ = env.step(macro_actions)
+            if bool(dones.any()):
+                env.reset()  # caller-driven auto-reset
+                # After reset, _prev_houses_state must be all zeros (no stale
+                # RUINED bits leaking from the prior episode).
+                assert np.all(env.base_env._prev_houses_state == 0)
+
+
+class TestSmokeRollout:
+    def test_smoke_rollout(self):
+        """Instantiate env via wrapper, step a few rollouts, sanity-check."""
+        env = _make_env(num_agents=4, commit_steps=3)
+        obs = env.reset(seed=42)
+        assert obs is not None
+
+        rng = np.random.RandomState(0)
+        for _ in range(10):
+            # Sample a random option per agent.
+            macro_actions = rng.randint(0, env.num_options, size=4).astype(np.int64)
+            obs, rewards, dones, info = env.step(macro_actions)
+            assert rewards.shape == (4,)
+            assert dones.shape == (4,)
+            assert 1 <= info["base_steps"] <= 3
+            if bool(dones.any()):
+                env.reset()


### PR DESCRIPTION
## Summary

Adds `MacroActionEnv`: a drop-in wrapper around `BucketBrigadeEnv` that
coarsens the decision frequency from per-step to per-N-step. Each agent
commits to a single discrete option (PATROL, DEFEND_OWN, REST_UNTIL_FIRE,
FOLLOW_j) for `commit_steps` base-env steps. Implements intervention #4
from the misaligned-gradients thesis as a structural env-side change.

## Changes

- New `bucket_brigade/envs/macro_action_env.py` — `MacroActionEnv` class
  exposing the same `reset()` / `step(actions)` contract as
  `BucketBrigadeEnv`. Option set: `[PATROL, DEFEND_OWN, REST_UNTIL_FIRE,
  FOLLOW_0, ..., FOLLOW_{N-1}\{self}]` with `num_options = 3 + (N - 1)`.
- Reward accumulation: undiscounted sum over the commit window
  (discounted optional via `discount_gamma`).
- `bucket_brigade/envs/__init__.py` — re-export `MacroActionEnv` and the
  option-index constants.
- `experiments/p3_specialization/train.py` — `--macro-actions` and
  `--commit-steps` CLI flags; `env_fn` returns `MacroActionEnv` when
  enabled; `action_dims=[num_options]` probed from the wrapper; mirror
  back into `cfg.action_dims` so `config.json` records the runtime
  value. Defensive single-column packed-action path in
  `_other_agent_action_codes` and `action_entropy`.
- New `tests/test_macro_action_env.py` — 16 unit + smoke tests covering
  per-option primitive semantics, reward aggregation, early termination,
  edge cases, and a randomized rollout smoke test.

Zero trainer changes — `JointPPOTrainer` already accepts arbitrary
`action_dims`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Wrapper at `BucketBrigadeEnv` level (not Gym) | yes | `MacroActionEnv` wraps, exposes same dict-obs/numpy-action contract |
| 4 options w/ primitive semantics + early term | yes | `OPT_PATROL/DEFEND_OWN/REST_UNTIL_FIRE/FOLLOW_j` in `macro_action_env.py`; per-option unit tests pass |
| `commit_steps` configurable; default N=3 | yes | constructor arg + CLI flag; default 3 |
| Reward accumulation undiscounted | yes | `test_reward_aggregation_undiscounted` |
| Zero changes to `JointPPOTrainer` | yes | no edits in `bucket_brigade/training/joint_trainer.py` |
| `action_dims=[num_options]` | yes | probed from wrapper in `train_one_cell` |
| `env_fn` integration in `train.py` | yes | `train.py:628-642` |
| `_prev_houses_state` reset hygiene | yes | `test_commit_steps_exceeds_min_nights_no_state_leak` |
| Unit tests (8+ per Test Plan) | yes | 16 tests in `test_macro_action_env.py` |

## Test Plan

- [x] `pytest tests/test_macro_action_env.py` — 16/16 passed
- [x] `pytest tests/test_environment.py tests/test_joint_trainer.py` —
  82/82 passed (no regression)
- [x] Local smoke training: 2 iters with `--macro-actions --commit-steps
  3 --rollout-steps 128` on `minimal_specialization` — completed in <60s,
  `metrics.json` well-formed, `config.json` records `action_dims=[6]`
- [x] Local primitive-action baseline smoke — also completes cleanly
  (no regression in the non-macro code path)
- [ ] Full multi-cell sweep on `$COMPUTE_HOST_PRIMARY` (deferred per
  user instructions; this PR is implementation + smoke tests only)

Closes #286