### PR TITLE
feat(p3): potential-based team-welfare shaping (NHR-aligned)

### DIFF
--- a/bucket-brigade-core/src/engine/rewards.rs
+++ b/bucket-brigade-core/src/engine/rewards.rs
@@ -2,6 +2,43 @@ use super::core::{ring_dist, BucketBrigade};
 use crate::{Action, HouseState};
 
 impl BucketBrigade {
+    /// Issue #283: closed-form team-welfare potential Phi(s) for
+    /// Ng-Harada-Russell potential-based shaping. Mirrors the Python
+    /// implementation in
+    /// `bucket_brigade/envs/bucket_brigade_env.py::_compute_team_welfare_phi`.
+    ///
+    /// Pure function of `houses` — no policy-conditioned features. This is
+    /// what makes the NHR telescoping identity hold.
+    ///
+    /// Returns 0.0 when shaping is disabled (`kind == "none"`) so callers
+    /// can use the value unconditionally without short-circuiting on every
+    /// step.
+    pub(super) fn team_welfare_phi(&self, houses: &[HouseState]) -> f32 {
+        let kind = self.scenario.team_welfare_kind.as_str();
+        if kind == "none" {
+            return 0.0;
+        }
+        if kind == "team_welfare_closed_form" {
+            let num_houses_f = self.scenario.num_houses as f32;
+            let num_safe = houses.iter().filter(|&&h| h == 0).count() as f32;
+            let num_ruined = houses.iter().filter(|&&h| h == 2).count() as f32;
+            let num_burning = houses.iter().filter(|&&h| h == 1).count() as f32;
+            let w_safe = self.scenario.team_reward_house_survives;
+            let w_penalty = self.scenario.team_penalty_house_burns;
+            return w_safe * (num_safe / num_houses_f)
+                - w_penalty * (num_ruined / num_houses_f)
+                - 0.5 * w_penalty * (num_burning / num_houses_f);
+        }
+        // Defensive — the serde and `validate()` allowlist catches unknown
+        // kinds at construction time, but if a future kind is added without
+        // engine support we surface a clear panic rather than silently
+        // returning 0.
+        panic!(
+            "Unknown team_welfare_kind={:?}; supported: ['none', 'team_welfare_closed_form']",
+            self.scenario.team_welfare_kind
+        );
+    }
+
     pub(super) fn compute_rewards(
         &mut self,
         actions: &[Action],
@@ -166,6 +203,45 @@ impl BucketBrigade {
                 if beta != 0.0 && prev_houses[h] == 0 && self.houses[h] == 0 {
                     rewards[agent_idx] += beta;
                 }
+            }
+        }
+
+        // 6. Potential-based team-welfare shaping (issue #283, NHR 1999).
+        //
+        // F(s, a, s') = lambda * (gamma * Phi(s') - Phi(s))
+        //
+        // Added to every agent's reward (team-shared bonus). At a terminal
+        // transition Phi(s') is forced to 0 so the telescoping sum
+        // identity holds exactly:
+        //     sum_t gamma^t F_t = lambda * (gamma^T Phi(s_T) - Phi(s_0))
+        //                       = -lambda * Phi(s_0)   when Phi(s_T)=0.
+        // NHR (ICML 1999) guarantees optimal-policy invariance under this
+        // shaping for any potential function Phi.
+        //
+        // When `team_welfare_lambda == 0.0` (the default for every pre-#283
+        // scenario) or `team_welfare_kind == "none"` we skip this block
+        // entirely so per-step rewards are byte-identical to pre-#283
+        // behavior. Mirrors the Python implementation in
+        // `bucket_brigade/envs/bucket_brigade_env.py::_compute_rewards`.
+        let team_welfare_lambda = self.scenario.team_welfare_lambda;
+        if team_welfare_lambda != 0.0 && self.scenario.team_welfare_kind != "none" {
+            let gamma = self.scenario.team_welfare_gamma;
+            let phi_prev = self.team_welfare_phi(prev_houses);
+            // Determine whether s' is terminal. `check_termination` is a
+            // pure function of `self.houses` and `self.night` (which has
+            // not yet been advanced — see `engine/core.rs::step` order),
+            // so this is safe and idempotent. Terminal-state convention
+            // (NHR): Phi(terminal) := 0 so the telescoping identity holds.
+            let is_terminal_next = self.check_termination();
+            let phi_next = if is_terminal_next {
+                0.0
+            } else {
+                self.team_welfare_phi(&self.houses)
+            };
+            let shaping_term = team_welfare_lambda * (gamma * phi_next - phi_prev);
+            // Apply to every agent (team-shared bonus).
+            for r in rewards.iter_mut() {
+                *r += shaping_term;
             }
         }
 

--- a/bucket-brigade-core/src/engine/tests.rs
+++ b/bucket-brigade-core/src/engine/tests.rs
@@ -1039,6 +1039,146 @@ fn test_action_shaping_engine_smoke() {
 }
 
 // ==============================================================================
+// Issue #283: Potential-based team-welfare shaping (Ng-Harada-Russell 1999)
+// ==============================================================================
+
+/// Phi(s) is a pure function of `houses` for the closed-form kind. Spot-check
+/// hand-computed values to keep parity with the Python implementation in
+/// `bucket_brigade/envs/bucket_brigade_env.py::_compute_team_welfare_phi`.
+#[test]
+fn test_team_welfare_phi_closed_form_values() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.team_reward_house_survives = 10.0;
+    scenario.team_penalty_house_burns = 10.0;
+    scenario.team_welfare_kind = "team_welfare_closed_form".to_string();
+    let engine = BucketBrigade::new(scenario, 4, Some(0));
+
+    // All safe: Phi = 10*(10/10) - 0 - 0 = 10.0
+    let all_safe = vec![0u8; 10];
+    assert!((engine.team_welfare_phi(&all_safe) - 10.0).abs() < 1e-5);
+
+    // All ruined: Phi = 0 - 10 - 0 = -10.0
+    let all_ruined = vec![2u8; 10];
+    assert!((engine.team_welfare_phi(&all_ruined) - (-10.0)).abs() < 1e-5);
+
+    // All burning: Phi = 0 - 0 - 0.5*10 = -5.0
+    let all_burning = vec![1u8; 10];
+    assert!((engine.team_welfare_phi(&all_burning) - (-5.0)).abs() < 1e-5);
+
+    // Mixed: 5 safe, 3 burning, 2 ruined. Phi = 5 - 2 - 1.5 = 1.5.
+    let mut mixed = vec![0u8; 10];
+    for h in &mut mixed[5..8] {
+        *h = 1;
+    }
+    for h in &mut mixed[8..10] {
+        *h = 2;
+    }
+    assert!((engine.team_welfare_phi(&mixed) - 1.5).abs() < 1e-5);
+}
+
+/// Phi(s) = 0 unconditionally when kind = "none". Guards the engine
+/// fast-path skip in `compute_rewards`.
+#[test]
+fn test_team_welfare_phi_kind_none_returns_zero() {
+    let scenario = SCENARIOS.get("default").unwrap().clone();
+    // Defaults: team_welfare_kind == "none".
+    let engine = BucketBrigade::new(scenario, 4, Some(0));
+    for state_code in 0u8..=2 {
+        let houses = vec![state_code; 10];
+        assert_eq!(
+            engine.team_welfare_phi(&houses),
+            0.0,
+            "kind=\"none\" must produce Phi=0 for any houses state"
+        );
+    }
+}
+
+/// Issue #283: `team_welfare_kind` allowlist re-check via `validate()`.
+/// Mirrors the `distance_metric` invariant in
+/// `test_validate_rejects_unknown_distance_metric` (scenarios.rs).
+#[test]
+#[should_panic(expected = "team_welfare_kind")]
+fn test_engine_rejects_unknown_team_welfare_kind() {
+    let mut scenario = SCENARIOS.get("default").unwrap().clone();
+    scenario.team_welfare_kind = "bogus_kind".to_string();
+    // Must panic from BucketBrigade::new -> Scenario::validate.
+    let _ = BucketBrigade::new(scenario, 4, Some(42));
+}
+
+/// Byte-identity regression: `team_welfare_lambda == 0.0` (any kind) must
+/// produce identical rewards to a scenario without the new fields touched.
+/// Guards the engine fast-path skip in `compute_rewards`.
+#[test]
+fn test_zero_lambda_byte_identical_rewards() {
+    let scenario_a = SCENARIOS.get("default").unwrap().clone();
+    let mut scenario_b = scenario_a.clone();
+    // Treatment: kind set but lambda zero -> still inert.
+    scenario_b.team_welfare_kind = "team_welfare_closed_form".to_string();
+    scenario_b.team_welfare_lambda = 0.0;
+    scenario_b.team_welfare_gamma = 0.99;
+
+    let mut engine_a = BucketBrigade::new(scenario_a, 4, Some(123));
+    let mut engine_b = BucketBrigade::new(scenario_b, 4, Some(123));
+
+    let actions = vec![[0, 1, 1], [1, 1, 1], [2, 1, 1], [3, 0, 0]];
+    for _ in 0..15 {
+        if engine_a.done {
+            break;
+        }
+        let r_a = engine_a.step(&actions).rewards;
+        let r_b = engine_b.step(&actions).rewards;
+        for (a, b) in r_a.iter().zip(r_b.iter()) {
+            assert_eq!(
+                a, b,
+                "lambda=0 must yield byte-identical rewards regardless of kind"
+            );
+        }
+    }
+}
+
+/// Shaping is team-shared: when lambda != 0, every agent receives the same
+/// shaping increment, so the cross-agent reward differential is unchanged
+/// vs the no-shaping case (rewards differ only by a uniform team-wide bonus).
+#[test]
+fn test_shaping_is_team_shared() {
+    // Two engines that differ only in lambda. Same RNG seed + same actions
+    // -> identical houses dynamics -> only difference in rewards is the
+    // shaping term.
+    let mut scenario_a = SCENARIOS.get("default").unwrap().clone();
+    scenario_a.team_welfare_kind = "team_welfare_closed_form".to_string();
+    scenario_a.team_welfare_lambda = 0.0;
+    scenario_a.team_welfare_gamma = 0.99;
+
+    let mut scenario_b = scenario_a.clone();
+    scenario_b.team_welfare_lambda = 1.5;
+
+    let mut engine_a = BucketBrigade::new(scenario_a, 4, Some(99));
+    let mut engine_b = BucketBrigade::new(scenario_b, 4, Some(99));
+
+    let actions = vec![[1, 1, 1], [2, 1, 1], [3, 0, 0], [4, 1, 1]];
+    for _ in 0..10 {
+        if engine_a.done {
+            break;
+        }
+        let r_a = engine_a.step(&actions).rewards;
+        let r_b = engine_b.step(&actions).rewards;
+        // Confirm trajectories aligned.
+        assert_eq!(engine_a.houses, engine_b.houses, "trajectories diverged");
+        // Per-agent differential under team-shared shaping must be uniform.
+        let diff0 = r_b[0] - r_a[0];
+        for i in 1..r_a.len() {
+            let diff_i = r_b[i] - r_a[i];
+            assert!(
+                (diff_i - diff0).abs() < 1e-4,
+                "Shaping must be team-shared; per-agent diff non-uniform: {} vs {}",
+                diff_i,
+                diff0
+            );
+        }
+    }
+}
+
+// ==============================================================================
 // Property-Based Tests
 // ==============================================================================
 
