### PR TITLE
feat(p3): HCA advantage estimator (Eq. 9) + sweep harness

### DIFF
--- a/bucket_brigade/training/__init__.py
+++ b/bucket_brigade/training/__init__.py
@@ -5,7 +5,15 @@ RL algorithms and curriculum learning strategies.
 """
 
 from .curriculum import CurriculumStage, CurriculumTrainer
-from .networks import PolicyNetwork, TransformerPolicyNetwork, compute_gae
+from .networks import (
+    HindsightNetwork,
+    PolicyNetwork,
+    TransformerPolicyNetwork,
+    compute_gae,
+    compute_hca_advantages,
+    compute_returns_to_go,
+    encode_return_bucket,
+)
 from .game_simulator import GameSimulator, Matchmaker
 from .policy_learner import PolicyLearner, learner_process
 from .population_trainer import PopulationTrainer
@@ -18,9 +26,13 @@ from .observation_utils import (
 __all__ = [
     "PolicyNetwork",
     "TransformerPolicyNetwork",
+    "HindsightNetwork",
     "CurriculumTrainer",
     "CurriculumStage",
     "compute_gae",
+    "compute_hca_advantages",
+    "compute_returns_to_go",
+    "encode_return_bucket",
     "GameSimulator",
     "Matchmaker",
     "PolicyLearner",

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -51,8 +51,10 @@ import torch.optim as optim
 from bucket_brigade.training.networks import (
     CentralizedCritic,
     CentralizedQCritic,
+    HindsightNetwork,
     PolicyNetwork,
     compute_gae,
+    compute_hca_advantages,
 )
 from bucket_brigade.training.normalizers import RunningMeanStd
 
@@ -212,6 +214,23 @@ class JointPPOTrainer:
         coma_target_update_every: How often (in PPO update steps) to hard-
             copy the Q-critic into the target network. Default 200 matches
             the Foerster 2018 paper. Only used when ``coma=True``.
+        advantage_estimator: Selector for the per-agent advantage path
+            (issue #289). One of:
+
+            - ``"gae"`` (default) — Generalized Advantage Estimation, the
+              pre-#289 path. Bit-identical to prior behavior.
+            - ``"hca"`` — Hindsight Credit Assignment (Harutyunyan et al.
+              2019, Eq. 9). Instantiates per-agent :class:`HindsightNetwork`
+              instances trained alongside the actors and computes
+              ``A_t = (1 - pi/h) * (Z_t - V_t)`` with a quantile-bucketed
+              return as the future statistic.
+        hindsight_lr: Adam learning rate for the per-agent hindsight nets.
+            Only used when ``advantage_estimator == "hca"``. Default matches
+            the actor ``lr``.
+        hindsight_num_return_buckets: Alphabet size of the future-statistic
+            bucket encoding. Default 8.
+        hindsight_ratio_clip: Symmetric clip on the ``pi/h`` hindsight ratio.
+            Default 10.0.
     """
 
     def __init__(
@@ -237,6 +256,10 @@ class JointPPOTrainer:
         centralized_critic: bool = False,
         coma: bool = False,
         coma_target_update_every: int = 200,
+        advantage_estimator: str = "gae",
+        hindsight_lr: Optional[float] = None,
+        hindsight_num_return_buckets: int = 8,
+        hindsight_ratio_clip: float = 10.0,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
@@ -386,6 +409,47 @@ class JointPPOTrainer:
             self.q_critic_target = None
             self.q_critic_optimizer = None
             self._coma_update_step = 0
+
+        # Issue #289: HCA advantage path. Validated and wired here so the
+        # default ``advantage_estimator="gae"`` path is bit-identical to
+        # pre-#289 behavior (no hindsight network is instantiated, no
+        # extra optimizer is added).
+        if advantage_estimator not in ("gae", "hca"):
+            raise ValueError(
+                f"advantage_estimator must be 'gae' or 'hca', got "
+                f"{advantage_estimator!r}"
+            )
+        if advantage_estimator == "hca" and coma:
+            raise ValueError(
+                "advantage_estimator='hca' is incompatible with coma=True: "
+                "COMA overrides per-agent advantages with counterfactual "
+                "values, which would silently negate the HCA computation. "
+                "Pick one."
+            )
+        self.advantage_estimator = advantage_estimator
+        self.hindsight_num_return_buckets = int(hindsight_num_return_buckets)
+        self.hindsight_ratio_clip = float(hindsight_ratio_clip)
+        self.hindsight_nets: Optional[nn.ModuleList] = None
+        self.hindsight_optimizers: Optional[List[optim.Optimizer]] = None
+        if self.advantage_estimator == "hca":
+            _h_lr = float(lr if hindsight_lr is None else hindsight_lr)
+            self.hindsight_lr = _h_lr
+            self.hindsight_nets = nn.ModuleList(
+                [
+                    HindsightNetwork(
+                        obs_dim=obs_dim,
+                        x_dim=self.hindsight_num_return_buckets,
+                        action_dims=action_dims,
+                        hidden_size=hidden_size,
+                    )
+                    for _ in range(num_agents)
+                ]
+            ).to(self.device)
+            self.hindsight_optimizers = [
+                optim.Adam(h.parameters(), lr=_h_lr) for h in self.hindsight_nets
+            ]
+        else:
+            self.hindsight_lr = float(lr if hindsight_lr is None else hindsight_lr)
 
         self._reset_env(seed=seed)
 
@@ -656,20 +720,124 @@ class JointPPOTrainer:
         rewards: torch.Tensor,
         values: torch.Tensor,
         dones: torch.Tensor,
+        agent_id: Optional[int] = None,
+        observations: Optional[torch.Tensor] = None,
+        actions: Optional[torch.Tensor] = None,
+        policy_log_probs: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        adv = torch.tensor(
-            compute_gae(
-                rewards.cpu().tolist(),
-                values.cpu().tolist(),
-                dones.cpu().tolist(),
-                self.gamma,
-                self.gae_lambda,
-            ),
-            dtype=torch.float32,
-            device=self.device,
+        """Compute per-agent advantages and value-regression targets.
+
+        Branches on :attr:`advantage_estimator`:
+
+        - ``"gae"`` (default) — Generalized Advantage Estimation. Bit-identical
+          to the pre-#289 path. The HCA-only kwargs are ignored.
+        - ``"hca"`` (issue #289) — Hindsight Credit Assignment. Requires
+          ``agent_id``, ``observations``, ``actions``, and ``policy_log_probs``
+          to evaluate ``h(a | s, X)`` and compute
+          ``A_t = (1 - pi/h)(Z_t - V_t)``. The return target ``Z_t`` (pure
+          Monte-Carlo) is used as the value-regression target — the value
+          head still learns a baseline, just without TD bootstrapping.
+
+        Diagnostic info from the HCA path (clip rate, mean ratio, etc.) is
+        stashed on ``self._last_hca_info[agent_id]`` for the trainer's stats
+        dict.
+        """
+        if self.advantage_estimator == "gae":
+            adv = torch.tensor(
+                compute_gae(
+                    rewards.cpu().tolist(),
+                    values.cpu().tolist(),
+                    dones.cpu().tolist(),
+                    self.gamma,
+                    self.gae_lambda,
+                ),
+                dtype=torch.float32,
+                device=self.device,
+            )
+            ret = adv + values
+            return adv, ret
+
+        # HCA path.
+        if (
+            agent_id is None
+            or observations is None
+            or actions is None
+            or policy_log_probs is None
+        ):
+            raise ValueError(
+                "advantage_estimator='hca' requires agent_id, observations, "
+                "actions, and policy_log_probs to be passed in."
+            )
+        assert self.hindsight_nets is not None
+        hindsight_net = self.hindsight_nets[agent_id]
+        adv, returns, info = compute_hca_advantages(
+            rewards=rewards.cpu().tolist(),
+            values=values.cpu().tolist(),
+            dones=dones.cpu().tolist(),
+            actions=actions,
+            observations=observations,
+            policy_log_probs=policy_log_probs,
+            hindsight_net=hindsight_net,
+            gamma=self.gamma,
+            num_return_buckets=self.hindsight_num_return_buckets,
+            ratio_clip=self.hindsight_ratio_clip,
         )
-        ret = adv + values
-        return adv, ret
+        # Stash diagnostics for the update() stats dict.
+        if not hasattr(self, "_last_hca_info"):
+            self._last_hca_info: Dict[int, Dict[str, float]] = {}
+        self._last_hca_info[agent_id] = info
+        # Returns target for the value head is the Monte-Carlo Z_t.
+        return adv, returns
+
+    def _update_hindsight_nets(self, rollout: "RolloutBuffer") -> Dict[int, float]:
+        """One supervised-learning step per agent's hindsight network.
+
+        Issue #289: trains each per-agent :class:`HindsightNetwork` by maximum
+        likelihood on the rollout's ``(s_t, X_t) -> a_t`` triples, where
+        ``X_t`` is the quantile-bucketed Monte-Carlo return. Uses the
+        per-agent hindsight optimizer (independent from the actor optimizers
+        and the centralized critic optimizer when one is active).
+
+        Called once per ``update()`` invocation, before the PPO epochs, so
+        that the hindsight ratio used inside the advantage computation
+        reflects the most recent hindsight fit.
+
+        Returns:
+            Per-agent cross-entropy loss values keyed by agent id.
+        """
+        from bucket_brigade.training.networks import (
+            compute_returns_to_go,
+            encode_return_bucket,
+        )
+
+        assert self.advantage_estimator == "hca"
+        assert self.hindsight_nets is not None
+        assert self.hindsight_optimizers is not None
+        losses: Dict[int, float] = {}
+        for i in range(self.num_agents):
+            obs_i = rollout.observations[:, i, :]  # [T, obs_dim]
+            actions_i = rollout.actions[i]  # [T, A]
+            rewards_i = rollout.rewards[i].cpu().tolist()
+            dones_i = rollout.dones.cpu().tolist()
+            Z_i = torch.tensor(
+                compute_returns_to_go(rewards_i, dones_i, gamma=self.gamma),
+                dtype=torch.float32,
+                device=self.device,
+            )
+            X_i = encode_return_bucket(
+                Z_i.detach(), num_buckets=self.hindsight_num_return_buckets
+            )
+            log_p = self.hindsight_nets[i].log_prob(obs_i, X_i, actions_i)
+            loss = -log_p.mean()
+            opt = self.hindsight_optimizers[i]
+            opt.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(
+                self.hindsight_nets[i].parameters(), self.max_grad_norm
+            )
+            opt.step()
+            losses[i] = float(loss.item())
+        return losses
 
     @staticmethod
     def coma_counterfactual_advantage(
@@ -861,13 +1029,33 @@ class JointPPOTrainer:
         """
         t_total = rollout.observations.shape[0]
 
-        # Per-agent advantages and returns from GAE.
+        # Issue #289: HCA path trains the per-agent hindsight nets once per
+        # ``update()`` call, *before* the advantages are computed, so the
+        # ratio used inside the advantage formula reflects the most recent
+        # hindsight fit. The supervised hindsight-net step is independent
+        # from the PPO optimizer (separate Adam state).
+        hindsight_losses: Dict[int, float] = {}
+        if self.advantage_estimator == "hca":
+            hindsight_losses = self._update_hindsight_nets(rollout)
+
+        # Per-agent advantages and returns from GAE or HCA.
         advantages: Dict[int, torch.Tensor] = {}
         returns: Dict[int, torch.Tensor] = {}
         for i in range(self.num_agents):
-            adv, ret = self._compute_advantages(
-                rollout.rewards[i], rollout.values[i], rollout.dones
-            )
+            if self.advantage_estimator == "hca":
+                adv, ret = self._compute_advantages(
+                    rollout.rewards[i],
+                    rollout.values[i],
+                    rollout.dones,
+                    agent_id=i,
+                    observations=rollout.observations[:, i, :],
+                    actions=rollout.actions[i],
+                    policy_log_probs=rollout.log_probs[i],
+                )
+            else:
+                adv, ret = self._compute_advantages(
+                    rollout.rewards[i], rollout.values[i], rollout.dones
+                )
             advantages[i] = (adv - adv.mean()) / (adv.std() + 1e-8)
             returns[i] = ret
 
@@ -897,6 +1085,30 @@ class JointPPOTrainer:
         stats.update({f"entropy/agent_{i}": 0.0 for i in range(self.num_agents)})
         stats["redundancy_loss"] = 0.0
         stats["total_loss"] = 0.0
+
+        # Issue #289: HCA-specific diagnostics. Reported per-agent so callers
+        # can see when individual hindsight nets are underfit or saturate
+        # the ratio clip. When ``advantage_estimator == "gae"`` these keys
+        # are omitted entirely to keep the GAE stats schema bit-identical.
+        if self.advantage_estimator == "hca":
+            for i in range(self.num_agents):
+                stats[f"hindsight_loss/agent_{i}"] = float(
+                    hindsight_losses.get(i, float("nan"))
+                )
+                info_i = (
+                    self._last_hca_info.get(i, {})
+                    if hasattr(self, "_last_hca_info")
+                    else {}
+                )
+                stats[f"hca_clip_frac/agent_{i}"] = float(
+                    info_i.get("clip_frac", float("nan"))
+                )
+                stats[f"hca_ratio_mean/agent_{i}"] = float(
+                    info_i.get("ratio_mean", float("nan"))
+                )
+                stats[f"hca_hindsight_log_prob_mean/agent_{i}"] = float(
+                    info_i.get("hindsight_log_prob_mean", float("nan"))
+                )
 
         mb_size = min(self.minibatch_size, t_total)
 

--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -6,6 +6,7 @@ spaces, commonly used in reinforcement learning scenarios.
 
 from typing import List, Optional, Tuple
 
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -425,6 +426,288 @@ def compute_gae(
         advantages.insert(0, gae)
 
     return advantages
+
+
+def compute_returns_to_go(
+    rewards: List[float],
+    dones: List[bool],
+    gamma: float = 0.99,
+) -> List[float]:
+    """Compute discounted Monte-Carlo returns-to-go ``Z_t``.
+
+    Used as the outcome target ``Z_t`` in HCA advantage estimation (issue #289).
+    Unlike GAE, this is a pure Monte-Carlo target that does not bootstrap on
+    learned value estimates. Episode boundaries (``dones[t] == 1``) reset the
+    backward accumulator so credit does not leak across episodes.
+
+    Args:
+        rewards: Per-timestep rewards.
+        dones: Per-timestep episode-termination flags. A ``True`` at index ``t``
+            means step ``t`` was the last step of its episode.
+        gamma: Discount factor.
+
+    Returns:
+        List of returns-to-go, same length as ``rewards``.
+
+    Example:
+        >>> # 1-step episodes (dones=True everywhere) -> Z_t == r_t.
+        >>> rewards = [1.0, 2.0, 3.0]
+        >>> dones = [True, True, True]
+        >>> compute_returns_to_go(rewards, dones)
+        [1.0, 2.0, 3.0]
+    """
+    returns: List[float] = [0.0] * len(rewards)
+    running = 0.0
+    for t in reversed(range(len(rewards))):
+        if dones[t]:
+            running = 0.0
+        running = float(rewards[t]) + gamma * running
+        returns[t] = running
+    return returns
+
+
+class HindsightNetwork(nn.Module):
+    """State-conditional hindsight classifier ``h(a | s, X)`` (issue #289).
+
+    Implements the hindsight posterior over actions used by HCA (Harutyunyan
+    et al., NeurIPS 2019, Eq. 9). Given the state ``s_t`` and a future
+    statistic ``X_t`` (e.g., a discrete return-bucket or final-observation
+    summary), the network produces a categorical posterior over the action
+    that *was* taken at ``t`` — i.e., the retrospective question "given we
+    ended up in ``X``, what was the action most likely to have been chosen?"
+
+    Architecture mirrors :class:`PolicyNetwork`'s actor head: a small shared
+    MLP trunk over ``(s, X)`` followed by one categorical head per action
+    dimension. Returns logits — callers turn them into probabilities via
+    softmax. The trainer wires a separate Adam optimizer for this network
+    and trains it by maximum-likelihood (cross-entropy) on rollout
+    ``(s_t, X_t) -> a_t`` triples.
+
+    Args:
+        obs_dim: Dimension of the observation ``s_t``.
+        x_dim: Dimension of the future-statistic embedding ``X_t``. The
+            P3 cell currently uses a discrete return bucket encoded as a
+            one-hot of length ``num_return_buckets`` (default 8).
+        action_dims: Per-dimension action sizes, matching the actor's
+            ``action_dims`` (e.g., ``[10, 2, 2]`` post-#235).
+        hidden_size: Size of the hidden layers (default: 64, matching
+            :class:`PolicyNetwork`'s default).
+    """
+
+    def __init__(
+        self,
+        obs_dim: int,
+        x_dim: int,
+        action_dims: List[int],
+        hidden_size: int = 64,
+    ) -> None:
+        super().__init__()
+        self.obs_dim = obs_dim
+        self.x_dim = x_dim
+        self.action_dims = list(action_dims)
+        self.hidden_size = hidden_size
+
+        self.shared = nn.Sequential(
+            nn.Linear(obs_dim + x_dim, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+        )
+        self.action_heads = nn.ModuleList(
+            [nn.Linear(hidden_size, dim) for dim in action_dims]
+        )
+
+    def forward(self, obs: torch.Tensor, x: torch.Tensor) -> List[torch.Tensor]:
+        """Forward pass producing per-action-dim hindsight logits.
+
+        Args:
+            obs: Observation tensor ``[batch, obs_dim]``.
+            x: Future-statistic tensor ``[batch, x_dim]``.
+
+        Returns:
+            List of logits tensors, one per action dimension, each shaped
+            ``[batch, action_dims[k]]``.
+        """
+        if obs.dim() != 2 or x.dim() != 2:
+            raise ValueError(
+                f"HindsightNetwork.forward expects 2D inputs, got "
+                f"obs.shape={tuple(obs.shape)} x.shape={tuple(x.shape)}"
+            )
+        features = self.shared(torch.cat([obs, x], dim=-1))
+        return [head(features) for head in self.action_heads]
+
+    def log_prob(
+        self, obs: torch.Tensor, x: torch.Tensor, actions: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-sample log-probability of the joint multi-discrete action.
+
+        Args:
+            obs: ``[batch, obs_dim]``.
+            x: ``[batch, x_dim]``.
+            actions: ``[batch, num_action_dims]`` integer-coded actions.
+
+        Returns:
+            ``[batch]`` tensor of ``sum_k log h(a_k | s, X)``.
+        """
+        logits_list = self.forward(obs, x)
+        log_probs = []
+        for k, logits in enumerate(logits_list):
+            log_p = torch.log_softmax(logits, dim=-1)
+            log_probs.append(log_p.gather(1, actions[:, k : k + 1]).squeeze(-1))
+        return torch.stack(log_probs, dim=1).sum(dim=1)
+
+
+def encode_return_bucket(
+    returns: torch.Tensor, num_buckets: int = 8
+) -> torch.Tensor:
+    """Quantize per-step Monte-Carlo returns into a one-hot bucket encoding.
+
+    Used as the future-statistic ``X_t`` consumed by :class:`HindsightNetwork`
+    in the state-conditional HCA estimator (issue #289). The encoding is
+    deterministic and pure-tensor: bucket boundaries are computed as
+    equally-spaced quantiles of the input batch, with degenerate cases
+    (all-equal returns) collapsing to bucket 0.
+
+    Args:
+        returns: ``[T]`` Monte-Carlo returns ``Z_t``.
+        num_buckets: Alphabet size of the future statistic. Default 8 follows
+            the curator's recommended starting value.
+
+    Returns:
+        ``[T, num_buckets]`` float32 one-hot tensor.
+    """
+    if returns.dim() != 1:
+        raise ValueError(
+            f"encode_return_bucket expects 1D returns, got shape "
+            f"{tuple(returns.shape)}"
+        )
+    T = returns.shape[0]
+    # Use quantile boundaries for an empirically-balanced bucket assignment.
+    # In the degenerate constant-returns case this collapses to all-zero
+    # bucket indices, which is well-defined (and the hindsight ratio
+    # gracefully degenerates to 1 for that timestep).
+    if T == 0:
+        return torch.zeros((0, num_buckets), dtype=torch.float32, device=returns.device)
+    sorted_returns = torch.sort(returns).values
+    # Compute internal boundaries (num_buckets - 1 cutpoints).
+    if num_buckets < 2:
+        return torch.zeros((T, num_buckets), dtype=torch.float32, device=returns.device)
+    edges = torch.tensor(
+        [
+            sorted_returns[
+                min(int((k + 1) * T / num_buckets), T - 1)
+            ].item()
+            for k in range(num_buckets - 1)
+        ],
+        device=returns.device,
+    )
+    # bucketize: bucket index = number of edges strictly less than returns
+    bucket_idx = torch.bucketize(returns, edges)
+    bucket_idx = torch.clamp(bucket_idx, 0, num_buckets - 1)
+    one_hot = torch.zeros(
+        (T, num_buckets), dtype=torch.float32, device=returns.device
+    )
+    one_hot.scatter_(1, bucket_idx.unsqueeze(1), 1.0)
+    return one_hot
+
+
+def compute_hca_advantages(
+    rewards: List[float],
+    values: List[float],
+    dones: List[bool],
+    actions: torch.Tensor,
+    observations: torch.Tensor,
+    policy_log_probs: torch.Tensor,
+    hindsight_net: HindsightNetwork,
+    gamma: float = 0.99,
+    num_return_buckets: int = 8,
+    ratio_clip: float = 10.0,
+) -> Tuple[torch.Tensor, torch.Tensor, dict]:
+    """Compute state-conditional Hindsight Credit Assignment advantages.
+
+    Implements Eq. 9 of Harutyunyan et al. 2019:
+
+        A_t^HCA = (1 - pi(a_t | s_t) / h(a_t | s_t, X_t)) * (Z_t - V(s_t))
+
+    where:
+        - ``Z_t``  = Monte-Carlo return-to-go (no bootstrap),
+        - ``X_t``  = future statistic — here, a quantile-bucketed encoding of
+          ``Z_t`` (the curator's recommended starting value),
+        - ``h(a | s, X)`` = the learned :class:`HindsightNetwork` posterior,
+        - ``pi(a | s)`` = the rollout-time actor policy, captured via the
+          stored per-step ``policy_log_probs``.
+
+    The hindsight ratio ``pi/h`` is clipped to ``[1/ratio_clip, ratio_clip]``
+    for numerical stability (mirrors PPO's own ratio-clip philosophy). A
+    diagnostic dict reports the fraction of steps that hit the clip and the
+    Monte-Carlo return baseline so downstream loggers can detect when the
+    hindsight signal is degenerate.
+
+    Args:
+        rewards: Per-timestep rewards, length ``T``.
+        values: Per-timestep critic values, length ``T``.
+        dones: Per-timestep episode-termination flags, length ``T``.
+        actions: ``[T, A]`` integer-coded actions actually taken.
+        observations: ``[T, obs_dim]`` per-step observation rows (one
+            agent's view).
+        policy_log_probs: ``[T]`` log-probability under the rollout policy
+            ``pi(a_t | s_t)`` — already captured by the trainer for PPO's
+            ratio. Re-used here to avoid a second actor forward.
+        hindsight_net: :class:`HindsightNetwork` instance for this agent.
+        gamma: Discount factor for ``Z_t``.
+        num_return_buckets: Alphabet size for the return-bucket future
+            statistic. Must match ``hindsight_net.x_dim``.
+        ratio_clip: Symmetric clip on the ``pi/h`` ratio. Default 10.0.
+
+    Returns:
+        Tuple of:
+            - ``advantages``: ``[T]`` float32 tensor (per-step HCA advantage).
+            - ``returns``: ``[T]`` Monte-Carlo returns ``Z_t``.
+            - ``info``: dict with diagnostic scalars — ``clip_frac``
+              (fraction of steps where the ratio hit either bound),
+              ``hindsight_log_prob_mean`` (mean log h, for tracking
+              hindsight-net fit), ``ratio_mean`` (mean unclipped ratio).
+    """
+    device = observations.device
+    T = len(rewards)
+
+    # Monte-Carlo return-to-go Z_t.
+    Z_list = compute_returns_to_go(rewards, dones, gamma=gamma)
+    Z = torch.tensor(Z_list, dtype=torch.float32, device=device)
+    V = torch.tensor(values, dtype=torch.float32, device=device)
+
+    # Future-statistic encoding X_t. Detached so gradients into the bucket
+    # boundaries do not propagate (the bucketization is a hard discrete
+    # operation).
+    X = encode_return_bucket(Z.detach(), num_buckets=num_return_buckets)
+
+    # Hindsight log-prob of the actually-taken action. The hindsight network
+    # is in eval-style here — we want the forward log-prob, gradient flow into
+    # the hindsight net is handled separately in the trainer's
+    # ``_update_hindsight_nets`` step (it has its own optimizer + loss).
+    with torch.no_grad():
+        log_h = hindsight_net.log_prob(observations, X, actions)
+
+    # log(pi/h) clipped; convert to ratio in safe range.
+    log_ratio = policy_log_probs.detach() - log_h
+    log_ratio_clamped = torch.clamp(
+        log_ratio,
+        min=float(np.log(1.0 / ratio_clip)),
+        max=float(np.log(ratio_clip)),
+    )
+    clip_frac = (log_ratio_clamped != log_ratio).float().mean().item()
+    ratio = torch.exp(log_ratio_clamped)
+
+    # HCA advantage: A_t = (1 - pi/h) * (Z_t - V_t).
+    advantages = (1.0 - ratio) * (Z - V)
+
+    info = {
+        "clip_frac": float(clip_frac),
+        "hindsight_log_prob_mean": float(log_h.mean().item()),
+        "ratio_mean": float(torch.exp(log_ratio).mean().item()),
+        "Z_mean": float(Z.mean().item()),
+    }
+    return advantages, Z, info
 
 
 class TransformerPolicyNetwork(nn.Module):

--- a/experiments/p3_specialization/analyze_289.py
+++ b/experiments/p3_specialization/analyze_289.py
@@ -1,0 +1,252 @@
+"""Analysis for issue #289 — HCA verdict.
+
+Compares per-iteration team rewards from:
+
+- **HCA arm** (this issue): cells under
+  ``experiments/p3_specialization/runs/issue289_hca/minimal_specialization/hca_default/seed_{42,43,44}/``.
+- **GAE baseline arm** (re-run at identical config in the same sweep):
+  ``.../gae_baseline/seed_{42,43,44}/``.
+- **PPO baseline reference** (PR #257): hardcoded gap_closed = 0.182 as
+  the conservative floor.
+- **High-λ GAE comparator** (issue #282): pulled in if its analysis
+  artifact exists; otherwise reported as ``unavailable``.
+
+Emits a markdown summary + JSON to
+``experiments/p3_specialization/diagnostics/results/issue289_hca/`` and
+applies the verdict matrix from the issue body:
+
+| HCA gap_closed (50-iter, 3 seeds, mean) | Verdict |
+|---|---|
+| >= 0.5 | STRONG_WIN |
+| 0.2..0.5 AND clearly above #282 high-λ result | WEAK_WIN_DISTINCT_FROM_MC |
+| similar to #282 high-λ | AMBIGUOUS |
+| similar to PPO baseline | NEGATIVE |
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# Hardcoded references (mirror analyze_270.py:34-35).
+MINSPEC_RANDOM = -96.07
+MINSPEC_SPECIALIST = -22.07
+TRAILING_N = 5
+
+# PR #257 PPO baseline gap_closed (from the issue body).
+PPO_BASELINE_GAP_CLOSED = 0.182
+
+
+def gap_closed(per_step_team: float) -> float:
+    return (per_step_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+def _load_metrics(path: Path) -> Optional[List[dict]]:
+    f = path / "metrics.json"
+    if not f.exists():
+        return None
+    return json.loads(f.read_text())
+
+
+def _trajectory(metrics: List[dict]) -> np.ndarray:
+    return np.asarray(
+        [row["mean_step_reward_team"] for row in metrics], dtype=np.float64
+    )
+
+
+def aggregate_arm(cells: List[Path], label: str) -> Dict:
+    seeds_data = []
+    trajectories = []
+    for cell in cells:
+        metrics = _load_metrics(cell)
+        if metrics is None:
+            seeds_data.append({"cell": str(cell), "missing": True})
+            continue
+        traj = _trajectory(metrics)
+        seeds_data.append(
+            {
+                "cell": str(cell),
+                "n_iters": int(traj.size),
+                "trailing5_team": float(traj[-TRAILING_N:].mean()),
+                "trailing5_gap_closed": float(
+                    gap_closed(float(traj[-TRAILING_N:].mean()))
+                ),
+            }
+        )
+        trajectories.append(traj)
+
+    if not trajectories:
+        return {"label": label, "seeds": seeds_data, "n_seeds": 0}
+    min_len = min(t.size for t in trajectories)
+    stacked = np.stack([t[:min_len] for t in trajectories], axis=0)
+    mean_traj_step = stacked.mean(axis=0)
+    mean_traj_gc = (mean_traj_step - MINSPEC_RANDOM) / (
+        MINSPEC_SPECIALIST - MINSPEC_RANDOM
+    )
+
+    return {
+        "label": label,
+        "seeds": seeds_data,
+        "n_seeds": len(trajectories),
+        "n_iters": int(min_len),
+        "trailing5_team_mean": float(mean_traj_step[-TRAILING_N:].mean()),
+        "trailing5_gap_closed_mean": float(mean_traj_gc[-TRAILING_N:].mean()),
+        "mean_traj_step_reward": mean_traj_step.tolist(),
+        "mean_traj_gap_closed": mean_traj_gc.tolist(),
+    }
+
+
+def classify_verdict(
+    hca_arm: Dict,
+    gae_arm: Dict,
+    high_lambda_gap_closed: Optional[float],
+) -> Tuple[str, str]:
+    if hca_arm.get("n_seeds", 0) == 0:
+        return "no_data", "HCA arm has no completed seeds"
+    hca_gc = hca_arm["trailing5_gap_closed_mean"]
+    if hca_gc >= 0.5:
+        return "STRONG_WIN", (
+            f"HCA trailing-5 gap_closed = {hca_gc:.3f} >= 0.5. "
+            "Retrospective credit assignment fixes the misalignment. "
+            "Validates the 'coarse-grained gradient' framing."
+        )
+    near_baseline = abs(hca_gc - PPO_BASELINE_GAP_CLOSED) < 0.05
+    if near_baseline:
+        return "NEGATIVE", (
+            f"HCA trailing-5 gap_closed = {hca_gc:.3f} within 0.05 of "
+            f"PPO baseline {PPO_BASELINE_GAP_CLOSED}. Backward credit "
+            "isn't the right mechanism for this game's misalignment."
+        )
+    if high_lambda_gap_closed is not None:
+        if abs(hca_gc - high_lambda_gap_closed) < 0.05:
+            return "AMBIGUOUS", (
+                f"HCA trailing-5 gap_closed = {hca_gc:.3f} matches the "
+                f"#282 high-λ GAE result ({high_lambda_gap_closed:.3f}). "
+                "Both are Monte-Carlo-y; HCA's hindsight machinery isn't "
+                "adding signal over a return target."
+            )
+        if 0.2 <= hca_gc < 0.5 and hca_gc - high_lambda_gap_closed > 0.05:
+            return "WEAK_WIN_DISTINCT_FROM_MC", (
+                f"HCA trailing-5 gap_closed = {hca_gc:.3f} (in 0.2..0.5) "
+                f"is meaningfully above #282 high-λ ({high_lambda_gap_closed:.3f}). "
+                "Hindsight ratio is doing something high-λ GAE cannot."
+            )
+    if 0.2 <= hca_gc < 0.5:
+        return "WEAK_WIN", (
+            f"HCA trailing-5 gap_closed = {hca_gc:.3f} in 0.2..0.5; "
+            "comparison to #282 high-λ unavailable, but HCA clearly beats "
+            f"the PPO baseline ({PPO_BASELINE_GAP_CLOSED})."
+        )
+    return "PARTIAL", (
+        f"HCA trailing-5 gap_closed = {hca_gc:.3f}. Above PPO baseline "
+        "but below 0.2; ambiguous improvement."
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--hca-runs-root",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/runs/issue289_hca/"
+            "minimal_specialization/hca_default"
+        ),
+    )
+    p.add_argument(
+        "--gae-runs-root",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/runs/issue289_hca/"
+            "minimal_specialization/gae_baseline"
+        ),
+    )
+    p.add_argument(
+        "--high-lambda-result",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/diagnostics/results/"
+            "issue282_high_lambda/analysis.json"
+        ),
+        help=(
+            "Optional path to the #282 high-λ analysis JSON. If present "
+            "and contains ``trailing5_gap_closed_mean``, that value is "
+            "used as the WEAK_WIN_DISTINCT_FROM_MC comparator."
+        ),
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/diagnostics/results/issue289_hca"
+        ),
+    )
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    hca_cells = [args.hca_runs_root / f"seed_{s}" for s in args.seeds]
+    gae_cells = [args.gae_runs_root / f"seed_{s}" for s in args.seeds]
+    hca_arm = aggregate_arm(hca_cells, "hca")
+    gae_arm = aggregate_arm(gae_cells, "gae_baseline")
+
+    high_lambda_gc: Optional[float] = None
+    if args.high_lambda_result.exists():
+        try:
+            payload = json.loads(args.high_lambda_result.read_text())
+            high_lambda_gc = float(
+                payload.get("trailing5_gap_closed_mean")
+                or payload.get("high_lambda_arm", {}).get(
+                    "trailing5_gap_closed_mean"
+                )
+            )
+        except (ValueError, TypeError, KeyError):
+            high_lambda_gc = None
+
+    verdict, reasoning = classify_verdict(hca_arm, gae_arm, high_lambda_gc)
+
+    out = {
+        "issue": 289,
+        "verdict": verdict,
+        "reasoning": reasoning,
+        "hca_arm": hca_arm,
+        "gae_baseline_arm": gae_arm,
+        "high_lambda_comparator_gap_closed": high_lambda_gc,
+        "references": {
+            "minspec_random": MINSPEC_RANDOM,
+            "minspec_specialist": MINSPEC_SPECIALIST,
+            "trailing_n": TRAILING_N,
+            "ppo_baseline_gap_closed": PPO_BASELINE_GAP_CLOSED,
+        },
+    }
+    (args.output_dir / "analysis.json").write_text(json.dumps(out, indent=2))
+
+    md = [
+        "# Issue #289 — HCA verdict",
+        "",
+        f"**Verdict**: `{verdict}`",
+        "",
+        f"**Reasoning**: {reasoning}",
+        "",
+        "| Arm | n_seeds | trailing-5 team reward | trailing-5 gap_closed |",
+        "|---|---|---|---|",
+        f"| HCA | {hca_arm.get('n_seeds', 0)} "
+        f"| {hca_arm.get('trailing5_team_mean', float('nan')):.3f} "
+        f"| {hca_arm.get('trailing5_gap_closed_mean', float('nan')):.3f} |",
+        f"| GAE (in-sweep baseline) | {gae_arm.get('n_seeds', 0)} "
+        f"| {gae_arm.get('trailing5_team_mean', float('nan')):.3f} "
+        f"| {gae_arm.get('trailing5_gap_closed_mean', float('nan')):.3f} |",
+        f"| PPO baseline (PR #257) | — | — | {PPO_BASELINE_GAP_CLOSED:.3f} |",
+        f"| #282 high-λ GAE | — | — | "
+        f"{'unavailable' if high_lambda_gc is None else f'{high_lambda_gc:.3f}'} |",
+    ]
+    (args.output_dir / "analysis.md").write_text("\n".join(md) + "\n")
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue289_sweep.sh
+++ b/experiments/p3_specialization/run_issue289_sweep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Issue #289: Hindsight Credit Assignment (HCA) verdict sweep on
+# minimal_specialization. 50 iters x 3 seeds, plus a baseline GAE arm at
+# the same config so the gap_closed comparison against the PPO baseline
+# (PR #257: 0.182) is on a level playing field.
+#
+# DO NOT run this on localhost --- HCA adds a per-agent hindsight network
+# (one extra MLP forward per step) and 50 iters x 2048 rollout-steps is
+# squarely in "use a compute host" territory. See CLAUDE.md /
+# experiments/REMOTE_EXECUTION.md for the remote workflow.
+#
+# Usage:
+#   # On a compute host, inside tmux:
+#   ./experiments/p3_specialization/run_issue289_sweep.sh [seed1 seed2 ...]
+#
+# Defaults seeds: 42 43 44. Cells land at:
+#   experiments/p3_specialization/runs/issue289_hca/minimal_specialization/<arm>/seed_<S>/
+# where <arm> is one of "hca_default" or "gae_baseline".
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  set -- 42 43 44
+fi
+
+OUT_ROOT="experiments/p3_specialization/runs/issue289_hca/minimal_specialization"
+mkdir -p "$OUT_ROOT"
+export OUT_ROOT
+
+run_hca() {
+  local s="$1"
+  local out="$OUT_ROOT/hca_default/seed_$s"
+  mkdir -p "$out"
+  python experiments/p3_specialization/train.py \
+    --scenario minimal_specialization \
+    --lambda-red 0.0 \
+    --seed "$s" \
+    --num-iterations 50 \
+    --rollout-steps 2048 \
+    --num-agents 4 \
+    --use-hca \
+    --hindsight-num-return-buckets 8 \
+    --hindsight-ratio-clip 10.0 \
+    --output-dir "$out" 2>&1 | tee "$out/train.log"
+}
+
+run_gae() {
+  local s="$1"
+  local out="$OUT_ROOT/gae_baseline/seed_$s"
+  mkdir -p "$out"
+  python experiments/p3_specialization/train.py \
+    --scenario minimal_specialization \
+    --lambda-red 0.0 \
+    --seed "$s" \
+    --num-iterations 50 \
+    --rollout-steps 2048 \
+    --num-agents 4 \
+    --advantage-estimator gae \
+    --output-dir "$out" 2>&1 | tee "$out/train.log"
+}
+
+export -f run_hca run_gae
+
+# Run two seeds at a time to share CPU with parallel builders on this host.
+echo "== HCA arm =="
+printf "%s\n" "$@" | xargs -P 2 -I{} bash -c 'run_hca "$@"' _ {}
+
+echo "== GAE baseline arm =="
+printf "%s\n" "$@" | xargs -P 2 -I{} bash -c 'run_gae "$@"' _ {}
+
+echo "All cells finished. Run experiments/p3_specialization/analyze_289.py next."

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -156,6 +156,22 @@ class CellConfig:
     # ``False`` preserves bit-identical pre-#286 behavior.
     macro_actions: bool = False
     commit_steps: int = 3
+    # Issue #289: HCA advantage path selector. ``"gae"`` (default) preserves
+    # bit-identical pre-#289 behavior. ``"hca"`` swaps in the Hindsight
+    # Credit Assignment advantage estimator (Harutyunyan et al. 2019, Eq. 9)
+    # and trains per-agent hindsight networks alongside the actors.
+    advantage_estimator: str = "gae"
+    # Issue #289: Adam LR for the per-agent hindsight networks. None defers
+    # to ``lr`` (the actor LR) so the default sweep cell does not need to
+    # think about a second hyperparameter.
+    hindsight_lr: Optional[float] = None
+    # Issue #289: alphabet size of the quantile-bucketed return-to-go
+    # encoding used as the future statistic ``X_t``. Default 8 matches the
+    # curator's recommendation.
+    hindsight_num_return_buckets: int = 8
+    # Issue #289: symmetric clip on the ``pi/h`` hindsight ratio for
+    # numerical stability. Mirrors PPO's own clip philosophy.
+    hindsight_ratio_clip: float = 10.0
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -739,6 +755,10 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         centralized_critic=cfg.centralized_critic,
         coma=cfg.coma,
         coma_target_update_every=cfg.coma_target_update_every,
+        advantage_estimator=cfg.advantage_estimator,
+        hindsight_lr=cfg.hindsight_lr,
+        hindsight_num_return_buckets=cfg.hindsight_num_return_buckets,
+        hindsight_ratio_clip=cfg.hindsight_ratio_clip,
         device=cfg.device,
         seed=cfg.seed,
     )
@@ -1057,8 +1077,62 @@ def main() -> None:
             "--macro-actions is set. Default 3. Sweep grid is {3, 5, 8}."
         ),
     )
+    p.add_argument(
+        "--advantage-estimator",
+        type=str,
+        choices=["gae", "hca"],
+        default=CellConfig.__dataclass_fields__["advantage_estimator"].default,
+        help=(
+            "Issue #289: select the advantage estimator path. 'gae' "
+            "(default) preserves bit-identical pre-#289 behavior. 'hca' "
+            "swaps in Hindsight Credit Assignment (Harutyunyan et al. "
+            "2019, Eq. 9) and trains per-agent hindsight nets alongside "
+            "the actors."
+        ),
+    )
+    p.add_argument(
+        "--use-hca",
+        action="store_true",
+        help=(
+            "Issue #289: convenience alias for "
+            "'--advantage-estimator hca'. Mutually exclusive override of "
+            "the --advantage-estimator flag."
+        ),
+    )
+    p.add_argument(
+        "--hindsight-lr",
+        type=float,
+        default=None,
+        help=(
+            "Issue #289: Adam LR for the per-agent hindsight networks. "
+            "Default (None) defers to the actor --lr."
+        ),
+    )
+    p.add_argument(
+        "--hindsight-num-return-buckets",
+        type=int,
+        default=CellConfig.__dataclass_fields__["hindsight_num_return_buckets"].default,
+        help=(
+            "Issue #289: alphabet size of the quantile-bucketed return-to-"
+            "go encoding used as the HCA future statistic X_t. Default 8."
+        ),
+    )
+    p.add_argument(
+        "--hindsight-ratio-clip",
+        type=float,
+        default=CellConfig.__dataclass_fields__["hindsight_ratio_clip"].default,
+        help=(
+            "Issue #289: symmetric clip on the pi/h hindsight ratio for "
+            "numerical stability. Default 10.0."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
+
+    # Issue #289: ``--use-hca`` is a convenience alias for
+    # ``--advantage-estimator hca``. It overrides whatever was passed via
+    # ``--advantage-estimator`` so callers don't need to set both flags.
+    advantage_estimator = "hca" if args.use_hca else args.advantage_estimator
 
     cfg = CellConfig(
         scenario=args.scenario,
@@ -1084,6 +1158,10 @@ def main() -> None:
         gae_lambda=args.gae_lambda,
         macro_actions=args.macro_actions,
         commit_steps=args.commit_steps,
+        advantage_estimator=advantage_estimator,
+        hindsight_lr=args.hindsight_lr,
+        hindsight_num_return_buckets=args.hindsight_num_return_buckets,
+        hindsight_ratio_clip=args.hindsight_ratio_clip,
         device=args.device,
     )
     print(

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -783,3 +783,231 @@ class TestCOMA:
             assert torch.equal(va, b.q_critic_target.state_dict()[ka]), (
                 f"q_critic_target init differs at {ka} — COMA seeding broken"
             )
+
+
+class TestHCA:
+    """Issue #289: Hindsight Credit Assignment.
+
+    HCA is gated by ``advantage_estimator="hca"`` on the trainer. The
+    default ``advantage_estimator="gae"`` path is bit-identical to the
+    pre-#289 codepath, so the existing TestUpdate suite covers regression.
+    """
+
+    def _make_hca_trainer(self, **overrides) -> JointPPOTrainer:
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        kwargs = dict(
+            env_fn=_env_fn,
+            num_agents=NUM_AGENTS,
+            obs_dim=obs_dim,
+            action_dims=ACTION_DIMS,
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            advantage_estimator="hca",
+            seed=0,
+        )
+        kwargs.update(overrides)
+        return JointPPOTrainer(**kwargs)
+
+    def test_gae_default_path_bit_identical(self):
+        """Regression: ``advantage_estimator="gae"`` (the default) must
+        produce the exact same per-agent advantages as a trainer
+        constructed without specifying the flag."""
+        # Two trainers seeded identically — one default, one with the
+        # GAE flag passed explicitly. Both must produce identical
+        # advantages on the same rollout.
+        t_default = _make_trainer()
+        t_explicit = _make_trainer()
+        # Override the explicit one to set the flag (default-value via
+        # ``__init__`` — should be a no-op semantically).
+        assert t_default.advantage_estimator == "gae"
+        assert t_explicit.advantage_estimator == "gae"
+        # Use the same rollout for both, so we test only the advantage
+        # path. We compute advantages directly via the private method
+        # rather than running update() (which mutates optimizer state).
+        rollout = t_default.collect_rollout(ROLLOUT_STEPS)
+        a0, r0 = t_default._compute_advantages(
+            rollout.rewards[0], rollout.values[0], rollout.dones
+        )
+        a1, r1 = t_explicit._compute_advantages(
+            rollout.rewards[0], rollout.values[0], rollout.dones
+        )
+        torch.testing.assert_close(a0, a1)
+        torch.testing.assert_close(r0, r1)
+
+    def test_hca_trainer_constructs(self):
+        """Hindsight nets and optimizers exist on the HCA path; GAE path
+        leaves them ``None``."""
+        hca = self._make_hca_trainer()
+        assert hca.hindsight_nets is not None
+        assert hca.hindsight_optimizers is not None
+        assert len(hca.hindsight_nets) == NUM_AGENTS
+        assert len(hca.hindsight_optimizers) == NUM_AGENTS
+
+        gae = _make_trainer()
+        assert gae.hindsight_nets is None
+        assert gae.hindsight_optimizers is None
+
+    def test_hca_update_runs_without_nan(self):
+        """End-to-end: one rollout + one update on the HCA path must
+        produce finite stats."""
+        trainer = self._make_hca_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        for k, v in stats.items():
+            assert np.isfinite(v), f"non-finite stat {k}={v}"
+        # HCA-specific diagnostics must be present.
+        for i in range(NUM_AGENTS):
+            assert f"hindsight_loss/agent_{i}" in stats
+            assert f"hca_clip_frac/agent_{i}" in stats
+            assert f"hca_ratio_mean/agent_{i}" in stats
+
+    def test_hca_advantages_shape_matches_gae(self):
+        """The HCA advantage tensor must have the same shape as GAE's
+        on the same rollout (one scalar per timestep)."""
+        gae_trainer = _make_trainer()
+        hca_trainer = self._make_hca_trainer()
+        rollout = gae_trainer.collect_rollout(ROLLOUT_STEPS)
+        # Run the hindsight-net step so the HCA call inside compute is
+        # well-defined.
+        hca_trainer._update_hindsight_nets(rollout)
+        a_gae, _ = gae_trainer._compute_advantages(
+            rollout.rewards[0], rollout.values[0], rollout.dones
+        )
+        a_hca, _ = hca_trainer._compute_advantages(
+            rollout.rewards[0],
+            rollout.values[0],
+            rollout.dones,
+            agent_id=0,
+            observations=rollout.observations[:, 0, :],
+            actions=rollout.actions[0],
+            policy_log_probs=rollout.log_probs[0],
+        )
+        assert a_gae.shape == a_hca.shape
+        assert a_hca.dtype == torch.float32
+
+    def test_hca_reduces_to_mc_when_ratio_is_one(self):
+        """Sanity: when the hindsight ratio is forced to 1.0 (i.e.
+        ``h == pi``), HCA's advantage collapses to ``(Z_t - V_t)`` —
+        the pure Monte-Carlo advantage. Test by patching ``log_prob``
+        of the hindsight net to mirror the rollout log-probs.
+        """
+        from bucket_brigade.training.networks import compute_returns_to_go
+
+        trainer = self._make_hca_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+
+        # Patch hindsight net so log h(a|s,X) == policy_log_probs[t] for
+        # every t, making the ratio exactly 1 (and thus advantage 0
+        # outside any clipping path).
+        original_log_prob = trainer.hindsight_nets[0].log_prob
+
+        def fake_log_prob(obs, x, actions):
+            # Match the captured policy log-probs of agent 0 for this batch.
+            return rollout.log_probs[0]
+
+        trainer.hindsight_nets[0].log_prob = fake_log_prob  # type: ignore[assignment]
+        try:
+            adv, ret = trainer._compute_advantages(
+                rollout.rewards[0],
+                rollout.values[0],
+                rollout.dones,
+                agent_id=0,
+                observations=rollout.observations[:, 0, :],
+                actions=rollout.actions[0],
+                policy_log_probs=rollout.log_probs[0],
+            )
+        finally:
+            trainer.hindsight_nets[0].log_prob = original_log_prob  # type: ignore[assignment]
+
+        # Ratio 1.0 → (1 - 1) * (Z - V) = 0 everywhere.
+        assert torch.allclose(adv, torch.zeros_like(adv), atol=1e-5)
+        # Returns target is Z_t exactly.
+        Z_expected = torch.tensor(
+            compute_returns_to_go(
+                rollout.rewards[0].cpu().tolist(),
+                rollout.dones.cpu().tolist(),
+                gamma=trainer.gamma,
+            ),
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(ret, Z_expected, atol=1e-5, rtol=1e-5)
+
+    def test_hindsight_loss_decreases_on_synthetic_data(self):
+        """The hindsight network's MLE loss must decrease on a small
+        synthetic dataset (smoke test that gradients flow and the
+        optimizer actually steps the network)."""
+        from bucket_brigade.training.networks import (
+            HindsightNetwork,
+            encode_return_bucket,
+        )
+
+        torch.manual_seed(0)
+        obs_dim = 8
+        x_dim = 4
+        action_dims = [3, 2]
+        T = 256
+        net = HindsightNetwork(
+            obs_dim=obs_dim, x_dim=x_dim, action_dims=action_dims, hidden_size=16
+        )
+        opt = torch.optim.Adam(net.parameters(), lr=1e-2)
+
+        obs = torch.randn(T, obs_dim)
+        # Make X deterministically informative about the action by tying
+        # X to the action taken so the net has something to learn.
+        actions = torch.stack(
+            [
+                torch.randint(0, action_dims[0], (T,)),
+                torch.randint(0, action_dims[1], (T,)),
+            ],
+            dim=1,
+        )
+        returns = (actions[:, 0].float() + actions[:, 1].float()).detach()
+        X = encode_return_bucket(returns, num_buckets=x_dim)
+
+        loss_first = -net.log_prob(obs, X, actions).mean()
+        for _ in range(50):
+            loss = -net.log_prob(obs, X, actions).mean()
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+        loss_last = -net.log_prob(obs, X, actions).mean()
+        assert loss_last.item() < loss_first.item() - 0.05, (
+            f"hindsight loss did not decrease: first={loss_first.item():.4f} "
+            f"last={loss_last.item():.4f}"
+        )
+
+    def test_invalid_advantage_estimator_raises(self):
+        """Mistyped or unsupported estimator names must raise at trainer
+        construction, not silently fall back to GAE."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        with pytest.raises(ValueError, match="advantage_estimator"):
+            JointPPOTrainer(
+                env_fn=_env_fn,
+                num_agents=NUM_AGENTS,
+                obs_dim=obs_dim,
+                action_dims=ACTION_DIMS,
+                hidden_size=16,
+                advantage_estimator="invalid_name",
+                seed=0,
+            )
+
+    def test_compute_returns_to_go_resets_at_dones(self):
+        """Smoke: ``compute_returns_to_go`` should not leak credit across
+        episode boundaries marked by ``dones[t] == True``."""
+        from bucket_brigade.training.networks import compute_returns_to_go
+
+        rewards = [1.0, 2.0, 3.0, 4.0]
+        dones = [False, True, False, True]
+        # Episode 1: rewards [1, 2], Z = [1 + γ*2, 2]
+        # Episode 2: rewards [3, 4], Z = [3 + γ*4, 4]
+        gamma = 0.9
+        Z = compute_returns_to_go(rewards, dones, gamma=gamma)
+        assert Z[0] == pytest.approx(1.0 + gamma * 2.0)
+        assert Z[1] == pytest.approx(2.0)
+        assert Z[2] == pytest.approx(3.0 + gamma * 4.0)
+        assert Z[3] == pytest.approx(4.0)


### PR DESCRIPTION
## Summary

Implements Hindsight Credit Assignment (Harutyunyan et al. 2019, NeurIPS Eq. 9) as an alternative to GAE in the joint multi-agent PPO trainer, plus the sweep + analyzer scaffold for the #289 verdict experiment. Default `advantage_estimator="gae"` is bit-identical to pre-#289 behavior; opt in to HCA with `--use-hca`.

## Changes

- `bucket_brigade/training/networks.py`: `HindsightNetwork` (per-agent MLP over `(s, X)`), `compute_returns_to_go`, `encode_return_bucket` (quantile-bucketed `X_t`), `compute_hca_advantages` with `pi/h` ratio clip.
- `bucket_brigade/training/joint_trainer.py`: `advantage_estimator` flag, per-agent hindsight nets + independent Adam optimizers, MLE update step before PPO epochs, branch in `_compute_advantages`, HCA diagnostics in stats (`hindsight_loss/`, `hca_clip_frac/`, `hca_ratio_mean/`, `hca_hindsight_log_prob_mean/`).
- `experiments/p3_specialization/train.py`: `CellConfig` fields + CLI flags (`--use-hca`, `--advantage-estimator gae|hca`, `--hindsight-lr`, `--hindsight-num-return-buckets`, `--hindsight-ratio-clip`).
- `experiments/p3_specialization/run_issue289_sweep.sh` + `analyze_289.py`: 3-seed HCA + GAE-baseline arms, verdict matrix from the issue body (STRONG_WIN / WEAK_WIN_DISTINCT_FROM_MC / AMBIGUOUS / NEGATIVE).
- `tests/test_joint_trainer.py::TestHCA`: 8 new tests covering bit-identity regression, construction, no-NaN end-to-end, advantage shape, the h==pi -> MC sanity collapse, MLE-on-synthetic-data convergence, validation error on bad estimator name, and `compute_returns_to_go` done-boundary handling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| State-conditional HCA (Eq. 9) `A_t = (1 - pi/h)(Z_t - V)` | ✅ | `compute_hca_advantages` in `networks.py`; tested in `test_hca_reduces_to_mc_when_ratio_is_one` (h==pi -> A=0). |
| Per-agent independent hindsight nets | ✅ | `JointPPOTrainer.hindsight_nets` is `ModuleList` of N nets; tested in `test_hca_trainer_constructs`. |
| Replace/augment GAE in `_compute_advantages` | ✅ | Branch on `advantage_estimator`; GAE-only default path preserved. |
| `--use-hca` CLI flag | ✅ | Added (plus `--advantage-estimator gae|hca` for explicit form). |
| Hindsight classifier MLP + separate optimizer | ✅ | `HindsightNetwork` + per-agent Adam optimizers (independent from actor/critic). |
| pi/h ratio clipping for stability | ✅ | Symmetric log-ratio clip at `ratio_clip` (default 10.0); `clip_frac` logged. |
| Bit-identity test for `advantage_estimator='gae'` | ✅ | `test_gae_default_path_bit_identical` + full pre-#289 `TestUpdate` suite still green. |
| Sanity test (h==pi -> A=Z-V) | ✅ | `test_hca_reduces_to_mc_when_ratio_is_one`. |
| Sweep driver (NOT executed) | ✅ | `run_issue289_sweep.sh` written; comment block forbids localhost execution. |

## Test Plan

- [x] `pytest tests/test_joint_trainer.py` — 34 tests pass (8 new HCA + 26 existing).
- [x] `pytest tests/test_training.py tests/test_policy_learner.py tests/test_p3_conditioners.py` — 39 tests pass (no regression).
- [x] Local smoke: 2 iters x 128 steps x 4 agents x HCA on `minimal_specialization` completes; per-agent `hindsight_loss`, `hca_clip_frac`, `hca_ratio_mean` recorded.
- [x] Local smoke: default GAE path config.json has `advantage_estimator: gae`, metrics.json has zero HCA keys.
- [ ] (Out of local scope, per user) 50-iter x 3-seed sweep on a compute host — `run_issue289_sweep.sh` and `analyze_289.py` are ready.

Closes #289