### PR TITLE
feat(p3): dense Δsafe progress shaping (#265 intervention #4)

### DIFF
--- a/bucket-brigade-core/src/engine/rewards.rs
+++ b/bucket-brigade-core/src/engine/rewards.rs
@@ -24,8 +24,23 @@ impl BucketBrigade {
         let total_burned_fraction = ruined_houses / num_houses_f;
 
         // Team reward component (shared by all, public goods)
-        let team_reward = self.scenario.team_reward_house_survives * total_saved_fraction
+        let mut team_reward = self.scenario.team_reward_house_survives * total_saved_fraction
             - self.scenario.team_penalty_house_burns * total_burned_fraction;
+
+        // Issue #265: dense progress shaping. Per-step team-shared bonus
+        // proportional to the change in the number of SAFE houses since
+        // the previous step. ``progress_shaping_coef`` defaults to 0.0 on
+        // every pre-#265 scenario, so this block is a no-op (preserving
+        // bit-exact behavior). When non-zero, the team component picks up
+        // ``coef * (cur_safe - prev_safe)`` and is broadcast to all agents
+        // via the per-agent ``rewards[i] += team_reward`` line below.
+        // Mirrors ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards``.
+        let progress_coef = self.scenario.progress_shaping_coef;
+        if progress_coef != 0.0 {
+            let prev_safe = prev_houses.iter().filter(|&&h| h == 0).count() as f32;
+            let cur_safe = saved_houses;
+            team_reward += progress_coef * (cur_safe - prev_safe);
+        }
 
         for agent_idx in 0..self.num_agents {
             // 1. Work/rest component.

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -1220,6 +1220,9 @@ mod proptests {
                 // invariants (which assume pre-#259 reward semantics) hold.
                 action_shaping_alpha: 0.0,
                 action_shaping_beta: 0.0,
+                // Issue #265: progress shaping off so the existing proptest
+                // invariants (which assume pre-#265 reward semantics) hold.
+                progress_shaping_coef: 0.0,
             };
 
             let mut engine = BucketBrigade::new(scenario, 4, Some(42));

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -105,6 +105,7 @@ impl PyScenario {
         reward_other_house_survives,
         penalty_own_house_burns,
         penalty_other_house_burns,
+        progress_shaping_coef = 0.0_f32,
     ))]
     fn new(
         prob_fire_spreads_to_neighbor: f32,
@@ -118,6 +119,7 @@ impl PyScenario {
         reward_other_house_survives: PyObject,
         penalty_own_house_burns: PyObject,
         penalty_other_house_burns: PyObject,
+        progress_shaping_coef: f32,
         py: Python,
     ) -> PyResult<Self> {
         // Scalar -> vec![v; 10] auto-promotion (mirrors the Python
@@ -163,6 +165,12 @@ impl PyScenario {
             // existing PyScenario callers see byte-identical rewards).
             action_shaping_alpha: 0.0,
             action_shaping_beta: 0.0,
+            // Issue #265: dense progress shaping coefficient. Exposed as an
+            // optional kwarg with default ``0.0`` so existing PyScenario
+            // callers (which pass only positional args) are byte-identical
+            // to the pre-#265 path. Non-zero values flow through to the
+            // engine's progress-shaping block in ``engine/rewards.rs``.
+            progress_shaping_coef,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator. The literal above is safe today but the helper keeps the
@@ -274,6 +282,17 @@ impl PyScenario {
     #[getter]
     fn action_shaping_beta(&self) -> f32 {
         self.inner.action_shaping_beta
+    }
+
+    /// Issue #265: dense progress shaping coefficient. Defaults to ``0.0``
+    /// so every pre-#265 scenario is bit-exactly preserved. When non-zero,
+    /// the per-step team reward picks up ``coef * (cur_safe - prev_safe)``,
+    /// giving PPO a dense gradient signal on save/burn transition steps.
+    /// To use this knob from Python, prefer the ``Scenario`` dataclass or
+    /// pull from ``bucket_brigade_core.SCENARIOS[...]`` (JSON path).
+    #[getter]
+    fn progress_shaping_coef(&self) -> f32 {
+        self.inner.progress_shaping_coef
     }
 }
 

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -81,6 +81,16 @@ fn default_action_shaping_beta() -> f32 {
     0.0
 }
 
+/// Default for `Scenario::progress_shaping_coef`. Zero preserves bit-exact
+/// backward compatibility with pre-#265 behavior (no dense progress shaping
+/// term added to the per-step team reward). When non-zero, the team reward
+/// each step gains `coef * (cur_safe - prev_safe)`, which gives PPO a dense
+/// per-step gradient signal on save/burn transitions without changing the
+/// long-horizon optimum. See `engine/rewards.rs` for the implementation.
+fn default_progress_shaping_coef() -> f32 {
+    0.0
+}
+
 /// Allowed values for `Scenario::distance_metric`.
 ///
 /// `engine/rewards.rs` currently consumes `distance_cost_alpha + ring_dist_10(...)`
@@ -210,6 +220,25 @@ pub struct Scenario {
     pub action_shaping_alpha: f32,
     #[serde(default = "default_action_shaping_beta")]
     pub action_shaping_beta: f32,
+
+    // Dense progress shaping (issue #265, optional, additive).
+    //
+    // Defaults to `0.0` so every pre-#265 scenario is bit-exactly
+    // preserved (the engine takes a fast-path skip when this knob is zero;
+    // see `engine/rewards.rs`).
+    //
+    // When non-zero, the per-step team reward picks up
+    // `coef * (cur_safe - prev_safe)`, which gives PPO a dense gradient
+    // signal on save/burn transition steps. The long-horizon optimum is
+    // not changed: the integral of `(cur_safe - prev_safe)` over an
+    // episode equals net houses saved, which the team reward already
+    // captures via `team_reward_house_survives * saved_fraction`.
+    //
+    // This is *state-difference* shaping (not potential-based / NHR);
+    // policy invariance is not guaranteed in general. Issue #283 covers
+    // the potential-based variant explicitly.
+    #[serde(default = "default_progress_shaping_coef")]
+    pub progress_shaping_coef: f32,
 }
 
 impl Scenario {
@@ -282,6 +311,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -305,6 +335,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -328,6 +359,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -352,6 +384,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -375,6 +408,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -398,6 +432,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -421,6 +456,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -444,6 +480,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -467,6 +504,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -490,6 +528,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -513,6 +552,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -536,6 +576,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -566,6 +607,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -595,6 +637,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -627,6 +670,7 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             num_houses: 2,
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         },
     );
 
@@ -1199,6 +1243,7 @@ mod tests {
             num_houses: default_num_houses(),
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
+            progress_shaping_coef: default_progress_shaping_coef(),
         };
         let err = scenario
             .validate()

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -172,6 +172,10 @@ impl WasmScenario {
             // fields.
             action_shaping_alpha: 0.0,
             action_shaping_beta: 0.0,
+            // Issue #265: dense progress shaping defaults to off so existing
+            // JS/TS callers see byte-identical rewards. Routed through the
+            // JSON path (``Scenario::to_json`` / ``from_json``) when non-zero.
+            progress_shaping_coef: 0.0,
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator so future kwargs additions can't reintroduce silent

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -316,6 +316,20 @@ class BucketBrigadeEnv:
             - self.scenario.team_penalty_house_burns * total_burned_fraction
         )
 
+        # Issue #265: dense progress shaping. Per-step team-shared bonus
+        # proportional to the change in the number of SAFE houses since
+        # the previous step. ``progress_shaping_coef`` defaults to 0.0 on
+        # every pre-#265 scenario, so this block is a no-op (preserving
+        # bit-exact behavior). When non-zero, the team component picks up
+        # ``coef * (cur_safe - prev_safe)`` and is broadcast to all agents
+        # via the per-agent ``individual_rewards[i] += team_reward`` line
+        # below. Mirrors ``bucket-brigade-core/src/engine/rewards.rs``.
+        progress_coef = float(getattr(self.scenario, "progress_shaping_coef", 0.0))
+        if progress_coef != 0.0:
+            prev_safe = int(np.sum(prev_houses == self.SAFE))
+            cur_safe = int(saved_houses)
+            team_reward += progress_coef * float(cur_safe - prev_safe)
+
         # Individual rewards
         individual_rewards = np.zeros(self.num_agents, dtype=np.float32)
 

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -99,6 +99,20 @@ class Scenario:
     action_shaping_alpha: float = 0.0
     action_shaping_beta: float = 0.0
 
+    # Dense progress shaping (issue #265, optional, additive). Per-step
+    # team-shared reward bonus proportional to the change in the number of
+    # SAFE houses between the previous step and the current step:
+    #
+    #     team_reward += progress_shaping_coef * (cur_safe - prev_safe)
+    #
+    # Defaults to ``0.0`` so every pre-#265 scenario is bit-exactly
+    # preserved (the env takes a fast-path skip when this knob is zero).
+    # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards``
+    # and ``bucket-brigade-core/src/engine/rewards.rs`` for the canonical
+    # implementation. Sequenced before potential-based shaping (#283) as
+    # the cheap mechanical test of the dense-team-signal hypothesis.
+    progress_shaping_coef: float = 0.0
+
     def __post_init__(self) -> None:
         """Auto-promote scalar ownership reward fields to per-agent vectors.
 

--- a/experiments/p3_specialization/analyze_265.py
+++ b/experiments/p3_specialization/analyze_265.py
@@ -1,0 +1,266 @@
+"""Analysis for issue #265 — dense Δsafe progress shaping smoke test.
+
+Reads per-cell ``metrics.json`` files under
+
+    experiments/p3_specialization/runs/issue265_progress_signal/coef_<COEF>/seed_<SEED>/
+
+where ``<COEF>`` in ``{0.0, 1.0, 5.0, 25.0}`` and ``<SEED>`` in ``{42, 43, 44}``.
+Emits a markdown + JSON summary under
+
+    experiments/p3_specialization/diagnostics/results/issue265_progress_signal/
+
+Pre-registered 3-tier verdict ladder (per the curator enrichment on #265):
+
+* ``gap_closed`` reported for each non-zero ``coef`` (mean across seeds):
+    - **Tier 1 (success)**: ``gap_closed >= 0.25`` at any ``coef > 0``.
+      Promote to fuller sweep / additional scenarios.
+    - **Tier 2 (partial)**: ``0.10 <= gap_closed < 0.25`` (best
+      non-zero coef).  Layer with action-shaping (#262) or curriculum
+      and re-test.
+    - **Tier 3 (failed)**: ``gap_closed < 0.10`` for every cell.
+      File follow-up: "dense Δsafe shaping unhelpful — escalate to
+      potential-based shaping (#283) for policy-invariant aligned signal".
+
+``gap_closed = (mean_team_reward - random_ref) / (specialist_ref - random_ref)``,
+using the published ``minimal_specialization`` references from #260's verdict:
+random=-92.921, specialist=-22.072, gap=+70.850.
+
+Usage::
+
+    uv run python experiments/p3_specialization/analyze_265.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+# Pre-registered coefficient grid (mirrors run_issue265_progress_sweep.sh).
+COEFS = [0.0, 1.0, 5.0, 25.0]
+SEEDS = [42, 43, 44]
+TRAILING_N = 5
+SCENARIO = "minimal_specialization"
+
+# Per-step (random, specialist) team-reward references for
+# ``minimal_specialization`` (sourced from
+# ``experiments/p3_specialization/diagnostics/results/issue260_curriculum/summary.md``).
+RANDOM_REF = -92.92147252747253
+SPECIALIST_REF = -22.07174358974359
+SPEC_RAND_GAP = SPECIALIST_REF - RANDOM_REF  # ≈ +70.85
+
+# Verdict thresholds (per #265 issue body).
+TIER_1_THRESHOLD = 0.25  # >= => clear win (any non-zero coef)
+TIER_2_THRESHOLD = 0.10  # >= => partial (best non-zero coef)
+
+
+def _coef_dir_name(coef: float) -> str:
+    # Match the directory layout emitted by ``run_issue265_progress_sweep.sh``,
+    # which interpolates the bash array value (e.g. ``0.0`` or ``25.0``).
+    return f"coef_{coef}"
+
+
+def _cell_dir(root: Path, coef: float, seed: int) -> Path:
+    return root / "issue265_progress_signal" / _coef_dir_name(coef) / f"seed_{seed}"
+
+
+def _trailing_team(metrics: List[dict], n: int = TRAILING_N) -> float:
+    rewards = [row["mean_step_reward_team"] for row in metrics]
+    tail = rewards[-n:] if len(rewards) >= n else rewards
+    return float(np.mean(tail))
+
+
+def load_cell(cell: Path) -> Optional[dict]:
+    mfile = cell / "metrics.json"
+    if not mfile.exists():
+        return None
+    metrics = json.loads(mfile.read_text())
+    return {
+        "cell": str(cell),
+        "trailing5_team_reward": _trailing_team(metrics),
+        "final_iter": len(metrics) - 1,
+        "final_team_reward": float(metrics[-1]["mean_step_reward_team"]),
+    }
+
+
+def gap_closed(per_step: float) -> float:
+    return (per_step - RANDOM_REF) / SPEC_RAND_GAP
+
+
+def aggregate_coef(root: Path, coef: float) -> Dict[str, object]:
+    seeds_data: List[Dict] = []
+    for s in SEEDS:
+        d = load_cell(_cell_dir(root, coef, s))
+        if d is None:
+            seeds_data.append({"seed": s, "missing": True})
+            continue
+        d["seed"] = s
+        seeds_data.append(d)
+    present = [d for d in seeds_data if not d.get("missing")]
+    if not present:
+        return {"coef": coef, "seeds": seeds_data, "n_seeds": 0}
+    team = np.array([d["trailing5_team_reward"] for d in present])
+    return {
+        "coef": coef,
+        "seeds": seeds_data,
+        "n_seeds": len(present),
+        "team_reward_mean": float(team.mean()),
+        "team_reward_std": float(team.std(ddof=1)) if len(team) > 1 else 0.0,
+        "team_reward_per_seed": team.tolist(),
+        "gap_closed_mean": float(gap_closed(team.mean())),
+        "gap_closed_per_seed": [float(gap_closed(x)) for x in team],
+    }
+
+
+def _tier(best_gap_nonzero: Optional[float]) -> str:
+    if best_gap_nonzero is None:
+        return "missing_treatment"
+    if best_gap_nonzero >= TIER_1_THRESHOLD:
+        return "tier_1_clear_win"
+    if best_gap_nonzero >= TIER_2_THRESHOLD:
+        return "tier_2_partial_layer_with_other_shaping"
+    return "tier_3_progress_signal_unhelpful_escalate_to_283"
+
+
+def compute_verdict(results: Dict[float, Dict[str, object]]) -> Dict[str, object]:
+    """Verdict based on the best gap_closed across *non-zero* coefficients.
+
+    The baseline (coef=0.0) gap is reported for context but the tiering
+    follows the #265 success criterion which is "any coef>0 hits the
+    threshold", consistent with the calibration-style readout.
+    """
+    baseline = results.get(0.0, {})
+    baseline_gap = baseline.get("gap_closed_mean") if baseline.get("n_seeds") else None
+
+    treatment_entries = [
+        (c, r) for c, r in results.items() if c != 0.0 and r.get("n_seeds")
+    ]
+    if not treatment_entries:
+        return {
+            "status": "missing_treatment",
+            "baseline_gap": baseline_gap,
+            "tier": _tier(None),
+        }
+
+    # Track each treatment cell's gap and the best of them.
+    per_coef_gap = {c: float(r["gap_closed_mean"]) for c, r in treatment_entries}  # type: ignore[index]
+    best_coef = max(per_coef_gap, key=per_coef_gap.get)
+    best_gap = per_coef_gap[best_coef]
+
+    delta_vs_baseline: Optional[float] = None
+    if baseline_gap is not None:
+        delta_vs_baseline = best_gap - float(baseline_gap)
+
+    return {
+        "baseline_gap": baseline_gap,
+        "per_coef_gap_closed": per_coef_gap,
+        "best_coef": best_coef,
+        "best_gap_closed": best_gap,
+        "delta_vs_baseline": delta_vs_baseline,
+        "tier": _tier(best_gap),
+    }
+
+
+def render_markdown(
+    results: Dict[float, Dict[str, object]], verdict: Dict[str, object]
+) -> str:
+    lines = [
+        f"# Issue #265 — dense Δsafe progress shaping on `{SCENARIO}`",
+        "",
+        f"Pre-registered references (per-step mean team reward) on `{SCENARIO}`:",
+        "",
+        f"- random: `{RANDOM_REF:+.3f}`",
+        f"- specialist: `{SPECIALIST_REF:+.3f}`",
+        f"- spec-rand gap: `{SPEC_RAND_GAP:+.3f}`",
+        "",
+        "## Team reward (trailing-5 mean of `mean_step_reward_team`)",
+        "",
+        "| coef | n | mean ± std | gap_closed | per-seed |",
+        "|---|---|---|---|---|",
+    ]
+    for coef in COEFS:
+        r = results.get(coef, {})
+        if not r.get("n_seeds"):
+            lines.append(f"| {coef} | 0 | — | — | missing |")
+            continue
+        per_seed = [f"{x:+.3f}" for x in r["team_reward_per_seed"]]  # type: ignore[index]
+        lines.append(
+            f"| {coef} | {r['n_seeds']} | "
+            f"{r['team_reward_mean']:+.3f} ± {r['team_reward_std']:.3f} | "
+            f"{r['gap_closed_mean']:+.3f} | "
+            f"{per_seed} |"
+        )
+
+    lines += [
+        "",
+        "## Verdict",
+        "",
+    ]
+    if verdict.get("status") == "missing_treatment":
+        lines.append("**MISSING_TREATMENT** — no non-zero coef cells found.")
+    else:
+        baseline_gap = verdict.get("baseline_gap")
+        if baseline_gap is not None:
+            lines.append(f"- `baseline (coef=0) gap_closed = {baseline_gap:+.3f}`")
+        per_coef = verdict.get("per_coef_gap_closed") or {}
+        for c in sorted(per_coef.keys()):
+            lines.append(f"- `coef={c} gap_closed = {per_coef[c]:+.3f}`")
+        lines.append(f"- **best coef**: `{verdict['best_coef']}`")
+        lines.append(f"- **best gap_closed**: `{verdict['best_gap_closed']:+.3f}`")
+        if verdict.get("delta_vs_baseline") is not None:
+            lines.append(
+                f"- `delta vs baseline = {verdict['delta_vs_baseline']:+.3f}`"
+            )
+        lines.append(f"- **Tier: `{verdict['tier']}`**")
+    lines.append("")
+
+    lines += [
+        "## Tier thresholds",
+        "",
+        f"- Tier 1 (clear win, escalate): `gap_closed >= {TIER_1_THRESHOLD}` at any `coef>0`",
+        f"- Tier 2 (partial, layer): `{TIER_2_THRESHOLD} <= gap_closed < {TIER_1_THRESHOLD}`",
+        f"- Tier 3 (failed, escalate to #283): `gap_closed < {TIER_2_THRESHOLD}` for every `coef>0`",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    runs_root = Path("experiments/p3_specialization/runs")
+    out_dir = Path(
+        "experiments/p3_specialization/diagnostics/results/issue265_progress_signal"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {coef: aggregate_coef(runs_root, coef) for coef in COEFS}
+    verdict = compute_verdict(results)
+    payload = {
+        "results": {str(k): v for k, v in results.items()},
+        "verdict": verdict,
+        "baselines": {
+            "scenario": SCENARIO,
+            "random": RANDOM_REF,
+            "specialist": SPECIALIST_REF,
+            "spec_rand_gap": SPEC_RAND_GAP,
+        },
+        "thresholds": {
+            "tier_1": TIER_1_THRESHOLD,
+            "tier_2": TIER_2_THRESHOLD,
+        },
+    }
+    (out_dir / "summary.json").write_text(json.dumps(payload, indent=2))
+    (out_dir / "summary.md").write_text(render_markdown(results, verdict))
+    print(f"wrote {out_dir / 'summary.json'}")
+    print(f"wrote {out_dir / 'summary.md'}")
+    if verdict.get("status") != "missing_treatment":
+        print(
+            f"verdict: {verdict['tier']} "
+            f"(best gap_closed={verdict['best_gap_closed']:+.3f} "
+            f"at coef={verdict['best_coef']})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/analyze_265.py
+++ b/experiments/p3_specialization/analyze_265.py
@@ -210,9 +210,7 @@ def render_markdown(
         lines.append(f"- **best coef**: `{verdict['best_coef']}`")
         lines.append(f"- **best gap_closed**: `{verdict['best_gap_closed']:+.3f}`")
         if verdict.get("delta_vs_baseline") is not None:
-            lines.append(
-                f"- `delta vs baseline = {verdict['delta_vs_baseline']:+.3f}`"
-            )
+            lines.append(f"- `delta vs baseline = {verdict['delta_vs_baseline']:+.3f}`")
         lines.append(f"- **Tier: `{verdict['tier']}`**")
     lines.append("")
 

--- a/experiments/p3_specialization/run_issue265_progress_sweep.sh
+++ b/experiments/p3_specialization/run_issue265_progress_sweep.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Issue #265 sweep driver — dense Δsafe progress shaping on minimal_specialization.
+#
+# Pre-registered grid (per the curator enhancement on #265):
+#   progress_shaping_coef in {0.0, 1.0, 5.0, 25.0}             = 4 configs
+#   seeds {42, 43, 44}                                          = 3 each
+#   total = 12 cells
+#
+# Per cell: 50 iterations x 2048 rollout steps x IPPO (no MAPPO).
+#
+# Layout (consumed by analyze_265.py):
+#   experiments/p3_specialization/runs/issue265_progress_signal/
+#       coef_{COEF}/seed_{SEED}/
+#           metrics.json, config.json, policies/, train.log
+#
+# Wall-clock: ~1.5 min/cell at 50 iters; 12 cells / 4-way parallel
+# ~5 min ideal, ~10-15 min realistic. The curator's issue-body estimate
+# (~30 min wall clock at 4-way parallel) is conservative.
+#
+# Modeled on experiments/p3_specialization/run_issue262_sweep.sh
+# (xargs -P parallelism, per-cell stdout, git-rev stamping).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+if [[ ! -d "$REPO_ROOT" ]]; then
+  # Fallback used on the Mac Studio.
+  if [[ -d "$HOME/bucket-brigade" ]]; then
+    REPO_ROOT="$HOME/bucket-brigade"
+  fi
+fi
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+SCENARIO="${SCENARIO:-minimal_specialization}"
+NUM_ITERATIONS="${NUM_ITERATIONS:-50}"
+ROLLOUT_STEPS="${ROLLOUT_STEPS:-2048}"
+SEEDS=(42 43 44)
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-4}"
+
+# Pre-registered grid. The baseline cell (coef=0.0) is the in-sweep
+# reference used by analyze_265.py to compute the gap_closed delta. The
+# magnitudes are chosen against the existing
+# ``team_reward_house_survives=10.0`` on minimal_specialization:
+# 1.0 is small relative to team signal, 25.0 is comparable, 5.0 intermediate.
+COEFS=(0.0 1.0 5.0 25.0)
+
+jobs=()
+for coef in "${COEFS[@]}"; do
+  for seed in "${SEEDS[@]}"; do
+    outdir="$OUTPUT_ROOT/issue265_progress_signal/coef_${coef}/seed_${seed}"
+    jobs+=("${coef}|${seed}|${outdir}")
+  done
+done
+
+echo
+echo "============================================================"
+echo "Issue #265 dense progress shaping sweep"
+echo "  scenario:        $SCENARIO"
+echo "  num_iterations:  $NUM_ITERATIONS"
+echo "  rollout_steps:   $ROLLOUT_STEPS"
+echo "  coefs:           ${COEFS[*]}"
+echo "  seeds:           ${SEEDS[*]}"
+echo "  cells:           ${#jobs[@]}"
+echo "  parallelism:     $PARALLEL_PER_POOL"
+echo "============================================================"
+
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r coef seed outdir <<< "$spec"
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (coef=$coef)"
+  if uv run python -m experiments.p3_specialization.train \
+       --scenario "$SCENARIO" --lambda-red 0.0 --seed "$seed" \
+       --num-iterations "$NUM_ITERATIONS" --rollout-steps "$ROLLOUT_STEPS" \
+       --progress-shaping-coef "$coef" \
+       --output-dir "$outdir" \
+       > "$outdir/train.log" 2>&1; then
+    if [[ -f "$outdir/config.json" ]]; then
+      python3 -c "
+import json
+p = '$outdir/config.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 265
+c['_progress_shaping_coef'] = float('$coef')
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    fi
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export SCENARIO NUM_ITERATIONS ROLLOUT_STEPS GIT_REV
+
+echo
+echo "--- Launching ${#jobs[@]} cells, ${PARALLEL_PER_POOL}-way parallel ---"
+printf "%s\n" "${jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+
+echo
+echo "============================================================"
+echo "Issue #265 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "============================================================"
+touch "$OUTPUT_ROOT/.issue265_progress_signal_done"

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -109,6 +109,13 @@ class CellConfig:
     # the ``--action-shaping-alpha`` / ``--action-shaping-beta`` flags.
     action_shaping_alpha: float = 0.0
     action_shaping_beta: float = 0.0
+    # Issue #265: dense progress shaping coefficient. Mutated onto the loaded
+    # ``Scenario`` instance in ``train_one_cell`` so the per-cell knob takes
+    # effect inside ``_compute_rewards``. Default ``0.0`` matches the
+    # ``Scenario.progress_shaping_coef`` default, keeps the env fast-path
+    # skip, and preserves bit-identical pre-#265 behavior. The #265 sweep
+    # driver passes per-cell values via ``--progress-shaping-coef``.
+    progress_shaping_coef: float = 0.0
     # Issue #270: optional BC-pretrained init. Directory containing per-agent
     # ``agent_{i}.pt`` state dicts produced by
     # ``experiments/p3_specialization/bc_init.py``. ``None`` (default)
@@ -625,6 +632,11 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
     scenario.action_shaping_alpha = float(cfg.action_shaping_alpha)
     scenario.action_shaping_beta = float(cfg.action_shaping_beta)
 
+    # Issue #265: mutate the dense progress shaping coefficient. Default
+    # ``0.0`` keeps the env fast-path skip and bit-identical pre-#265
+    # behavior; the #265 sweep driver passes per-cell values.
+    scenario.progress_shaping_coef = float(cfg.progress_shaping_coef)
+
     def env_fn():
         env = BucketBrigadeEnv(scenario=scenario)
         return env
@@ -849,6 +861,17 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--progress-shaping-coef",
+        type=float,
+        default=CellConfig.__dataclass_fields__["progress_shaping_coef"].default,
+        help=(
+            "Issue #265: dense Δsafe per-step team-shaping coefficient. "
+            "Mutated onto the loaded Scenario instance pre-rollout. "
+            "Default 0.0 keeps the env fast-path skip and bit-identical "
+            "pre-#265 behavior. The #265 sweep uses {0.0, 1.0, 5.0, 25.0}."
+        ),
+    )
+    p.add_argument(
         "--bc-init-checkpoint-dir",
         type=str,
         default=None,
@@ -878,6 +901,7 @@ def main() -> None:
         curriculum=args.curriculum,
         action_shaping_alpha=args.action_shaping_alpha,
         action_shaping_beta=args.action_shaping_beta,
+        progress_shaping_coef=args.progress_shaping_coef,
         bc_init_checkpoint_dir=args.bc_init_checkpoint_dir,
         device=args.device,
     )
@@ -885,7 +909,8 @@ def main() -> None:
         f"== P3 cell: scenario={cfg.scenario} lambda_red={cfg.lambda_red} "
         f"seed={cfg.seed} "
         f"action_shaping_alpha={cfg.action_shaping_alpha} "
-        f"action_shaping_beta={cfg.action_shaping_beta} =="
+        f"action_shaping_beta={cfg.action_shaping_beta} "
+        f"progress_shaping_coef={cfg.progress_shaping_coef} =="
     )
     train_one_cell(cfg, args.output_dir)
 

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -199,6 +199,20 @@ def generate_scenarios(json_path: Path, output_path: Path):
         action_shaping_alpha: float = 0.0
         action_shaping_beta: float = 0.0
 
+        # Dense progress shaping (issue #265, optional, additive). Per-step
+        # team-shared reward bonus proportional to the change in the number of
+        # SAFE houses between the previous step and the current step:
+        #
+        #     team_reward += progress_shaping_coef * (cur_safe - prev_safe)
+        #
+        # Defaults to ``0.0`` so every pre-#265 scenario is bit-exactly
+        # preserved (the env takes a fast-path skip when this knob is zero).
+        # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards``
+        # and ``bucket-brigade-core/src/engine/rewards.rs`` for the canonical
+        # implementation. Sequenced before potential-based shaping (#283) as
+        # the cheap mechanical test of the dense-team-signal hypothesis.
+        progress_shaping_coef: float = 0.0
+
         def __post_init__(self) -> None:
             """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -358,6 +372,13 @@ def generate_scenarios(json_path: Path, output_path: Path):
         if "action_shaping_beta" in spec:
             code += (
                 f"        action_shaping_beta={spec['action_shaping_beta']},\n"
+            )
+        # Issue #265 optional dense progress shaping field. Emit only when set
+        # in JSON so every pre-#265 scenario factory is byte-identical to
+        # pre-#265 codegen output (they all keep the dataclass default of 0.0).
+        if "progress_shaping_coef" in spec:
+            code += (
+                f"        progress_shaping_coef={spec['progress_shaping_coef']},\n"
             )
         code += f"    )\n\n\n"
 

--- a/tests/test_progress_shaping.py
+++ b/tests/test_progress_shaping.py
@@ -1,0 +1,379 @@
+"""Tests for issue #265 — dense Δsafe progress shaping.
+
+The Python env mirrors the Rust core's new ``Scenario.progress_shaping_coef``
+field. The default is ``0.0`` and every pre-#265 scenario keeps it zero, so
+existing behavior is bit-exactly preserved (fast-path skip in
+``_compute_rewards``).
+
+Test pattern modeled on ``tests/test_environment.py::TestActionShaping``
+(issue #259 / PR #263 precedent).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bucket_brigade.envs import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import Scenario, SCENARIO_REGISTRY
+
+
+def _make_minimal_scenario(**overrides) -> Scenario:
+    """Build a Scenario with all reward/cost fields zeroed except those overridden.
+
+    Mirrors the helper in ``tests/test_environment.py`` (kept duplicated here
+    to avoid an import-only edit to that file). Used to isolate the
+    contribution of ``progress_shaping_coef`` to ``_compute_rewards``.
+    """
+    base = dict(
+        prob_fire_spreads_to_neighbor=0.0,
+        prob_solo_agent_extinguishes_fire=0.0,
+        prob_house_catches_fire=0.0,
+        team_reward_house_survives=0.0,
+        team_penalty_house_burns=0.0,
+        reward_own_house_survives=0.0,
+        reward_other_house_survives=0.0,
+        penalty_own_house_burns=0.0,
+        penalty_other_house_burns=0.0,
+        cost_to_work_one_night=0.0,
+        min_nights=12,
+        num_agents=4,
+    )
+    base.update(overrides)
+    return Scenario(**base)
+
+
+class TestProgressShapingDefaults:
+    """Issue #265 default-value regression: every pre-#265 scenario must keep
+    ``progress_shaping_coef = 0.0`` so the post-#236 P3 protocol and all
+    standing regression numerics remain reproducible.
+    """
+
+    def test_defaults_are_zero_across_all_scenarios(self):
+        """Every pre-#265 scenario keeps the shaping coef at 0.0."""
+        for name, factory in SCENARIO_REGISTRY.items():
+            s = factory(num_agents=4)
+            assert s.progress_shaping_coef == 0.0, (
+                f"Pre-#265 scenario '{name}' must keep "
+                f"progress_shaping_coef=0.0; got {s.progress_shaping_coef}"
+            )
+
+    def test_scenario_dataclass_has_the_field(self):
+        """The new field exists on ``Scenario`` and defaults to 0.0."""
+        s = _make_minimal_scenario()
+        assert hasattr(s, "progress_shaping_coef")
+        assert s.progress_shaping_coef == 0.0
+
+
+class TestProgressShapingBitExactBaseline:
+    """Coef=0.0 must produce byte-identical per-step rewards to the pre-#265
+    fast path. This guards the entire prior P3 ladder's numerics — the May-14
+    baselines, the #260 verdict, etc."""
+
+    def test_zero_coef_matches_default_scenario(self):
+        """With coef=0, a full episode produces identical per-step rewards
+        on the canonical ``default`` scenario."""
+        from bucket_brigade.envs.scenarios_generated import default_scenario
+
+        env_a = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        env_b = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        env_a.reset(seed=99)
+        env_b.reset(seed=99)
+        # Explicitly assert the treatment env's coef is the default zero.
+        assert env_b.scenario.progress_shaping_coef == 0.0
+        rng = np.random.RandomState(0)
+        for _ in range(10):
+            actions = rng.randint(0, 2, size=(4, 2)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+            _, r_a, _, _ = env_a.step(actions)
+            _, r_b, _, _ = env_b.step(actions)
+            np.testing.assert_allclose(r_a, r_b)
+
+    def test_explicit_zero_coef_matches_unset_field(self):
+        """Explicitly setting coef=0.0 on a fresh scenario object is
+        indistinguishable from leaving it at the dataclass default."""
+        s_default = _make_minimal_scenario()
+        s_explicit = _make_minimal_scenario()
+        s_explicit.progress_shaping_coef = 0.0
+        env_a = BucketBrigadeEnv(scenario=s_default)
+        env_b = BucketBrigadeEnv(scenario=s_explicit)
+        env_a.reset(seed=7)
+        env_b.reset(seed=7)
+        rng = np.random.RandomState(1)
+        for _ in range(8):
+            actions = rng.randint(0, 2, size=(4, 2)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+            _, r_a, _, _ = env_a.step(actions)
+            _, r_b, _, _ = env_b.step(actions)
+            np.testing.assert_allclose(r_a, r_b)
+
+
+class TestProgressShapingSignChecks:
+    """Hand-crafted Δsafe scenarios verify the sign and magnitude of the
+    shaping bonus.
+
+    The bonus is shared across all agents via the team-reward broadcast at
+    the end of the per-agent loop in ``_compute_rewards``, so each agent
+    receives ``coef * (cur_safe - prev_safe)`` on top of their other reward
+    components. With all other reward fields zeroed, the bonus is the
+    *only* contribution to per-agent rewards.
+    """
+
+    def test_positive_delta_safe_yields_positive_bonus(self):
+        """One BURNING -> SAFE transition gives every agent +coef of team
+        bonus on that step."""
+        scenario = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,  # deterministic extinguish
+            progress_shaping_coef=10.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # Setup: only house 5 burning, nothing else changes.
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[5] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # All 4 agents work at house 5 -> guaranteed extinguish.
+        actions = np.array(
+            [[5, 1, 1], [5, 1, 1], [5, 1, 1], [5, 1, 1]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # cur_safe - prev_safe = 10 - 9 = +1, bonus = 10*1 = +10 per agent.
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - 10.0) < 1e-5, (
+                f"Agent {i} should get progress bonus of +10.0, got {r}"
+            )
+
+    def test_zero_delta_safe_yields_zero_bonus(self):
+        """A steady-state step (no SAFE-count change) gives every agent +0
+        of progress bonus.
+
+        Note: REST actions still produce the standard +0.5 rest reward in
+        ``_compute_rewards`` regardless of shaping. We isolate the shaping
+        contribution by having all agents WORK (no rest reward) at SAFE
+        houses where nothing happens; cost_to_work_one_night is also zero,
+        so each agent's total reward equals the progress bonus alone (0.0).
+        """
+        scenario = _make_minimal_scenario(
+            prob_fire_spreads_to_neighbor=0.0,
+            prob_solo_agent_extinguishes_fire=0.0,
+            prob_house_catches_fire=0.0,
+            cost_to_work_one_night=0.0,
+            progress_shaping_coef=10.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # All houses SAFE, no fires, nothing ignites (fire prob = 0). The
+        # extinguish-fire phase still runs but has no burning house to act on.
+        env.houses = np.zeros(10, dtype=np.int8)
+        env._prev_houses_state = env.houses.copy()
+        # Use WORK actions to avoid the +0.5 rest reward; cost is zero.
+        actions = np.array(
+            [[0, 1, 0], [3, 1, 0], [5, 1, 0], [8, 1, 0]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - 0.0) < 1e-5, (
+                f"Agent {i} should get zero progress bonus on a "
+                f"no-transition step, got {r}"
+            )
+
+    def test_negative_delta_safe_yields_negative_bonus(self):
+        """A SAFE -> BURNING transition (loss of one safe house) gives
+        every agent -coef of progress penalty on that step.
+
+        We trigger the spark phase to ignite all SAFE houses (the spark
+        phase runs *after* the burn-out phase, so it directly mutates the
+        end-of-step house states that ``_compute_rewards`` reads). With
+        ``prob_house_catches_fire=1.0`` every SAFE house becomes BURNING
+        on this step.
+        """
+        scenario = _make_minimal_scenario(
+            prob_fire_spreads_to_neighbor=0.0,
+            prob_solo_agent_extinguishes_fire=0.0,
+            prob_house_catches_fire=1.0,
+            progress_shaping_coef=10.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        # All houses SAFE at start of step. Spark phase will set every
+        # SAFE house BURNING (prob=1.0). cur_safe = 0; prev_safe = 10.
+        env.houses = np.zeros(10, dtype=np.int8)
+        env._prev_houses_state = env.houses.copy()
+        # All agents WORK (no rest reward); cost is zero.
+        actions = np.array(
+            [[0, 1, 0], [3, 1, 0], [5, 1, 0], [8, 1, 0]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # delta_safe = 0 - 10 = -10. Per-agent bonus = 10.0 * -10 = -100.0.
+        expected = 10.0 * (0 - 10)  # = -100.0
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - expected) < 1e-5, (
+                f"Agent {i} should get progress penalty of {expected}, got {r}"
+            )
+
+    def test_shaping_is_team_shared(self):
+        """The progress bonus is team-shared: every agent gets the *same*
+        bonus regardless of action. Distinguishes #265 (team-shared) from
+        #262 (per-agent action-shaping)."""
+        scenario = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,
+            progress_shaping_coef=3.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[5] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # Only agent 0 works at house 5; rest are resting at other houses.
+        actions = np.array(
+            [[5, 1, 1], [0, 0, 0], [3, 0, 0], [8, 0, 0]],
+            dtype=np.int8,
+        )
+        _, rewards, _, _ = env.step(actions)
+        # All agents should receive the same +3.0 progress bonus (delta=+1).
+        # No other reward source (team_reward_house_survives=0,
+        # cost_to_work_one_night=0, ownership rewards 0). Rest-reward is 0.5
+        # per resting agent.
+        expected_worker = 3.0  # progress bonus only (no work cost).
+        expected_rester = 3.0 + 0.5  # progress bonus + rest reward.
+        assert abs(float(rewards[0]) - expected_worker) < 1e-5, (
+            f"Working agent should get progress bonus only "
+            f"({expected_worker}), got {rewards[0]}"
+        )
+        for i in range(1, 4):
+            assert abs(float(rewards[i]) - expected_rester) < 1e-5, (
+                f"Resting agent {i} should get progress bonus + rest "
+                f"({expected_rester}), got {rewards[i]}"
+            )
+
+
+@pytest.mark.requires_rust
+class TestProgressShapingRustParity:
+    """Rust/Python parity for a non-zero ``progress_shaping_coef``.
+
+    Uses ``trivial_cooperation`` dynamics (``prob_house_catches_fire=0.0``,
+    all-SAFE initial state) so the per-step rewards are fully deterministic
+    — no RNG decision actually changes house state or rewards, allowing
+    bit-comparable Rust vs Python rewards without depending on the
+    different underlying PRNG implementations. Pattern mirrors
+    ``tests/test_rust_integration.py::test_rust_vs_python_consistency``.
+    """
+
+    def test_rust_python_parity_with_nonzero_coef(self):
+        from bucket_brigade_core import BucketBrigade
+        from bucket_brigade_core import Scenario as RustPyScenario
+
+        # Build Rust + Python scenarios with identical fields and
+        # ``progress_shaping_coef = 10.0``. The PyScenario constructor now
+        # accepts ``progress_shaping_coef`` as an optional kwarg (default
+        # 0.0); existing positional callers stay byte-identical.
+        rust_scenario = RustPyScenario(
+            prob_fire_spreads_to_neighbor=0.1,
+            prob_solo_agent_extinguishes_fire=0.5,
+            prob_house_catches_fire=0.0,  # no spontaneous fires for determinism
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            cost_to_work_one_night=0.5,
+            min_nights=12,
+            reward_own_house_survives=1.0,
+            reward_other_house_survives=0.0,
+            penalty_own_house_burns=2.0,
+            penalty_other_house_burns=0.0,
+            progress_shaping_coef=10.0,
+        )
+        rust_env = BucketBrigade(rust_scenario, 4, seed=42)
+
+        py_scenario = Scenario(
+            prob_fire_spreads_to_neighbor=0.1,
+            prob_solo_agent_extinguishes_fire=0.5,
+            prob_house_catches_fire=0.0,
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            reward_own_house_survives=1.0,
+            reward_other_house_survives=0.0,
+            penalty_own_house_burns=2.0,
+            penalty_other_house_burns=0.0,
+            cost_to_work_one_night=0.5,
+            min_nights=12,
+            num_agents=4,
+        )
+        py_scenario.progress_shaping_coef = 10.0
+        py_env = BucketBrigadeEnv(scenario=py_scenario)
+        py_env.reset(seed=42)
+
+        # Drive both engines with the same action sequence; rewards agree
+        # to float tolerance because all-SAFE initial state + prob_fire=0
+        # means no RNG branches actually trigger.
+        actions_seq = [
+            [[0, 1], [1, 0], [2, 1], [3, 0]],
+            [[1, 1], [2, 1], [3, 1], [0, 0]],
+            [[0, 0], [1, 0], [2, 0], [3, 0]],
+        ]
+        for i, action_set in enumerate(actions_seq):
+            rust_rewards, _, _ = rust_env.step(action_set)
+            _, py_rewards, _, _ = py_env.step(np.array(action_set))
+            np.testing.assert_allclose(
+                rust_rewards,
+                py_rewards,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Rust/Python rewards differ at step {i}",
+            )
+
+    def test_rust_python_parity_with_zero_coef(self):
+        """Coef=0.0 PyScenario via the new kwarg path matches the
+        all-default Rust scenario (existing pre-#265 PyScenario behavior)."""
+        from bucket_brigade_core import BucketBrigade
+        from bucket_brigade_core import Scenario as RustPyScenario
+
+        rust_scenario = RustPyScenario(
+            prob_fire_spreads_to_neighbor=0.1,
+            prob_solo_agent_extinguishes_fire=0.5,
+            prob_house_catches_fire=0.0,
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            cost_to_work_one_night=0.5,
+            min_nights=12,
+            reward_own_house_survives=1.0,
+            reward_other_house_survives=0.0,
+            penalty_own_house_burns=2.0,
+            penalty_other_house_burns=0.0,
+            # progress_shaping_coef omitted; defaults to 0.0.
+        )
+        assert rust_scenario.progress_shaping_coef == 0.0
+        rust_env = BucketBrigade(rust_scenario, 4, seed=42)
+
+        py_scenario = Scenario(
+            prob_fire_spreads_to_neighbor=0.1,
+            prob_solo_agent_extinguishes_fire=0.5,
+            prob_house_catches_fire=0.0,
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            reward_own_house_survives=1.0,
+            reward_other_house_survives=0.0,
+            penalty_own_house_burns=2.0,
+            penalty_other_house_burns=0.0,
+            cost_to_work_one_night=0.5,
+            min_nights=12,
+            num_agents=4,
+        )
+        py_env = BucketBrigadeEnv(scenario=py_scenario)
+        py_env.reset(seed=42)
+
+        actions_seq = [
+            [[0, 1], [1, 0], [2, 1], [3, 0]],
+            [[1, 1], [2, 1], [3, 1], [0, 0]],
+        ]
+        for i, action_set in enumerate(actions_seq):
+            rust_rewards, _, _ = rust_env.step(action_set)
+            _, py_rewards, _, _ = py_env.step(np.array(action_set))
+            np.testing.assert_allclose(
+                rust_rewards,
+                py_rewards,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Rust/Python (coef=0) rewards differ at step {i}",
+            )


### PR DESCRIPTION
## Summary

Implements issue #265 — intervention #4 from #193's ladder. Adds a per-step
team-shared reward bonus proportional to ``cur_safe - prev_safe`` so PPO sees
a dense gradient on save/burn transitions without changing the long-horizon
optimum.

Scope per user direction: **local implementation + smoke tests only**. The
12-cell remote sweep is not executed by this PR; the driver script is in
place for the follow-up run on the primary compute host.

## Changes

- ``Scenario`` gains ``progress_shaping_coef: float = 0.0`` in both the Python
  dataclass (``bucket_brigade/envs/scenarios_generated.py``) and the Rust
  struct (``bucket-brigade-core/src/scenarios.rs``). Codegen template +
  ``scripts/generate_python.py`` JSON path updated; all 16 Rust SCENARIOS
  entries + the proptest fixture + the validate-rejects test scenario carry
  the new field at its zero default.
- ``bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards`` folds
  ``coef * (cur_safe - prev_safe)`` into the team reward when coef != 0.0
  (fast-path skip otherwise), reusing ``prev_houses`` cached at line 297-302.
- ``bucket-brigade-core/src/engine/rewards.rs`` mirrors the Python block.
- ``bucket-brigade-core/src/python.rs`` extends ``PyScenario`` with an optional
  ``progress_shaping_coef`` kwarg (default 0.0) + a getter; ``wasm.rs`` carries
  the zero default for the WASM constructor path.
- ``experiments/p3_specialization/train.py`` gains ``--progress-shaping-coef``
  CLI flag + ``CellConfig.progress_shaping_coef`` field; mutated onto the
  scenario in ``train_one_cell`` after the action-shaping knobs.
- ``experiments/p3_specialization/run_issue265_progress_sweep.sh`` — sweep
  driver (4 coefs × 3 seeds × 50 iters = 12 cells), modeled on
  ``run_issue262_sweep.sh``.
- ``experiments/p3_specialization/analyze_265.py`` — analyzer with the
  pre-registered Tier-1 (≥0.25) / Tier-2 (0.10–0.25) / Tier-3 (<0.10) verdict
  ladder against the published ``minimal_specialization`` references.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Dense per-step team-level shaping term defined + added to env (gated by scenario field defaulting to 0.0) | ✅ | ``_compute_rewards`` block + ``Scenario.progress_shaping_coef = 0.0`` default. Pytest ``test_defaults_are_zero_across_all_scenarios`` enforces. |
| Rust mirror + scenario field | ✅ | ``engine/rewards.rs``, ``scenarios.rs`` (struct + default fn + all 16 scenarios + proptest + validate-test). |
| CLI flag in ``train.py`` | ✅ | ``--progress-shaping-coef`` wired into ``CellConfig`` + ``train_one_cell`` mutation. |
| Sweep driver (DO NOT execute) | ✅ | ``run_issue265_progress_sweep.sh`` (4 × 3 = 12 cells). Not run per user instruction. |
| Analyzer with verdict ladder | ✅ | ``analyze_265.py`` emits ``summary.{md,json}`` + per-coef gap_closed + tiered verdict; smoke-tested with empty results dir. |
| Bit-exact regression on coef=0.0 | ✅ | ``TestProgressShapingBitExactBaseline::test_zero_coef_matches_default_scenario`` + ``test_explicit_zero_coef_matches_unset_field``. ``test_environment.py`` (60 tests) + ``test_rust_integration.py`` continue to pass. |
| Rust/Python parity for non-zero coef | ✅ | ``TestProgressShapingRustParity::test_rust_python_parity_with_nonzero_coef`` (coef=10.0, all-SAFE deterministic dynamics) + zero-coef parity test. |
| Hand-crafted Δsafe sign checks | ✅ | ``test_positive_delta_safe_yields_positive_bonus`` (+1 → +10), ``test_zero_delta_safe_yields_zero_bonus`` (no transition → 0), ``test_negative_delta_safe_yields_negative_bonus`` (spark all-safe → -100), ``test_shaping_is_team_shared`` (worker vs rester get identical bonus). |

## Test Plan

- [x] ``uv run python -m pytest tests/test_progress_shaping.py`` — 10/10 pass (1 originally skipped, then implemented as PyScenario kwarg path).
- [x] ``uv run python -m pytest tests/test_environment.py tests/test_rust_integration.py`` — 70 pass / 5 skipped (no regressions).
- [x] ``cargo test --lib`` in ``bucket-brigade-core/`` — 121 pass / 0 failed.
- [x] ``cargo check`` clean.
- [x] ``uv run python scripts/generate_python.py`` — regenerates ``scenarios_generated.py`` with the new field included (template updated).
- [x] ``uv run python experiments/p3_specialization/analyze_265.py`` — smoke test against empty runs dir produces ``summary.md`` + ``summary.json`` with the ``MISSING_TREATMENT`` verdict, exits 0.
- [ ] **Not run (per user)**: 12-cell sweep via ``run_issue265_progress_sweep.sh`` on primary compute host.

## Coordination

Sequenced before #283 (potential-based / NHR shaping) per the curator's note:
this is the cheap mechanical test of the dense-team-signal hypothesis. If the
sweep lands Tier-3 (gap_closed < 0.10 across all non-zero coefs), #283
becomes the principled escalation; if Tier-1/2, #283 becomes the
policy-invariant follow-up.

Closes #265