@@ -1223,6 +1363,11 @@ mod proptests {
                 // Issue #265: progress shaping off so the existing proptest
                 // invariants (which assume pre-#265 reward semantics) hold.
                 progress_shaping_coef: 0.0,
+                // Issue #283: potential-based shaping off so existing
+                // proptest invariants (assume pre-#283 reward semantics) hold.
+                team_welfare_lambda: 0.0,
+                team_welfare_gamma: 1.0,
+                team_welfare_kind: "none".to_string(),
             };
 
             let mut engine = BucketBrigade::new(scenario, 4, Some(42));

--- a/bucket-brigade-core/src/python.rs
+++ b/bucket-brigade-core/src/python.rs
@@ -171,6 +171,14 @@ impl PyScenario {
             // to the pre-#265 path. Non-zero values flow through to the
             // engine's progress-shaping block in ``engine/rewards.rs``.
             progress_shaping_coef,
+            // Issue #283: potential-based team-welfare shaping defaults
+            // to off (lambda=0 and kind="none" -> engine fast-path skip).
+            // PyScenario callers that need shaping should access scenarios
+            // through ``bucket_brigade_core.SCENARIOS[...]`` or the JSON
+            // path which preserves all fields.
+            team_welfare_lambda: 0.0,
+            team_welfare_gamma: 1.0,
+            team_welfare_kind: "none".to_string(),
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator. The literal above is safe today but the helper keeps the

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -91,6 +91,66 @@ fn default_progress_shaping_coef() -> f32 {
     0.0
 }
 
+/// Default for `Scenario::team_welfare_lambda` (issue #283). Zero preserves
+/// bit-exact backward compatibility with pre-#283 behavior (the engine takes
+/// a fast-path skip when lambda is zero). When non-zero, each step's reward
+/// is augmented by `lambda * (gamma * Phi(s') - Phi(s))` where `Phi` is the
+/// potential function selected by `team_welfare_kind`. Per Ng-Harada-Russell
+/// (1999), this shaping leaves the optimal policy set invariant for any
+/// `Phi: S -> R`.
+fn default_team_welfare_lambda() -> f32 {
+    0.0
+}
+
+/// Default for `Scenario::team_welfare_gamma` (issue #283). 1.0 collapses the
+/// shaping term to `lambda * (Phi(s') - Phi(s))` — a simple delta — which is
+/// the right starting point when shaping is enabled without coordinating
+/// with the trainer's PPO discount. NHR invariance holds for any
+/// `gamma in [0, 1]`; matching the trainer's gamma maximizes the strength of
+/// the invariance argument.
+fn default_team_welfare_gamma() -> f32 {
+    1.0
+}
+
+/// Allowed values for `Scenario::team_welfare_kind` (issue #283). Keep in
+/// sync with the Python validator in
+/// `bucket_brigade/envs/scenarios_generated.py::Scenario.__post_init__`.
+///
+/// - `"none"`: shaping disabled (also implied when `team_welfare_lambda` is
+///   zero — both paths take the fast-path skip in `engine/rewards.rs`).
+/// - `"team_welfare_closed_form"`: option B from issue #283. Closed-form
+///   team-welfare potential
+///   `Phi(s) = team_reward*(safe/N) - team_penalty*(ruined/N)
+///   - 0.5*team_penalty*(burning/N)`.
+///   Cheap, debuggable proxy for team value. No learning required.
+pub const ALLOWED_TEAM_WELFARE_KINDS: &[&str] = &["none", "team_welfare_closed_form"];
+
+/// Default for `Scenario::team_welfare_kind` (issue #283). `"none"` keeps the
+/// shaping disabled even if a stale `team_welfare_lambda` is non-zero in
+/// some external scenario JSON; both fields must be set for shaping to fire.
+fn default_team_welfare_kind() -> String {
+    "none".to_string()
+}
+
+/// Custom serde deserializer for `Scenario::team_welfare_kind` (issue #283)
+/// that enforces the `ALLOWED_TEAM_WELFARE_KINDS` allowlist. Mirrors the
+/// `distance_metric` deserializer's pattern — without this guard, an
+/// unrecognized kind would silently disable shaping at runtime.
+fn deserialize_team_welfare_kind<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    let s = String::deserialize(deserializer)?;
+    if !ALLOWED_TEAM_WELFARE_KINDS.contains(&s.as_str()) {
+        return Err(D::Error::custom(format!(
+            "Scenario.team_welfare_kind={s:?} is not supported; allowed values: {ALLOWED_TEAM_WELFARE_KINDS:?}"
+        )));
+    }
+    Ok(s)
+}
+
+
 /// Allowed values for `Scenario::distance_metric`.
 ///
 /// `engine/rewards.rs` currently consumes `distance_cost_alpha + ring_dist_10(...)`
@@ -239,6 +299,27 @@ pub struct Scenario {
     // the potential-based variant explicitly.
     #[serde(default = "default_progress_shaping_coef")]
     pub progress_shaping_coef: f32,
+
+    // Potential-based team-welfare shaping (issue #283, Ng-Harada-Russell 1999).
+    //
+    // Default `team_welfare_lambda == 0.0` preserves bit-exact pre-#283
+    // behavior. The engine takes a fast-path skip when lambda is zero or
+    // kind is `"none"` (see `engine/rewards.rs`).
+    //
+    // When enabled, each step's reward is augmented by
+    //     `lambda * (gamma * Phi(s') - Phi(s))`
+    // shared equally across all agents. `Phi(terminal) := 0` is enforced so
+    // the telescoping sum identity holds exactly, preserving the NHR
+    // optimal-policy-invariance theorem.
+    #[serde(default = "default_team_welfare_lambda")]
+    pub team_welfare_lambda: f32,
+    #[serde(default = "default_team_welfare_gamma")]
+    pub team_welfare_gamma: f32,
+    #[serde(
+        default = "default_team_welfare_kind",
+        deserialize_with = "deserialize_team_welfare_kind"
+    )]
+    pub team_welfare_kind: String,
 }
 
 impl Scenario {
@@ -256,6 +337,16 @@ impl Scenario {
             return Err(format!(
                 "Scenario.distance_metric={:?} is not supported; allowed values: {:?}",
                 self.distance_metric, ALLOWED_DISTANCE_METRICS
+            ));
+        }
+        // Issue #283: team_welfare_kind allowlist re-check for the
+        // programmatic-construction path (PyScenario kwargs, WASM
+        // construction, Rust literal builds). Mirrors the
+        // `distance_metric` re-check above.
+        if !ALLOWED_TEAM_WELFARE_KINDS.contains(&self.team_welfare_kind.as_str()) {
+            return Err(format!(
+                "Scenario.team_welfare_kind={:?} is not supported; allowed values: {:?}",
+                self.team_welfare_kind, ALLOWED_TEAM_WELFARE_KINDS
             ));
         }
         Ok(())
@@ -312,6 +403,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -336,6 +430,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -360,6 +457,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -385,6 +485,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -409,6 +512,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -433,6 +539,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -457,6 +566,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -481,6 +593,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -505,6 +620,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -529,6 +647,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -553,6 +674,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -577,6 +701,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -608,6 +735,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -638,6 +768,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -671,6 +804,9 @@ pub static SCENARIOS: LazyLock<HashMap<&'static str, Scenario>> = LazyLock::new(
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         },
     );
 
@@ -1244,6 +1380,9 @@ mod tests {
             action_shaping_alpha: default_action_shaping_alpha(),
             action_shaping_beta: default_action_shaping_beta(),
             progress_shaping_coef: default_progress_shaping_coef(),
+            team_welfare_lambda: default_team_welfare_lambda(),
+            team_welfare_gamma: default_team_welfare_gamma(),
+            team_welfare_kind: default_team_welfare_kind(),
         };
         let err = scenario
             .validate()

--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -176,6 +176,13 @@ impl WasmScenario {
             // JS/TS callers see byte-identical rewards. Routed through the
             // JSON path (``Scenario::to_json`` / ``from_json``) when non-zero.
             progress_shaping_coef: 0.0,
+            // Issue #283: potential-based team-welfare shaping defaults to
+            // off so existing JS/TS callers see byte-identical rewards.
+            // The browser UI doesn't expose these knobs; to consume a
+            // scenario with shaping enabled, route through the JSON path.
+            team_welfare_lambda: 0.0,
+            team_welfare_gamma: 1.0,
+            team_welfare_kind: "none".to_string(),
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator so future kwargs additions can't reintroduce silent

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -514,9 +514,7 @@ class BucketBrigadeEnv:
         # scenario) this block is skipped entirely so per-step rewards are
         # byte-identical to pre-#283 behavior. Mirrors the Rust
         # implementation in ``bucket-brigade-core/src/engine/rewards.rs``.
-        team_welfare_lambda = float(
-            getattr(self.scenario, "team_welfare_lambda", 0.0)
-        )
+        team_welfare_lambda = float(getattr(self.scenario, "team_welfare_lambda", 0.0))
         team_welfare_kind = getattr(self.scenario, "team_welfare_kind", "none")
         if team_welfare_lambda != 0.0 and team_welfare_kind != "none":
             gamma = float(getattr(self.scenario, "team_welfare_gamma", 1.0))
@@ -531,8 +529,8 @@ class BucketBrigadeEnv:
             # final-step bonus would leak a Phi(s_T) term that depends on
             # the policy's terminal state — breaking invariance.
             is_terminal_next = self._check_termination()
-            phi_next = 0.0 if is_terminal_next else self._compute_team_welfare_phi(
-                self.houses
+            phi_next = (
+                0.0 if is_terminal_next else self._compute_team_welfare_phi(self.houses)
             )
             shaping_term = team_welfare_lambda * (gamma * phi_next - phi_prev)
             # Apply to every agent (team-shared bonus). Float32 to match

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -291,6 +291,50 @@ class BucketBrigadeEnv:
             ):
                 self.houses[house_idx] = self.BURNING
 
+    def _compute_team_welfare_phi(self, houses: np.ndarray) -> float:
+        """Issue #283: closed-form team-welfare potential Phi(s).
+
+        Option B from the issue: a cheap, debuggable proxy for team value
+        that's tied to the scenario's team-reward weights so the shaping
+        signal stays on the same scale as the base team reward.
+
+            Phi(s) = team_reward * (safe/N)
+                     - team_penalty * (ruined/N)
+                     - 0.5 * team_penalty * (burning/N)
+
+        The 0.5x weight on burning houses captures "anticipated burnout
+        cost" — a burning house is partway between SAFE and RUINED in
+        expectation but is still recoverable, so we charge half the
+        ruined penalty.
+
+        IMPORTANT: This is a pure function of ``houses`` (the state-only
+        signature is what makes the NHR telescoping identity hold). Do
+        not let any policy-conditioned features leak in. Mirrors
+        ``bucket-brigade-core/src/engine/rewards.rs::team_welfare_phi``.
+        """
+        kind = getattr(self.scenario, "team_welfare_kind", "none")
+        if kind == "none":
+            return 0.0
+        if kind == "team_welfare_closed_form":
+            num_houses_f = float(self.num_houses)
+            num_safe = float(np.sum(houses == self.SAFE))
+            num_ruined = float(np.sum(houses == self.RUINED))
+            num_burning = float(np.sum(houses == self.BURNING))
+            w_safe = float(self.scenario.team_reward_house_survives)
+            w_penalty = float(self.scenario.team_penalty_house_burns)
+            return (
+                w_safe * (num_safe / num_houses_f)
+                - w_penalty * (num_ruined / num_houses_f)
+                - 0.5 * w_penalty * (num_burning / num_houses_f)
+            )
+        # Defensive — ``__post_init__`` already rejects unknown kinds, but
+        # keep this branch so future kinds added without env support
+        # surface a clear error rather than silently returning 0.
+        raise ValueError(
+            f"Unknown team_welfare_kind={kind!r}; supported: "
+            f"('none', 'team_welfare_closed_form')."
+        )
+
     def _compute_rewards(self, actions: np.ndarray) -> np.ndarray:
         """Compute rewards for all agents."""
         # Store previous house states to compute changes
@@ -456,6 +500,44 @@ class BucketBrigadeEnv:
                     and self.houses[h] == self.SAFE
                 ):
                     individual_rewards[agent_idx] += action_beta
+
+        # Potential-based team-welfare shaping (issue #283, NHR 1999).
+        #
+        # F(s, a, s') = lambda * (gamma * Phi(s') - Phi(s))
+        #
+        # Added to every agent's reward (team-shared bonus). At a terminal
+        # transition Phi(s') is forced to 0 so the telescoping sum collapses
+        # to a policy-independent constant `gamma^T * Phi(s_T) - Phi(s_0) =
+        # -Phi(s_0)`, exactly preserving the NHR invariance theorem.
+        #
+        # When ``team_welfare_lambda == 0.0`` (the default for every pre-#283
+        # scenario) this block is skipped entirely so per-step rewards are
+        # byte-identical to pre-#283 behavior. Mirrors the Rust
+        # implementation in ``bucket-brigade-core/src/engine/rewards.rs``.
+        team_welfare_lambda = float(
+            getattr(self.scenario, "team_welfare_lambda", 0.0)
+        )
+        team_welfare_kind = getattr(self.scenario, "team_welfare_kind", "none")
+        if team_welfare_lambda != 0.0 and team_welfare_kind != "none":
+            gamma = float(getattr(self.scenario, "team_welfare_gamma", 1.0))
+            phi_prev = self._compute_team_welfare_phi(prev_houses)
+            # Determine whether s' is a terminal state. ``_check_termination``
+            # is a pure function of ``self.houses`` and ``self.night`` (which
+            # has not yet been advanced — see ``step()`` step order), so
+            # calling it here is safe and idempotent.
+            #
+            # Terminal-state convention (NHR): Phi(terminal) := 0 so the
+            # telescoping sum identity holds exactly. Without this, the
+            # final-step bonus would leak a Phi(s_T) term that depends on
+            # the policy's terminal state — breaking invariance.
+            is_terminal_next = self._check_termination()
+            phi_next = 0.0 if is_terminal_next else self._compute_team_welfare_phi(
+                self.houses
+            )
+            shaping_term = team_welfare_lambda * (gamma * phi_next - phi_prev)
+            # Apply to every agent (team-shared bonus). Float32 to match
+            # the rest of the reward vector dtype.
+            individual_rewards += np.float32(shaping_term)
 
         return individual_rewards
 

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -113,6 +113,42 @@ class Scenario:
     # the cheap mechanical test of the dense-team-signal hypothesis.
     progress_shaping_coef: float = 0.0
 
+    # Potential-based team-welfare shaping (issue #283, Ng-Harada-Russell 1999).
+    # Default ``team_welfare_lambda == 0.0`` preserves bit-exact pre-#283
+    # behavior (the env takes a fast-path skip when lambda is zero).
+    #
+    # When non-zero, an aligned per-step bonus ``F(s, a, s') = lambda * (
+    # gamma * Phi(s') - Phi(s))`` is added to every agent's reward, shared
+    # equally across the team. ``Phi(terminal) = 0`` is enforced exactly so
+    # the telescoping sum identity holds:
+    #     sum_t gamma^t F_t = lambda * (gamma^T Phi(s_T) - Phi(s_0))
+    # which collapses to a constant ``-lambda * Phi(s_0)`` per episode when
+    # ``Phi(s_T) == 0`` is enforced. NHR (ICML 1999) guarantees the optimal
+    # policy set is preserved under this shaping for any potential ``Phi``.
+    #
+    # ``team_welfare_kind`` selects the potential function:
+    #   - ``"none"``: shaping disabled (also implied when lambda == 0.0)
+    #   - ``"team_welfare_closed_form"`` (option B from the issue):
+    #         Phi(s) = team_reward * (safe/N) - team_penalty * (ruined/N)
+    #                 - 0.5 * team_penalty * (burning/N)
+    #     A cheap, debuggable closed-form proxy for team value. Coefficients
+    #     are tied to the scenario's team-reward weights so the shaping
+    #     signal stays on the same scale as the base reward.
+    #
+    # ``team_welfare_gamma`` is the NHR discount factor. It is **separate from**
+    # the trainer's PPO discount (which is set in JointPPOTrainer) — the
+    # theorem holds for *any* gamma applied in ``gamma * Phi(s') - Phi(s)``,
+    # but invariance is strongest when this matches the trainer's gamma.
+    # Default 1.0 keeps the shaping signal a simple delta when lambda is
+    # turned on without a matching trainer discount setting.
+    #
+    # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_team_welfare_phi``
+    # and ``bucket-brigade-core/src/engine/rewards.rs::team_welfare_phi`` for
+    # the canonical implementations (kept in byte-parity).
+    team_welfare_lambda: float = 0.0
+    team_welfare_gamma: float = 1.0
+    team_welfare_kind: str = "none"
+
     def __post_init__(self) -> None:
         """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -182,6 +218,18 @@ class Scenario:
             raise ValueError(
                 f"Scenario.distance_metric={self.distance_metric!r} "
                 "is not supported; only 'ring_arc' is implemented today."
+            )
+
+        # Issue #283: potential-based team-welfare shaping allowlist.
+        # Keep in sync with the Rust validator in
+        # ``bucket-brigade-core/src/scenarios.rs::ALLOWED_TEAM_WELFARE_KINDS``.
+        # ``"none"`` is the default and means shaping is disabled even if
+        # lambda is non-zero (the env shortcuts on kind="none").
+        allowed_team_welfare_kinds = ("none", "team_welfare_closed_form")
+        if self.team_welfare_kind not in allowed_team_welfare_kinds:
+            raise ValueError(
+                f"Scenario.team_welfare_kind={self.team_welfare_kind!r} "
+                f"is not supported; allowed values: {allowed_team_welfare_kinds!r}."
             )
 
     def to_feature_vector(self) -> np.ndarray:

--- a/experiments/p3_specialization/run_issue283_sweep.sh
+++ b/experiments/p3_specialization/run_issue283_sweep.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Issue #283 sweep driver — potential-based team-welfare shaping calibration
+# on minimal_specialization. Ng-Harada-Russell (1999) aligned shaping.
+#
+# Pre-registered grid:
+#   lambda in {0.0, 0.1, 0.5, 1.0}                              = 4 cells
+#   kind   = "team_welfare_closed_form"  (option B)
+#   gamma  = 0.99 (matches typical PPO discount)
+#   seeds  {42, 43, 44}                                          = 3 each
+#   total  = 12 cells
+#
+# Per cell: 50 iterations x 2048 rollout steps x IPPO (no MAPPO).
+#
+# The lambda=0 cell is the in-sweep baseline (env fast-path skip; reward
+# stream byte-identical to pre-#283). It anchors the within-sweep gap
+# comparison so we're not comparing to a stale historical baseline.
+#
+# Layout (intended for the future analyze_283_potential_shaping.py):
+#   experiments/p3_specialization/runs/issue283_potential_shaping/
+#       kind_{KIND}/lambda_{LAMBDA}/seed_{SEED}/
+#           metrics.json, config.json, policies/, train.log
+#
+# Wall-clock: ~1.5 min/cell at 50 iters; 12 cells / 4-way parallel
+# ~5 min ideal. Estimated ~10-15 min realistic on COMPUTE_HOST_PRIMARY.
+#
+# Per CLAUDE.md compute guidelines: DO NOT RUN LOCALLY. This is a sweep
+# script — execute it inside tmux on COMPUTE_HOST_PRIMARY only. Smoke
+# tests (single seed, ~10 iters, lambda=1) can run locally but the full
+# sweep is bound for the remote host.
+#
+# Modeled on experiments/p3_specialization/run_issue262_sweep.sh
+# (xargs -P parallelism, per-cell stdout, git-rev stamping).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+if [[ ! -d "$REPO_ROOT" ]]; then
+  # Fallback used on the Mac Studio.
+  if [[ -d "$HOME/bucket-brigade" ]]; then
+    REPO_ROOT="$HOME/bucket-brigade"
+  fi
+fi
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+SCENARIO="${SCENARIO:-minimal_specialization}"
+NUM_ITERATIONS="${NUM_ITERATIONS:-50}"
+ROLLOUT_STEPS="${ROLLOUT_STEPS:-2048}"
+SEEDS=(42 43 44)
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-4}"
+
+# Pre-registered grid. The baseline cell (lambda=0) anchors the in-sweep
+# comparison; the other 3 cells span the calibration grid.
+LAMBDAS=(0.0 0.1 0.5 1.0)
+# Default to option B (closed-form). Add "specialist_mc_regressor" here
+# when option A lands (#283 followup).
+KIND="${TEAM_WELFARE_KIND:-team_welfare_closed_form}"
+# NHR discount. Matched to a typical PPO gamma so the invariance argument
+# is tight; configurable via env var.
+TEAM_WELFARE_GAMMA="${TEAM_WELFARE_GAMMA:-0.99}"
+
+# Build job list (lambda|seed|outdir). The lambda=0 cell uses kind="none"
+# automatically via the env fast-path skip; we still pass the kind so the
+# config.json records the intended (non-)treatment cleanly.
+jobs=()
+for lam in "${LAMBDAS[@]}"; do
+  for seed in "${SEEDS[@]}"; do
+    outdir="$OUTPUT_ROOT/issue283_potential_shaping/kind_${KIND}/lambda_${lam}/seed_${seed}"
+    jobs+=("${lam}|${seed}|${outdir}")
+  done
+done
+
+echo
+echo "============================================================"
+echo "Issue #283 potential-based team-welfare shaping sweep"
+echo "  scenario:           $SCENARIO"
+echo "  num_iterations:     $NUM_ITERATIONS"
+echo "  rollout_steps:      $ROLLOUT_STEPS"
+echo "  kind:               $KIND"
+echo "  team_welfare_gamma: $TEAM_WELFARE_GAMMA"
+echo "  lambdas:            ${LAMBDAS[*]}"
+echo "  seeds:              ${SEEDS[*]}"
+echo "  cells:              ${#jobs[@]}"
+echo "  parallelism:        $PARALLEL_PER_POOL"
+echo "============================================================"
+
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r lam seed outdir <<< "$spec"
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (lambda=$lam)"
+  if uv run python -m experiments.p3_specialization.train \
+       --scenario "$SCENARIO" --lambda-red 0.0 --seed "$seed" \
+       --num-iterations "$NUM_ITERATIONS" --rollout-steps "$ROLLOUT_STEPS" \
+       --team-welfare-lambda "$lam" \
+       --team-welfare-gamma "$TEAM_WELFARE_GAMMA" \
+       --team-welfare-kind "$KIND" \
+       --output-dir "$outdir" \
+       > "$outdir/train.log" 2>&1; then
+    if [[ -f "$outdir/config.json" ]]; then
+      python3 -c "
+import json
+p = '$outdir/config.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 283
+c['_team_welfare_lambda'] = float('$lam')
+c['_team_welfare_gamma'] = float('$TEAM_WELFARE_GAMMA')
+c['_team_welfare_kind'] = '$KIND'
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    fi
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export SCENARIO NUM_ITERATIONS ROLLOUT_STEPS GIT_REV TEAM_WELFARE_GAMMA KIND
+
+echo
+echo "--- Launching ${#jobs[@]} cells, ${PARALLEL_PER_POOL}-way parallel ---"
+printf "%s\n" "${jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+
+echo
+echo "============================================================"
+echo "Issue #283 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "============================================================"
+touch "$OUTPUT_ROOT/.issue283_potential_shaping_done"

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -123,6 +123,15 @@ class CellConfig:
     # skip, and preserves bit-identical pre-#265 behavior. The #265 sweep
     # driver passes per-cell values via ``--progress-shaping-coef``.
     progress_shaping_coef: float = 0.0
+    # Issue #283: potential-based team-welfare shaping knobs (Ng-Harada-Russell
+    # 1999). Mutated onto the loaded ``Scenario`` instance in ``train_one_cell``
+    # next to the action-shaping mutation. Defaults match
+    # ``Scenario.team_welfare_lambda`` / ``_gamma`` / ``_kind``:
+    # lambda=0.0 and kind="none" keep the env fast-path skip and
+    # bit-identical pre-#283 behavior.
+    team_welfare_lambda: float = 0.0
+    team_welfare_gamma: float = 1.0
+    team_welfare_kind: str = "none"
     # Issue #270: optional BC-pretrained init. Directory containing per-agent
     # ``agent_{i}.pt`` state dicts produced by
     # ``experiments/p3_specialization/bc_init.py``. ``None`` (default)
@@ -652,6 +661,15 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
     # behavior; the #265 sweep driver passes per-cell values.
     scenario.progress_shaping_coef = float(cfg.progress_shaping_coef)
 
+    # Issue #283: potential-based team-welfare shaping (Ng-Harada-Russell 1999).
+    # Mutate the same loaded ``Scenario`` instance. When lambda=0.0 (default)
+    # the env takes the fast-path skip and per-step rewards are byte-identical
+    # to pre-#283 behavior, so the in-sweep baseline cell can share the same
+    # code path as treatment cells without distorting the comparison.
+    scenario.team_welfare_lambda = float(cfg.team_welfare_lambda)
+    scenario.team_welfare_gamma = float(cfg.team_welfare_gamma)
+    scenario.team_welfare_kind = str(cfg.team_welfare_kind)
+
     def env_fn():
         env = BucketBrigadeEnv(scenario=scenario)
         return env
@@ -914,6 +932,43 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--team-welfare-lambda",
+        type=float,
+        default=CellConfig.__dataclass_fields__["team_welfare_lambda"].default,
+        help=(
+            "Issue #283: potential-based team-welfare shaping multiplier "
+            "(Ng-Harada-Russell 1999). Mutated onto the loaded Scenario "
+            "instance pre-rollout. Default 0.0 keeps the env fast-path "
+            "skip and bit-identical pre-#283 behavior. Sweep cells: "
+            "{0.0, 0.1, 0.5, 1.0}."
+        ),
+    )
+    p.add_argument(
+        "--team-welfare-gamma",
+        type=float,
+        default=CellConfig.__dataclass_fields__["team_welfare_gamma"].default,
+        help=(
+            "Issue #283: NHR discount factor in `gamma*Phi(s') - Phi(s)`. "
+            "Default 1.0 collapses shaping to a simple delta. Should "
+            "match the trainer's PPO gamma for maximum invariance "
+            "strength, but NHR holds for any gamma in [0, 1]."
+        ),
+    )
+    p.add_argument(
+        "--team-welfare-kind",
+        type=str,
+        default=CellConfig.__dataclass_fields__["team_welfare_kind"].default,
+        choices=("none", "team_welfare_closed_form"),
+        help=(
+            "Issue #283: potential function selector. 'none' disables "
+            "shaping. 'team_welfare_closed_form' = option B (cheap, no "
+            "learning): Phi(s) = team_reward*safe/N - team_penalty*ruined/N "
+            "- 0.5*team_penalty*burning/N. Future kinds (e.g., "
+            "'specialist_mc_regressor' = option A) will be added when "
+            "the headline Phi regressor lands."
+        ),
+    )
+    p.add_argument(
         "--bc-init-checkpoint-dir",
         type=str,
         default=None,
@@ -961,6 +1016,9 @@ def main() -> None:
         action_shaping_alpha=args.action_shaping_alpha,
         action_shaping_beta=args.action_shaping_beta,
         progress_shaping_coef=args.progress_shaping_coef,
+        team_welfare_lambda=args.team_welfare_lambda,
+        team_welfare_gamma=args.team_welfare_gamma,
+        team_welfare_kind=args.team_welfare_kind,
         bc_init_checkpoint_dir=args.bc_init_checkpoint_dir,
         gae_lambda=args.gae_lambda,
         device=args.device,
@@ -971,7 +1029,9 @@ def main() -> None:
         f"gae_lambda={cfg.gae_lambda} "
         f"action_shaping_alpha={cfg.action_shaping_alpha} "
         f"action_shaping_beta={cfg.action_shaping_beta} "
-        f"progress_shaping_coef={cfg.progress_shaping_coef} =="
+        f"progress_shaping_coef={cfg.progress_shaping_coef} "
+        f"team_welfare_lambda={cfg.team_welfare_lambda} "
+        f"team_welfare_kind={cfg.team_welfare_kind} =="
     )
     train_one_cell(cfg, args.output_dir)
 

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -213,6 +213,42 @@ def generate_scenarios(json_path: Path, output_path: Path):
         # the cheap mechanical test of the dense-team-signal hypothesis.
         progress_shaping_coef: float = 0.0
 
+        # Potential-based team-welfare shaping (issue #283, Ng-Harada-Russell 1999).
+        # Default ``team_welfare_lambda == 0.0`` preserves bit-exact pre-#283
+        # behavior (the env takes a fast-path skip when lambda is zero).
+        #
+        # When non-zero, an aligned per-step bonus ``F(s, a, s') = lambda * (
+        # gamma * Phi(s') - Phi(s))`` is added to every agent's reward, shared
+        # equally across the team. ``Phi(terminal) = 0`` is enforced exactly so
+        # the telescoping sum identity holds:
+        #     sum_t gamma^t F_t = lambda * (gamma^T Phi(s_T) - Phi(s_0))
+        # which collapses to a constant ``-lambda * Phi(s_0)`` per episode when
+        # ``Phi(s_T) == 0`` is enforced. NHR (ICML 1999) guarantees the optimal
+        # policy set is preserved under this shaping for any potential ``Phi``.
+        #
+        # ``team_welfare_kind`` selects the potential function:
+        #   - ``"none"``: shaping disabled (also implied when lambda == 0.0)
+        #   - ``"team_welfare_closed_form"`` (option B from the issue):
+        #         Phi(s) = team_reward * (safe/N) - team_penalty * (ruined/N)
+        #                 - 0.5 * team_penalty * (burning/N)
+        #     A cheap, debuggable closed-form proxy for team value. Coefficients
+        #     are tied to the scenario's team-reward weights so the shaping
+        #     signal stays on the same scale as the base reward.
+        #
+        # ``team_welfare_gamma`` is the NHR discount factor. It is **separate from**
+        # the trainer's PPO discount (which is set in JointPPOTrainer) — the
+        # theorem holds for *any* gamma applied in ``gamma * Phi(s') - Phi(s)``,
+        # but invariance is strongest when this matches the trainer's gamma.
+        # Default 1.0 keeps the shaping signal a simple delta when lambda is
+        # turned on without a matching trainer discount setting.
+        #
+        # See ``bucket_brigade/envs/bucket_brigade_env.py::_compute_team_welfare_phi``
+        # and ``bucket-brigade-core/src/engine/rewards.rs::team_welfare_phi`` for
+        # the canonical implementations (kept in byte-parity).
+        team_welfare_lambda: float = 0.0
+        team_welfare_gamma: float = 1.0
+        team_welfare_kind: str = "none"
+
         def __post_init__(self) -> None:
             """Auto-promote scalar ownership reward fields to per-agent vectors.
 
@@ -282,6 +318,18 @@ def generate_scenarios(json_path: Path, output_path: Path):
                 raise ValueError(
                     f"Scenario.distance_metric={self.distance_metric!r} "
                     "is not supported; only 'ring_arc' is implemented today."
+                )
+
+            # Issue #283: potential-based team-welfare shaping allowlist.
+            # Keep in sync with the Rust validator in
+            # ``bucket-brigade-core/src/scenarios.rs::ALLOWED_TEAM_WELFARE_KINDS``.
+            # ``"none"`` is the default and means shaping is disabled even if
+            # lambda is non-zero (the env shortcuts on kind="none").
+            allowed_team_welfare_kinds = ("none", "team_welfare_closed_form")
+            if self.team_welfare_kind not in allowed_team_welfare_kinds:
+                raise ValueError(
+                    f"Scenario.team_welfare_kind={self.team_welfare_kind!r} "
+                    f"is not supported; allowed values: {allowed_team_welfare_kinds!r}."
                 )
 
         def to_feature_vector(self) -> np.ndarray:
@@ -379,6 +427,22 @@ def generate_scenarios(json_path: Path, output_path: Path):
         if "progress_shaping_coef" in spec:
             code += (
                 f"        progress_shaping_coef={spec['progress_shaping_coef']},\n"
+            )
+        # Issue #283 optional potential-based shaping fields. Emit only when
+        # set in JSON so every pre-#283 scenario factory is byte-identical
+        # to pre-#283 codegen output (they keep the dataclass defaults:
+        # lambda=0.0, gamma=1.0, kind="none").
+        if "team_welfare_lambda" in spec:
+            code += (
+                f"        team_welfare_lambda={spec['team_welfare_lambda']},\n"
+            )
+        if "team_welfare_gamma" in spec:
+            code += (
+                f"        team_welfare_gamma={spec['team_welfare_gamma']},\n"
+            )
+        if "team_welfare_kind" in spec:
+            code += (
+                f"        team_welfare_kind={spec['team_welfare_kind']!r},\n"
             )
         code += f"    )\n\n\n"
 

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -378,7 +378,7 @@ def generate_scenarios(json_path: Path, output_path: Path):
         function_name = f"{name}_scenario"
         code += f"def {function_name}(num_agents: int) -> Scenario:\n"
         code += f'    """{spec["description"]}"""\n'
-        code += f"    return Scenario(\n"
+        code += "    return Scenario(\n"
         code += f"        prob_fire_spreads_to_neighbor={spec['prob_fire_spreads_to_neighbor']},\n"
         code += f"        prob_solo_agent_extinguishes_fire={spec['prob_solo_agent_extinguishes_fire']},\n"
         code += f"        prob_house_catches_fire={spec['prob_house_catches_fire']},\n"
@@ -392,7 +392,7 @@ def generate_scenarios(json_path: Path, output_path: Path):
         code += f"        penalty_other_house_burns={_emit_value(spec['penalty_other_house_burns'])},\n"
         code += f"        cost_to_work_one_night={spec['cost_to_work_one_night']},\n"
         code += f"        min_nights={spec['min_nights']},\n"
-        code += f"        num_agents=num_agents,\n"
+        code += "        num_agents=num_agents,\n"
         # Issue #203 optional spatial-cost fields. Emit only when set in JSON
         # (every other scenario keeps the dataclass defaults: empty list,
         # alpha=0.0, metric="ring_arc") so behavior is byte-identical to
@@ -414,37 +414,25 @@ def generate_scenarios(json_path: Path, output_path: Path):
         # pre-#259 codegen output (they all keep the dataclass defaults
         # of 0.0).
         if "action_shaping_alpha" in spec:
-            code += (
-                f"        action_shaping_alpha={spec['action_shaping_alpha']},\n"
-            )
+            code += f"        action_shaping_alpha={spec['action_shaping_alpha']},\n"
         if "action_shaping_beta" in spec:
-            code += (
-                f"        action_shaping_beta={spec['action_shaping_beta']},\n"
-            )
+            code += f"        action_shaping_beta={spec['action_shaping_beta']},\n"
         # Issue #265 optional dense progress shaping field. Emit only when set
         # in JSON so every pre-#265 scenario factory is byte-identical to
         # pre-#265 codegen output (they all keep the dataclass default of 0.0).
         if "progress_shaping_coef" in spec:
-            code += (
-                f"        progress_shaping_coef={spec['progress_shaping_coef']},\n"
-            )
+            code += f"        progress_shaping_coef={spec['progress_shaping_coef']},\n"
         # Issue #283 optional potential-based shaping fields. Emit only when
         # set in JSON so every pre-#283 scenario factory is byte-identical
         # to pre-#283 codegen output (they keep the dataclass defaults:
         # lambda=0.0, gamma=1.0, kind="none").
         if "team_welfare_lambda" in spec:
-            code += (
-                f"        team_welfare_lambda={spec['team_welfare_lambda']},\n"
-            )
+            code += f"        team_welfare_lambda={spec['team_welfare_lambda']},\n"
         if "team_welfare_gamma" in spec:
-            code += (
-                f"        team_welfare_gamma={spec['team_welfare_gamma']},\n"
-            )
+            code += f"        team_welfare_gamma={spec['team_welfare_gamma']},\n"
         if "team_welfare_kind" in spec:
-            code += (
-                f"        team_welfare_kind={spec['team_welfare_kind']!r},\n"
-            )
-        code += f"    )\n\n\n"
+            code += f"        team_welfare_kind={spec['team_welfare_kind']!r},\n"
+        code += "    )\n\n\n"
 
     # Generate SCENARIO_REGISTRY
     code += "\n# Registry of all scenarios\n"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1395,9 +1395,7 @@ class TestPotentialBasedShaping:
             team_welfare_gamma=gamma,
             team_welfare_kind="team_welfare_closed_form",
         )
-        scenario_shaped = dataclasses.replace(
-            scenario_base, team_welfare_lambda=1.0
-        )
+        scenario_shaped = dataclasses.replace(scenario_base, team_welfare_lambda=1.0)
         env_base = BucketBrigadeEnv(scenario=scenario_base)
         env_shaped = BucketBrigadeEnv(scenario=scenario_shaped)
         # Identical RNG seed -> identical fire dynamics under identical
@@ -1443,8 +1441,7 @@ class TestPotentialBasedShaping:
                 f"shaped envs ({env_base.houses} vs {env_shaped.houses})."
             )
             assert bool(dones_base[0]) == bool(dones_shaped[0]), (
-                f"Step {t}: done flags diverged ({dones_base[0]} vs "
-                f"{dones_shaped[0]})."
+                f"Step {t}: done flags diverged ({dones_base[0]} vs {dones_shaped[0]})."
             )
 
             discount = gamma**t
@@ -1457,8 +1454,7 @@ class TestPotentialBasedShaping:
                 break
 
         assert terminated_at is not None, (
-            f"Episode did not terminate within {max_steps} steps; "
-            "test premise broken."
+            f"Episode did not terminate within {max_steps} steps; test premise broken."
         )
 
         # NHR identity: sum_t gamma^t F_t = lambda * (gamma^T Phi(s_T) - Phi(s_0)).
@@ -1582,7 +1578,10 @@ class TestPotentialBasedShaping:
         # agents — shaping is team-shared, not per-agent.
         diff = r_b - r_a
         np.testing.assert_allclose(
-            diff, np.full(4, diff[0]), rtol=0, atol=1e-5,
+            diff,
+            np.full(4, diff[0]),
+            rtol=0,
+            atol=1e-5,
             err_msg=(
                 "Potential-based shaping must apply equally to every "
                 "agent (team-shared bonus). Per-agent differential is "

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1166,3 +1166,426 @@ class TestActionShaping:
             assert np.all(np.isfinite(rewards))
             if dones[0]:
                 break
+
+
+class TestPotentialBasedShaping:
+    """Issue #283: potential-based team-welfare shaping (Ng-Harada-Russell 1999).
+
+    Adds an aligned per-step bonus ``F(s, a, s') = lambda * (
+    gamma * Phi(s') - Phi(s))`` shared across all agents. The
+    closed-form team-welfare potential (option B):
+        Phi(s) = team_reward * (safe/N)
+                 - team_penalty * (ruined/N)
+                 - 0.5 * team_penalty * (burning/N)
+    NHR (ICML 1999) guarantees the optimal-policy set is preserved under
+    this shaping for any potential function Phi.
+
+    The critical correctness test is the telescoping-identity check: if
+    Phi(s_T) = 0 is enforced at terminal states, the discounted sum of
+    shaping terms across a trajectory must equal a policy-independent
+    constant. A buggy implementation (e.g., forgetting to zero out the
+    terminal-state potential, or off-by-one in s vs s') breaks this
+    identity, and the test catches it.
+    """
+
+    def test_defaults_are_zero_across_all_scenarios(self):
+        """Every pre-#283 scenario keeps team_welfare_lambda=0.0 and
+        kind='none' so existing scenarios are bit-exactly unchanged."""
+        from bucket_brigade.envs.scenarios_generated import SCENARIO_REGISTRY
+
+        for name, factory in SCENARIO_REGISTRY.items():
+            s = factory(num_agents=4)
+            assert s.team_welfare_lambda == 0.0, (
+                f"Pre-#283 scenario '{name}' must keep "
+                f"team_welfare_lambda=0.0; got {s.team_welfare_lambda}"
+            )
+            assert s.team_welfare_kind == "none", (
+                f"Pre-#283 scenario '{name}' must keep "
+                f"team_welfare_kind='none'; got {s.team_welfare_kind!r}"
+            )
+            assert s.team_welfare_gamma == 1.0, (
+                f"Pre-#283 scenario '{name}' must keep "
+                f"team_welfare_gamma=1.0; got {s.team_welfare_gamma}"
+            )
+
+    def test_zero_lambda_matches_pre283_full_episode(self):
+        """Byte-identity regression guard: lambda=0 (any kind) produces the
+        same per-step reward trace as before — guards against accidental
+        side effects of threading the new fields through ``_compute_rewards``."""
+        env_a = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        # Same dynamics but with the new fields set explicitly to the
+        # disabled-shaping defaults — must produce identical rewards.
+        scenario_b = dataclasses.replace(
+            default_scenario(num_agents=4),
+            team_welfare_lambda=0.0,
+            team_welfare_gamma=1.0,
+            team_welfare_kind="none",
+        )
+        env_b = BucketBrigadeEnv(scenario=scenario_b)
+        env_a.reset(seed=99)
+        env_b.reset(seed=99)
+        rng = np.random.RandomState(0)
+        for _ in range(20):
+            actions = rng.randint(0, 2, size=(4, 3)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+            _, r_a, dones_a, _ = env_a.step(actions)
+            _, r_b, dones_b, _ = env_b.step(actions)
+            np.testing.assert_array_equal(r_a, r_b)
+            if bool(dones_a[0]):
+                break
+
+    def test_zero_lambda_with_kind_set_is_still_byte_identical(self):
+        """A scenario with kind=team_welfare_closed_form but lambda=0
+        must still produce byte-identical rewards (the env fast-path skips
+        shaping when lambda is zero, regardless of kind)."""
+        env_a = BucketBrigadeEnv(scenario=default_scenario(num_agents=4))
+        scenario_b = dataclasses.replace(
+            default_scenario(num_agents=4),
+            team_welfare_lambda=0.0,
+            team_welfare_gamma=0.99,  # different gamma — must still be inert
+            team_welfare_kind="team_welfare_closed_form",
+        )
+        env_b = BucketBrigadeEnv(scenario=scenario_b)
+        env_a.reset(seed=7)
+        env_b.reset(seed=7)
+        rng = np.random.RandomState(1)
+        for _ in range(15):
+            actions = rng.randint(0, 2, size=(4, 3)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+            _, r_a, dones_a, _ = env_a.step(actions)
+            _, r_b, dones_b, _ = env_b.step(actions)
+            np.testing.assert_array_equal(r_a, r_b)
+            if bool(dones_a[0]):
+                break
+
+    def test_phi_terminal_convention(self):
+        """At a truncated last step, the env must treat Phi(s') = 0 so the
+        shaping term at terminal becomes lambda * (-Phi(s)). This is the
+        NHR boundary condition that makes the telescoping identity exact.
+
+        We zero out every base-reward component (work cost, ownership,
+        team) so the per-agent reward equals the shaping term exactly,
+        making the terminal-state Phi(s')=0 convention directly testable.
+        """
+        # Compare two configurations: one where the step is terminal (and
+        # thus Phi(next) should be zeroed) and one where it's not (because
+        # the test setup forces a non-terminal next state). The per-agent
+        # reward must equal the shaping term in both cases.
+        scenario_terminal = _make_minimal_scenario(
+            # All base reward components zeroed so reward == shaping term.
+            team_reward_house_survives=0.0,
+            team_penalty_house_burns=0.0,
+            cost_to_work_one_night=0.0,
+            # min_nights=0 lets _check_termination fire on the first step.
+            # The env's `night` counter is 0 during the first step's
+            # termination check (it advances after) so `night >= min_nights`
+            # requires min_nights == 0 for first-step termination.
+            min_nights=0,
+            team_welfare_lambda=1.0,
+            team_welfare_gamma=0.99,
+            # Tie Phi to a separate non-zero scale so we can verify the
+            # terminal-zeroing without confounding with the base reward.
+            # Reusing Phi's coefficients from team_reward_* is the env's
+            # convention, but for this test we need both isolated.
+            # The closed-form Phi uses team_reward_house_survives and
+            # team_penalty_house_burns; both are 0 above, so Phi(s) = 0
+            # for ALL s, which makes the test vacuous.
+            #
+            # Solution: rest-reward component (+0.5 per REST agent) is
+            # hard-coded; instead, set BOTH team_reward and team_penalty
+            # to a non-zero scale -- the team reward is *added per agent*
+            # but the shaping is also per-agent so we just compute the
+            # expected total.
+            team_welfare_kind="team_welfare_closed_form",
+            prob_solo_agent_extinguishes_fire=1.0,  # deterministic save
+            prob_fire_spreads_to_neighbor=0.0,
+            prob_house_catches_fire=0.0,
+        )
+        # team_reward must be nonzero for Phi(s) to be nonzero, since Phi
+        # uses team_reward and team_penalty as coefficients. Reset them.
+        scenario_terminal = dataclasses.replace(
+            scenario_terminal,
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+        )
+        env = BucketBrigadeEnv(scenario=scenario_terminal)
+        env.reset(seed=0)
+        # Set up a single burning house at index 5; all 4 agents work it.
+        # After the step: house 5 is SAFE -> all houses SAFE -> terminate
+        # via _check_termination's `all_safe` branch.
+        env.houses = np.zeros(10, dtype=np.int8)
+        env.houses[5] = env.BURNING
+        env._prev_houses_state = env.houses.copy()
+        # Phi(s) before step: 1 burning, 9 safe, 0 ruined.
+        # = 10*(9/10) - 10*(0/10) - 0.5*10*(1/10) = 9 - 0 - 0.5 = 8.5
+        phi_prev_expected = 10.0 * 0.9 - 0.5 * 10.0 * 0.1
+        assert abs(phi_prev_expected - 8.5) < 1e-9
+        phi_prev = env._compute_team_welfare_phi(env._prev_houses_state)
+        assert abs(phi_prev - phi_prev_expected) < 1e-5
+
+        actions = np.array(
+            [[5, 1, 1], [5, 1, 1], [5, 1, 1], [5, 1, 1]],
+            dtype=np.int8,
+        )
+        _, rewards, dones, _ = env.step(actions)
+        assert bool(dones[0]), "Episode should have terminated this step"
+
+        # Decompose the expected reward:
+        #   - Work cost: 0 (cost_to_work_one_night = 0).
+        #   - Rest reward: 0 (all agents working).
+        #   - Ownership: 0 (own/other reward+penalty all zero).
+        #   - Team reward: team_reward_house_survives * 1.0 (all safe) = 10.0
+        #   - Shaping: lambda * (gamma * Phi(terminal) - Phi(prev))
+        #            = 1.0 * (0.99 * 0 - 8.5) = -8.5
+        # Total per agent: 10.0 + (-8.5) = 1.5
+        # Each agent receives the same total (team-shared shaping +
+        # team-shared team_reward).
+        expected_per_agent = 10.0 + (-phi_prev_expected)
+        for i, r in enumerate(rewards):
+            assert abs(float(r) - expected_per_agent) < 1e-4, (
+                f"Agent {i}: expected terminal-step reward "
+                f"team_reward + shaping = 10.0 + (-Phi(s_prev)) = "
+                f"{expected_per_agent}, got {float(r)}. Did the env "
+                f"forget the Phi(terminal)=0 convention? (Got value "
+                f"suggests Phi(s')=10.0 was used instead of 0.0.)"
+            )
+
+        # Negative control: if we'd used Phi(s') = Phi(actual all-safe) = 10
+        # instead of 0, each reward would have been 10 + (0.99*10 - 8.5) =
+        # 10 + 1.4 = 11.4 (not 1.5). Make sure the test would reject this.
+        wrong_shaping = 0.99 * 10.0 - 8.5
+        wrong_per_agent = 10.0 + wrong_shaping
+        assert abs(wrong_per_agent - 11.4) < 1e-4
+        assert abs(rewards[0] - wrong_per_agent) > 0.1, (
+            "Test sanity: if the terminal convention were broken, "
+            "rewards would be ~11.4, not the observed ~1.5. The test "
+            "must be sensitive to the difference."
+        )
+
+    def test_telescoping_identity_under_random_policy(self):
+        """CRITICAL: NHR invariance test. Under potential-based shaping,
+        the discounted sum of shaped rewards along any trajectory equals
+        the base discounted return + lambda * (gamma^T * Phi(s_T) - Phi(s_0)).
+
+        With Phi(terminal) := 0, the bracketed correction collapses to
+        -lambda * Phi(s_0), a constant independent of the policy or
+        trajectory tail. This is what makes NHR shaping invariant.
+
+        We verify by running the SAME policy (fixed seed) under both
+        lambda=0 (base) and lambda=1 (shaped) with everything else
+        deterministic, then checking the discounted-sum equation.
+
+        A buggy implementation that:
+          - forgets the terminal-state convention,
+          - swaps s and s' in the bonus,
+          - or fails to apply the discount inside the shaping bonus,
+        will violate this identity and the test will fail.
+        """
+        gamma = 0.99
+        # Build two envs that differ ONLY in lambda. Use a deterministic-
+        # enough setup that the same actions sequence produces the same
+        # trajectory in both envs (which is required for the per-step
+        # comparison to be meaningful).
+        scenario_base = _make_minimal_scenario(
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            min_nights=12,
+            cost_to_work_one_night=0.5,
+            team_welfare_lambda=0.0,
+            team_welfare_gamma=gamma,
+            team_welfare_kind="team_welfare_closed_form",
+        )
+        scenario_shaped = dataclasses.replace(
+            scenario_base, team_welfare_lambda=1.0
+        )
+        env_base = BucketBrigadeEnv(scenario=scenario_base)
+        env_shaped = BucketBrigadeEnv(scenario=scenario_shaped)
+        # Identical RNG seed -> identical fire dynamics under identical
+        # actions. We use the env-level seed for spread / spark / extinguish
+        # stochasticity.
+        env_base.reset(seed=12345)
+        env_shaped.reset(seed=12345)
+
+        # Snapshot s_0 for the constant correction term. Phi is computed
+        # from the env's `houses` after reset/initialization.
+        phi_s0_base = env_base._compute_team_welfare_phi(env_base.houses)
+        phi_s0_shaped = env_shaped._compute_team_welfare_phi(env_shaped.houses)
+        # Phi is a deterministic function of `houses` only; same seed ->
+        # same initial houses -> same Phi(s_0) in both envs.
+        assert phi_s0_base == phi_s0_shaped, (
+            f"Phi(s_0) must match across base/shaped envs with same seed; "
+            f"got base={phi_s0_base}, shaped={phi_s0_shaped}"
+        )
+        phi_s0 = phi_s0_base
+
+        rng = np.random.RandomState(2026)
+        # Track discounted sums per-agent. Both envs see the SAME actions.
+        discounted_base = np.zeros(4, dtype=np.float64)
+        discounted_shaped = np.zeros(4, dtype=np.float64)
+        t = 0
+        terminated_at = None
+        # Walk one full episode (or up to a long horizon if it doesn't
+        # terminate). We rely on min_nights=12 + nonzero ignition rate
+        # ensuring termination within a reasonable number of steps.
+        max_steps = 64
+        for _ in range(max_steps):
+            actions = rng.randint(0, 2, size=(4, 3)).astype(np.int8)
+            actions[:, 0] = rng.randint(0, 10, size=4)
+
+            _, r_base, dones_base, _ = env_base.step(actions)
+            _, r_shaped, dones_shaped, _ = env_shaped.step(actions)
+
+            # Same actions + same seed + same dynamics -> trajectories must
+            # match step-by-step. If this assertion fires, the test
+            # premise breaks and the comparison below is meaningless.
+            assert np.array_equal(env_base.houses, env_shaped.houses), (
+                f"Step {t}: house states diverged between base and "
+                f"shaped envs ({env_base.houses} vs {env_shaped.houses})."
+            )
+            assert bool(dones_base[0]) == bool(dones_shaped[0]), (
+                f"Step {t}: done flags diverged ({dones_base[0]} vs "
+                f"{dones_shaped[0]})."
+            )
+
+            discount = gamma**t
+            discounted_base += discount * r_base.astype(np.float64)
+            discounted_shaped += discount * r_shaped.astype(np.float64)
+            t += 1
+
+            if bool(dones_base[0]):
+                terminated_at = t
+                break
+
+        assert terminated_at is not None, (
+            f"Episode did not terminate within {max_steps} steps; "
+            "test premise broken."
+        )
+
+        # NHR identity: sum_t gamma^t F_t = lambda * (gamma^T Phi(s_T) - Phi(s_0)).
+        # With Phi(terminal) = 0 enforced, this collapses to -lambda * Phi(s_0).
+        # Lambda=1, so expected correction per agent = -Phi(s_0).
+        expected_correction = -1.0 * phi_s0
+        observed_correction = discounted_shaped - discounted_base
+        # All four agents share the team-wide shaping term, so the
+        # per-agent observed correction must be uniform (within float
+        # noise).
+        np.testing.assert_allclose(
+            observed_correction,
+            np.full(4, expected_correction),
+            rtol=0,
+            atol=1e-3,
+            err_msg=(
+                f"NHR telescoping identity violated. "
+                f"Expected per-agent correction = -Phi(s_0) = "
+                f"{expected_correction:.6f}; observed correction = "
+                f"{observed_correction}. "
+                f"This indicates a bug: either Phi(terminal) is not "
+                f"zeroed, or the per-step shaping term uses the wrong "
+                f"sign / state / discount."
+            ),
+        )
+
+    def test_phi_closed_form_values(self):
+        """Spot-check the closed-form Phi against hand-computed values
+        on a few small house states."""
+        scenario = _make_minimal_scenario(
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+            team_welfare_lambda=0.0,  # value computation does not require shaping enabled
+            team_welfare_gamma=1.0,
+            team_welfare_kind="team_welfare_closed_form",
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+
+        # All safe: Phi = 10*(10/10) - 10*0 - 0.5*10*0 = 10.0
+        houses_all_safe = np.full(10, env.SAFE, dtype=np.int8)
+        assert abs(env._compute_team_welfare_phi(houses_all_safe) - 10.0) < 1e-6
+
+        # All ruined: Phi = 0 - 10 - 0 = -10.0
+        houses_all_ruined = np.full(10, env.RUINED, dtype=np.int8)
+        assert abs(env._compute_team_welfare_phi(houses_all_ruined) - (-10.0)) < 1e-6
+
+        # All burning: Phi = 0 - 0 - 0.5*10 = -5.0
+        houses_all_burning = np.full(10, env.BURNING, dtype=np.int8)
+        assert abs(env._compute_team_welfare_phi(houses_all_burning) - (-5.0)) < 1e-6
+
+        # Mixed: 5 safe, 3 burning, 2 ruined.
+        # Phi = 10*(5/10) - 10*(2/10) - 0.5*10*(3/10) = 5 - 2 - 1.5 = 1.5
+        mixed = np.array(
+            [env.SAFE] * 5 + [env.BURNING] * 3 + [env.RUINED] * 2, dtype=np.int8
+        )
+        assert abs(env._compute_team_welfare_phi(mixed) - 1.5) < 1e-6
+
+    def test_phi_kind_none_returns_zero(self):
+        """When kind='none', Phi must be exactly 0 regardless of state.
+        Guards the env fast-path skip in _compute_rewards."""
+        scenario = _make_minimal_scenario(
+            team_reward_house_survives=100.0,
+            team_penalty_house_burns=100.0,
+            team_welfare_lambda=0.0,
+            team_welfare_gamma=1.0,
+            team_welfare_kind="none",
+        )
+        env = BucketBrigadeEnv(scenario=scenario)
+        env.reset(seed=0)
+        for state_code in (env.SAFE, env.BURNING, env.RUINED):
+            houses = np.full(10, state_code, dtype=np.int8)
+            assert env._compute_team_welfare_phi(houses) == 0.0, (
+                f"kind='none' must produce Phi=0; got "
+                f"{env._compute_team_welfare_phi(houses)} for state {state_code}"
+            )
+
+    def test_unknown_kind_rejected_at_construction(self):
+        """The Scenario allowlist must reject unknown team_welfare_kind
+        values at construction time."""
+        with pytest.raises(ValueError, match="team_welfare_kind"):
+            _make_minimal_scenario(team_welfare_kind="bogus")
+
+    def test_shaping_is_team_shared(self):
+        """The shaping term is added equally to every agent's reward, so
+        the per-agent reward differential under shaping equals the
+        per-agent reward differential without shaping. Confirms the
+        team-shared application (not per-agent decomposition)."""
+        # Scenario where shaping fires deterministically: solo extinguish
+        # of a burning house, no spread/spark, lambda=1.
+        scenario_no_shape = _make_minimal_scenario(
+            prob_solo_agent_extinguishes_fire=1.0,
+            prob_fire_spreads_to_neighbor=0.0,
+            prob_house_catches_fire=0.0,
+            team_reward_house_survives=10.0,
+            team_penalty_house_burns=10.0,
+        )
+        scenario_shaped = dataclasses.replace(
+            scenario_no_shape,
+            team_welfare_lambda=1.0,
+            team_welfare_gamma=0.99,
+            team_welfare_kind="team_welfare_closed_form",
+        )
+        env_a = BucketBrigadeEnv(scenario=scenario_no_shape)
+        env_b = BucketBrigadeEnv(scenario=scenario_shaped)
+        env_a.reset(seed=11)
+        env_b.reset(seed=11)
+        # Force identical start state.
+        env_a.houses = np.zeros(10, dtype=np.int8)
+        env_a.houses[3] = env_a.BURNING
+        env_a._prev_houses_state = env_a.houses.copy()
+        env_b.houses = env_a.houses.copy()
+        env_b._prev_houses_state = env_a.houses.copy()
+        actions = np.array(
+            [[3, 1, 1], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+            dtype=np.int8,
+        )
+        _, r_a, _, _ = env_a.step(actions)
+        _, r_b, _, _ = env_b.step(actions)
+        # The pairwise differential (r_b - r_a) must be uniform across
+        # agents — shaping is team-shared, not per-agent.
+        diff = r_b - r_a
+        np.testing.assert_allclose(
+            diff, np.full(4, diff[0]), rtol=0, atol=1e-5,
+            err_msg=(
+                "Potential-based shaping must apply equally to every "
+                "agent (team-shared bonus). Per-agent differential is "
+                f"non-uniform: {diff}"
+            ),
+        )


### PR DESCRIPTION
## Summary

Adds Ng-Harada-Russell (1999) potential-based reward shaping to the
bucket-brigade env (issue #283). Implements **option B** from the
curator spec — the closed-form team-welfare potential — as the cheap
falsification path. The principled, theory-backed sibling of
mechanical Delta-safe shaping (#265).

NHR invariance: `F(s, a, s') = lambda * (gamma * Phi(s') - Phi(s))`
with `Phi(terminal) := 0` injects an aligned per-step signal without
distorting the optimal-policy set.

## Changes

- **Scenario fields (Python + Rust)**: `team_welfare_lambda` (0.0),
  `team_welfare_gamma` (1.0), `team_welfare_kind` ("none"). All
  defaults preserve byte-exact pre-#283 behavior via the env
  fast-path skip.
- **Python env**: `_compute_team_welfare_phi` helper +
  shaping block in `_compute_rewards`
  (`bucket_brigade/envs/bucket_brigade_env.py`).
- **Rust env**: `BucketBrigade::team_welfare_phi` + shaping block in
  `compute_rewards` (`bucket-brigade-core/src/engine/rewards.rs`).
  Allowlist validator + serde deserializer in `scenarios.rs`. PyO3
  and WASM constructors updated to the new defaults.
- **Trainer**: `--team-welfare-{lambda,gamma,kind}` CLI args on
  `experiments/p3_specialization/train.py` (mirror of the
  `--action-shaping-{alpha,beta}` plumbing).
- **Sweep driver**: `experiments/p3_specialization/run_issue283_sweep.sh`
  for `lambda in {0, 0.1, 0.5, 1.0} x 3 seeds = 12 cells`.
  **Not run locally** per CLAUDE.md compute guidelines; intended for
  `COMPUTE_HOST_PRIMARY` in tmux.
- **Generator**: `scripts/generate_python.py` updated to emit the new
  optional fields, keeping codegen byte-stable for pre-#283 scenarios.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| `team_welfare_lambda`/`_kind`/`_gamma` added in Python + Rust | Done | `Scenario` dataclass, `Scenario` struct + `validate()`, all 15 SCENARIOS entries, codegen, PyO3, WASM |
| Pre-#283 scenarios byte-identical at lambda=0 | Done | `test_zero_lambda_matches_pre283_full_episode` (Python) + `test_zero_lambda_byte_identical_rewards` (Rust). `test_defaults_are_zero_across_all_scenarios` enforces the invariant on every factory. |
| Option B closed-form Phi wired | Done | `_compute_team_welfare_phi` (Python) + `team_welfare_phi` (Rust); spot-checked in `test_phi_closed_form_values` (both sides). Option A (specialist-MC) deferred to a follow-up. |
| Shaped reward `F = gamma*Phi(s') - Phi(s)` gated by lambda | Done | Fast-path skip when `lambda == 0` OR `kind == "none"`. |
| Terminal-state convention `Phi(terminal)=0` | Done | `test_phi_terminal_convention` directly probes this, including a negative-control that the test would reject a non-zeroed implementation. |
| Telescoping-identity invariance unit test | Done | `test_telescoping_identity_under_random_policy` — the load-bearing NHR correctness test. Compares discounted-sum-of-shaped-rewards across base/shaped envs running the same actions+seed and asserts the difference equals `-lambda*Phi(s_0)` exactly. |
| Training-run sweep grid | Driver built | `run_issue283_sweep.sh` covers `lambda in {0, 0.1, 0.5, 1.0} x 3 seeds`. **Execution deferred** per user constraints. |
| Verdict notebook | Deferred | Will be added by the analyzer after the sweep runs. |

## Test Plan

- [x] Python: `uv run pytest tests/test_environment.py::TestPotentialBasedShaping -v` (9 passed)
- [x] Python: full `tests/test_environment.py` (65 passed, 4 pre-existing skips)
- [x] Rust: `cd bucket-brigade-core && cargo test` (126 passed, +5 new shaping tests)
- [x] Rust: `cargo check` clean; `cargo clippy` produces no new errors (only pre-existing style warnings)
- [ ] Sweep execution (deferred to compute host per CLAUDE.md guidance)

NB: overlaps with #265 (mechanical Delta-safe shaping); this PR adds
the principled potential-based version. Curator sequenced #265 first.

Closes #283