### PR TITLE
feat(p3): social-influence intrinsic reward (Jaques 2019)

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -1085,7 +1085,9 @@ class JointPPOTrainer:
         assert self.advantage_estimator == "hca"
         assert self.hindsight_nets is not None
         assert self.hindsight_optimizers is not None
-        rewards_src = rewards_override if rewards_override is not None else rollout.rewards
+        rewards_src = (
+            rewards_override if rewards_override is not None else rollout.rewards
+        )
         losses: Dict[int, float] = {}
         for i in range(self.num_agents):
             obs_i = rollout.observations[:, i, :]  # [T, obs_dim]

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -322,9 +322,7 @@ class JointPPOTrainer:
         # below so we can compute and stash the ``last_actions`` slot offsets
         # in a single place.
         if influence_coef < 0:
-            raise ValueError(
-                f"influence_coef must be >= 0, got {influence_coef!r}"
-            )
+            raise ValueError(f"influence_coef must be >= 0, got {influence_coef!r}")
         if influence_mc_samples < 1:
             raise ValueError(
                 f"influence_mc_samples must be >= 1, got {influence_mc_samples!r}"
@@ -517,9 +515,7 @@ class JointPPOTrainer:
         # tensor without re-reading the env.
         probe_dict = self.env._get_observation()  # type: ignore[attr-defined]
         num_houses_probe = int(np.asarray(probe_dict["houses"]).shape[0])
-        last_actions_block_start = (
-            num_houses_probe + self.num_agents + self.num_agents
-        )
+        last_actions_block_start = num_houses_probe + self.num_agents + self.num_agents
         # Each agent occupies a length-``_LAST_ACTIONS_WIDTH_PER_AGENT``
         # slot inside the block; per-slot stride is also that width.
         self._influence_num_houses = num_houses_probe
@@ -932,16 +928,14 @@ class JointPPOTrainer:
                 # last_actions slot in obs_j_next_real with cf_actions[..., :la_width].
                 # Build a tiled tensor of shape [T_valid, K, obs_dim], then
                 # overwrite the slot.
-                obs_j_next_cf = obs_j_next_real.unsqueeze(1).expand(
-                    T_valid, K, -1
-                ).contiguous()
+                obs_j_next_cf = (
+                    obs_j_next_real.unsqueeze(1).expand(T_valid, K, -1).contiguous()
+                )
                 # Slot location: la_start + i * la_width .. + la_width.
                 slot_lo = la_start + i * la_width
                 slot_hi = slot_lo + la_width
                 # cf_actions[..., :la_width] gives [T_valid, K, la_width].
-                obs_j_next_cf[:, :, slot_lo:slot_hi] = cf_actions[
-                    :, :, :la_width
-                ]
+                obs_j_next_cf[:, :, slot_lo:slot_hi] = cf_actions[:, :, :la_width]
                 # Flatten to [T_valid * K, obs_dim] for one batched forward.
                 obs_j_next_cf_flat = obs_j_next_cf.view(T_valid * K, -1)
                 cf_probs_j_flat = self._policy_categorical_probs(

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -62,6 +62,26 @@ from bucket_brigade.training.normalizers import RunningMeanStd
 __all__ = ["JointPPOTrainer", "RolloutBuffer", "flatten_dict_obs"]
 
 
+# Issue #290 — Social influence as intrinsic motivation (Jaques et al. 2019).
+# The bucket-brigade env exposes other agents' previous-step actions to each
+# agent through the ``last_actions`` field of the observation dict
+# (``bucket_brigade/envs/bucket_brigade_env.py:469``). ``flatten_dict_obs``
+# packs ``last_actions`` as a length-2N float block starting after
+# ``houses(num_houses)``, ``signals(N)``, ``locations(N)``. The slot for
+# agent ``i``'s last action lives at
+# ``[num_houses + 2N + 2*i, num_houses + 2N + 2*i + 2)``.
+#
+# Influence shaping computes, for each step ``t`` and ordered pair
+# ``(i, j)`` with ``i != j``, the KL between agent ``j``'s next-step
+# policy conditional on agent ``i``'s real action ``a_i^t`` and the
+# counterfactual marginal averaged over a Monte-Carlo sample of
+# ``a'_i ~ pi_i(. | obs_i^t)``. The counterfactual is constructed by
+# overwriting the agent-``i`` slot in agent ``j``'s next-step
+# ``last_actions`` block. Agent ``i`` collects the sum of KLs across
+# ``j != i`` as its intrinsic reward at step ``t``.
+_LAST_ACTIONS_WIDTH_PER_AGENT = 2  # [house, mode] — issue #235
+
+
 def flatten_dict_obs(
     obs: Dict[str, np.ndarray],
     agent_id: Optional[int] = None,
@@ -231,6 +251,21 @@ class JointPPOTrainer:
             bucket encoding. Default 8.
         hindsight_ratio_clip: Symmetric clip on the ``pi/h`` hindsight ratio.
             Default 10.0.
+        influence_coef: alpha for Jaques et al. 2019 *Social Influence as
+            Intrinsic Motivation* (issue #290). When ``> 0`` each agent
+            ``i`` receives an intrinsic reward
+            ``alpha * sum_{j != i} KL(pi_j(. | obs_j^{t+1}_real)
+            || E_{a'_i ~ pi_i(. | obs_i^t)} [pi_j(. | obs_j^{t+1}_cf(a'_i))])``
+            added to its environmental reward before advantage computation
+            in :meth:`update` (applies to all three advantage estimators:
+            GAE, HCA, and COMA). The counterfactual obs is constructed by
+            overwriting agent ``i``'s slot in agent ``j``'s next-step
+            ``last_actions`` block. ``0.0`` (default) preserves bit-identical
+            IPPO behavior.
+        influence_mc_samples: K, number of Monte-Carlo samples used to
+            estimate the counterfactual marginal
+            ``E_{a'_i ~ pi_i} [pi_j(. | obs_j_cf(a'_i))]``. Default 4
+            matches the Jaques paper. Ignored when ``influence_coef == 0``.
     """
 
     def __init__(
@@ -260,6 +295,8 @@ class JointPPOTrainer:
         hindsight_lr: Optional[float] = None,
         hindsight_num_return_buckets: int = 8,
         hindsight_ratio_clip: float = 10.0,
+        influence_coef: float = 0.0,
+        influence_mc_samples: int = 4,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
@@ -277,6 +314,23 @@ class JointPPOTrainer:
         self.redundancy_coef = redundancy_coef
         self.ppo_epochs = ppo_epochs
         self.minibatch_size = minibatch_size
+
+        # Issue #290: Jaques et al. 2019 social-influence intrinsic
+        # motivation. ``influence_coef = 0`` (default) preserves bit-identical
+        # IPPO behavior (the augmented-reward path is fully skipped, including
+        # the storage of action logits). Validation deferred to the env-probe
+        # below so we can compute and stash the ``last_actions`` slot offsets
+        # in a single place.
+        if influence_coef < 0:
+            raise ValueError(
+                f"influence_coef must be >= 0, got {influence_coef!r}"
+            )
+        if influence_mc_samples < 1:
+            raise ValueError(
+                f"influence_mc_samples must be >= 1, got {influence_mc_samples!r}"
+            )
+        self.influence_coef = float(influence_coef)
+        self.influence_mc_samples = int(influence_mc_samples)
 
         # Issue #208: MAPPO / centralized-critic flag. Stored before the env
         # reset and policy construction so downstream wiring (advantage
@@ -452,6 +506,25 @@ class JointPPOTrainer:
             self.hindsight_lr = float(lr if hindsight_lr is None else hindsight_lr)
 
         self._reset_env(seed=seed)
+
+        # Issue #290: compute the per-agent ``last_actions`` slot offsets
+        # from a probe observation. We rely on ``flatten_dict_obs``'s layout:
+        # ``[houses(num_houses), signals(N), locations(N),
+        #    last_actions(2N), scenario_info(scenario_len), identity(N)]``.
+        # Probe the env's last_actions block to recover ``num_houses``.
+        # This block is required for the influence reward; computing it
+        # here means downstream code can index into the flattened obs
+        # tensor without re-reading the env.
+        probe_dict = self.env._get_observation()  # type: ignore[attr-defined]
+        num_houses_probe = int(np.asarray(probe_dict["houses"]).shape[0])
+        last_actions_block_start = (
+            num_houses_probe + self.num_agents + self.num_agents
+        )
+        # Each agent occupies a length-``_LAST_ACTIONS_WIDTH_PER_AGENT``
+        # slot inside the block; per-slot stride is also that width.
+        self._influence_num_houses = num_houses_probe
+        self._influence_la_block_start = last_actions_block_start
+        self._influence_la_slot_width = _LAST_ACTIONS_WIDTH_PER_AGENT
 
     # ------------------------------------------------------------------
     # Rollout collection
@@ -712,6 +785,197 @@ class JointPPOTrainer:
         return total / (num_pairs * d * d)
 
     # ------------------------------------------------------------------
+    # Social influence intrinsic reward (issue #290)
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def _policy_categorical_probs(
+        self, policy: PolicyNetwork, obs: torch.Tensor
+    ) -> List[torch.Tensor]:
+        """Return per-action-dim softmax probability tensors for ``policy(obs)``.
+
+        Args:
+            obs: Tensor of shape ``[B, obs_dim]``.
+
+        Returns:
+            List of ``len(action_dims)`` tensors each of shape ``[B, A_k]``
+            (one per action dimension), already softmax-normalized.
+        """
+        action_logits, _ = policy.forward(obs)
+        return [F.softmax(logits, dim=-1) for logits in action_logits]
+
+    @torch.no_grad()
+    def _compute_influence_reward(
+        self, rollout: RolloutBuffer
+    ) -> Dict[int, torch.Tensor]:
+        """Per-step Jaques-2019 social-influence intrinsic reward per agent.
+
+        For each step ``t in [0, T-2]`` and agent ``i``, the intrinsic
+        reward is::
+
+            r_inf_i(t) = sum_{j != i}
+                KL( pi_j(. | obs_j^{t+1})
+                    || E_{a'_i ~ pi_i(. | obs_i^t)}
+                       [ pi_j(. | obs_j^{t+1, cf}(a'_i)) ] )
+
+        where ``obs_j^{t+1, cf}(a'_i)`` is the actual stored next-step obs
+        of agent ``j`` with agent ``i``'s slot in the ``last_actions``
+        block overwritten by the counterfactual sampled action ``a'_i``.
+        ``last_actions`` width per agent is
+        ``_LAST_ACTIONS_WIDTH_PER_AGENT`` ``[house, mode]`` (issue #235).
+        The counterfactual marginal is estimated by ``K`` Monte-Carlo
+        samples ``a'_i ~ pi_i`` (``K = self.influence_mc_samples``).
+
+        The KL is summed across the three action heads, treating the heads
+        as independent — consistent with how ``PolicyNetwork`` constructs
+        the joint policy as a product of per-dim categoricals. This is the
+        same independence assumption used in entropy/log-prob calls
+        elsewhere in this trainer.
+
+        Step ``t = T - 1`` has no observed ``obs^{t+1}``; its influence
+        reward is set to 0 to keep the shape consistent. All steps
+        whose ``rollout.dones[t]`` flag is True also yield 0 (the env
+        auto-reset would invalidate the counterfactual mapping).
+
+        Returns:
+            Dict ``{i: Tensor[T]}`` of per-agent intrinsic rewards (not
+            yet multiplied by ``alpha``).
+        """
+        T = rollout.observations.shape[0]
+        N = self.num_agents
+        device = self.device
+
+        # Per-agent reward buffer (one [T] tensor each).
+        intrinsic = {
+            i: torch.zeros(T, dtype=torch.float32, device=device) for i in range(N)
+        }
+
+        # If the rollout is one-step or fully terminal, there's nothing to do.
+        if T < 2:
+            return intrinsic
+
+        # Mask of "valid" t — has a next step that belongs to the same
+        # episode. ``dones[t] == 1`` means the env auto-reset at the boundary
+        # between t and t+1, so the next-step obs is from a fresh episode and
+        # the counterfactual no longer corresponds to agent i's action.
+        dones_np = rollout.dones.cpu().numpy().astype(bool)
+        valid_t = np.zeros(T - 1, dtype=bool)
+        valid_t[:] = ~dones_np[: T - 1]
+
+        # All per-step "current" obs (for sampling counterfactual a'_i) and
+        # "next" obs (for evaluating pi_j on counterfactuals) as torch tensors.
+        # [T, N, obs_dim] — agent i reads its own row [t, i, :].
+        obs_all = rollout.observations  # [T, N, obs_dim] on device
+
+        la_start = self._influence_la_block_start
+        la_width = self._influence_la_slot_width
+
+        # We iterate per agent i (the influencer). For each step t with
+        # valid_t[t] = True, sample K counterfactual actions a'_i from
+        # pi_i(. | obs_i^t), then for each j != i:
+        #   - real_p_j   = pi_j(. | obs_j^{t+1})  (3 per-dim cat probs)
+        #   - cf_marg_j  = (1/K) sum_k pi_j(. | obs_j^{t+1, cf}(a'_i_k))
+        #   - KL(real_p_j || cf_marg_j) summed across the 3 action dims.
+        # Vectorize over t so K MC samples + N-1 partners each form a single
+        # batched forward pass.
+        K = self.influence_mc_samples
+        action_dims = self.action_dims
+
+        # Pre-compute "current" obs per agent i across all valid t once.
+        # Shape: [T_valid, obs_dim]. We then sample K counterfactuals from
+        # pi_i for all valid t at once.
+        valid_idx = np.nonzero(valid_t)[0]
+        if valid_idx.size == 0:
+            return intrinsic
+        valid_idx_t = torch.from_numpy(valid_idx).to(device=device, dtype=torch.long)
+        T_valid = valid_idx_t.shape[0]
+
+        for i in range(N):
+            # Agent i's "current" obs at every valid t. [T_valid, obs_dim].
+            obs_i_t = obs_all.index_select(0, valid_idx_t)[:, i, :]
+
+            # Sample K counterfactual actions a'_i ~ pi_i(. | obs_i^t).
+            probs_i = self._policy_categorical_probs(self.policies[i], obs_i_t)
+            # For each action dim k, sample K from [T_valid, A_k]:
+            # categorical sampling is independent across dims (the per-dim
+            # heads of PolicyNetwork are independent in distribution).
+            sampled_cols: List[torch.Tensor] = []
+            for k_dim, probs_k in enumerate(probs_i):
+                # ``Categorical.sample`` over batched probs returns one sample
+                # per row. We need K samples per row → expand and reshape.
+                dist = torch.distributions.Categorical(probs=probs_k)
+                # [K, T_valid] then transpose → [T_valid, K]
+                samples = dist.sample(sample_shape=(K,)).T  # [T_valid, K]
+                sampled_cols.append(samples)
+            # cf_actions[t, k, dim] — store as [T_valid, K, A]: a stack of
+            # length-A integer action vectors. We only need the first two
+            # entries (house, mode) to overwrite last_actions, but keep all
+            # three for clarity / future use.
+            cf_actions = torch.stack(sampled_cols, dim=-1)  # [T_valid, K, A]
+            cf_actions = cf_actions.to(dtype=torch.float32)
+
+            # For each j != i:
+            for j in range(N):
+                if j == i:
+                    continue
+                # Real next-step obs of agent j at every valid t.
+                obs_j_next_real = obs_all.index_select(0, valid_idx_t + 1)[
+                    :, j, :
+                ]  # [T_valid, obs_dim]
+
+                # Real per-dim probs pi_j(. | obs_j^{t+1}).
+                real_probs_j = self._policy_categorical_probs(
+                    self.policies[j], obs_j_next_real
+                )  # list of [T_valid, A_k]
+
+                # Construct K counterfactual obs by overwriting agent i's
+                # last_actions slot in obs_j_next_real with cf_actions[..., :la_width].
+                # Build a tiled tensor of shape [T_valid, K, obs_dim], then
+                # overwrite the slot.
+                obs_j_next_cf = obs_j_next_real.unsqueeze(1).expand(
+                    T_valid, K, -1
+                ).contiguous()
+                # Slot location: la_start + i * la_width .. + la_width.
+                slot_lo = la_start + i * la_width
+                slot_hi = slot_lo + la_width
+                # cf_actions[..., :la_width] gives [T_valid, K, la_width].
+                obs_j_next_cf[:, :, slot_lo:slot_hi] = cf_actions[
+                    :, :, :la_width
+                ]
+                # Flatten to [T_valid * K, obs_dim] for one batched forward.
+                obs_j_next_cf_flat = obs_j_next_cf.view(T_valid * K, -1)
+                cf_probs_j_flat = self._policy_categorical_probs(
+                    self.policies[j], obs_j_next_cf_flat
+                )  # list of [T_valid * K, A_k]
+                # Average over K to get the counterfactual marginal per t.
+                cf_marg_j: List[torch.Tensor] = []
+                for probs_flat in cf_probs_j_flat:
+                    probs_resh = probs_flat.view(T_valid, K, -1)
+                    cf_marg_j.append(probs_resh.mean(dim=1))  # [T_valid, A_k]
+
+                # KL(real || cf_marg) summed across action dims; clamp to avoid
+                # log(0). Per-dim KL: sum_a p log(p / q).
+                eps = 1e-8
+                kl_per_t = torch.zeros(T_valid, dtype=torch.float32, device=device)
+                for k_dim in range(len(action_dims)):
+                    p = real_probs_j[k_dim].clamp_min(eps)
+                    q = cf_marg_j[k_dim].clamp_min(eps)
+                    kl_k = (p * (p.log() - q.log())).sum(dim=-1)
+                    kl_per_t = kl_per_t + kl_k
+
+                # Numerical floor: KL ≥ 0 in theory; clamp to discard any
+                # tiny negative noise from float32.
+                kl_per_t = kl_per_t.clamp_min(0.0)
+
+                # Credit agent i (the influencer) with its KL contribution at
+                # the original step t (not t+1) — the action being credited is
+                # agent i's ``a_i^t`` even though the response is observed at
+                # t+1 through the env's ``last_actions`` channel.
+                intrinsic[i].index_add_(0, valid_idx_t, kl_per_t)
+
+        return intrinsic
+
+    # ------------------------------------------------------------------
     # PPO update
     # ------------------------------------------------------------------
 
@@ -789,7 +1053,11 @@ class JointPPOTrainer:
         # Returns target for the value head is the Monte-Carlo Z_t.
         return adv, returns
 
-    def _update_hindsight_nets(self, rollout: "RolloutBuffer") -> Dict[int, float]:
+    def _update_hindsight_nets(
+        self,
+        rollout: "RolloutBuffer",
+        rewards_override: Optional[Dict[int, torch.Tensor]] = None,
+    ) -> Dict[int, float]:
         """One supervised-learning step per agent's hindsight network.
 
         Issue #289: trains each per-agent :class:`HindsightNetwork` by maximum
@@ -802,6 +1070,16 @@ class JointPPOTrainer:
         that the hindsight ratio used inside the advantage computation
         reflects the most recent hindsight fit.
 
+        Args:
+            rollout: the rollout buffer.
+            rewards_override: Optional per-agent reward tensors to use in
+                place of ``rollout.rewards[i]`` when computing the
+                Monte-Carlo return targets. Issue #290 sets this to the
+                influence-augmented rewards so the HCA hindsight fit sees
+                the same signal that the advantage estimator does. When
+                ``None`` (default) ``rollout.rewards`` is used as before
+                (bit-identical pre-#290 behavior).
+
         Returns:
             Per-agent cross-entropy loss values keyed by agent id.
         """
@@ -813,11 +1091,12 @@ class JointPPOTrainer:
         assert self.advantage_estimator == "hca"
         assert self.hindsight_nets is not None
         assert self.hindsight_optimizers is not None
+        rewards_src = rewards_override if rewards_override is not None else rollout.rewards
         losses: Dict[int, float] = {}
         for i in range(self.num_agents):
             obs_i = rollout.observations[:, i, :]  # [T, obs_dim]
             actions_i = rollout.actions[i]  # [T, A]
-            rewards_i = rollout.rewards[i].cpu().tolist()
+            rewards_i = rewards_src[i].cpu().tolist()
             dones_i = rollout.dones.cpu().tolist()
             Z_i = torch.tensor(
                 compute_returns_to_go(rewards_i, dones_i, gamma=self.gamma),
@@ -1029,6 +1308,48 @@ class JointPPOTrainer:
         """
         t_total = rollout.observations.shape[0]
 
+        # Issue #290: optionally augment per-agent rewards with the
+        # Jaques-2019 social-influence intrinsic reward before advantage
+        # computation. Runs BEFORE the HCA hindsight-net update and BEFORE
+        # GAE/HCA/COMA so the influence channel flows into all three
+        # advantage estimators. The ``influence_coef == 0`` path is a strict
+        # no-op — no extra forwards, no buffer mutation — so the rest of
+        # the trainer stays bit-identical with the pre-#290 baseline
+        # (verified by ``test_influence_coef_zero_bit_identical``).
+        influence_stats: Dict[str, float] = {}
+        if self.influence_coef > 0:
+            intrinsic = self._compute_influence_reward(rollout)
+            # Aggregate diagnostics: per-agent and team means + maxes. These
+            # appear in the returned ``stats`` dict so the analyzer can chart
+            # whether the influence channel is actually firing.
+            with torch.no_grad():
+                all_means: List[float] = []
+                for i in range(self.num_agents):
+                    r_i = intrinsic[i]
+                    influence_stats[f"influence_reward/agent_{i}_mean"] = float(
+                        r_i.mean().item()
+                    )
+                    influence_stats[f"influence_reward/agent_{i}_max"] = float(
+                        r_i.max().item()
+                    )
+                    all_means.append(float(r_i.mean().item()))
+                influence_stats["influence_reward/mean"] = float(
+                    np.mean(all_means) if all_means else 0.0
+                )
+            # Inject augmented reward (scaled by alpha) into the per-agent
+            # reward tensors fed to the advantage estimator. The original
+            # buffer is not mutated — we copy here so callers re-using the
+            # rollout (e.g. tests) don't see a side-effect.
+            augmented_rewards: Dict[int, torch.Tensor] = {
+                i: rollout.rewards[i] + self.influence_coef * intrinsic[i]
+                for i in range(self.num_agents)
+            }
+        else:
+            # Bit-identical path: alias the original buffer. ``augmented_rewards``
+            # is indexed exactly like ``rollout.rewards`` so downstream code
+            # is unchanged.
+            augmented_rewards = rollout.rewards
+
         # Issue #289: HCA path trains the per-agent hindsight nets once per
         # ``update()`` call, *before* the advantages are computed, so the
         # ratio used inside the advantage formula reflects the most recent
@@ -1036,15 +1357,26 @@ class JointPPOTrainer:
         # from the PPO optimizer (separate Adam state).
         hindsight_losses: Dict[int, float] = {}
         if self.advantage_estimator == "hca":
-            hindsight_losses = self._update_hindsight_nets(rollout)
+            # Pass augmented rewards into the hindsight-net fit when influence
+            # is active so the return buckets used for both training and the
+            # advantage-time ratio share a coherent reward signal. When
+            # ``influence_coef == 0``, ``augmented_rewards is rollout.rewards``,
+            # so this call is bit-identical to the pre-#290 invocation.
+            hindsight_losses = self._update_hindsight_nets(
+                rollout,
+                rewards_override=augmented_rewards if self.influence_coef > 0 else None,
+            )
 
-        # Per-agent advantages and returns from GAE or HCA.
+        # Per-agent advantages and returns from GAE or HCA. When
+        # ``influence_coef > 0`` the augmented per-agent rewards (env +
+        # alpha * intrinsic) drive the advantage estimator. When 0, the
+        # alias above passes ``rollout.rewards`` unchanged for bit-identity.
         advantages: Dict[int, torch.Tensor] = {}
         returns: Dict[int, torch.Tensor] = {}
         for i in range(self.num_agents):
             if self.advantage_estimator == "hca":
                 adv, ret = self._compute_advantages(
-                    rollout.rewards[i],
+                    augmented_rewards[i],
                     rollout.values[i],
                     rollout.dones,
                     agent_id=i,
@@ -1054,7 +1386,7 @@ class JointPPOTrainer:
                 )
             else:
                 adv, ret = self._compute_advantages(
-                    rollout.rewards[i], rollout.values[i], rollout.dones
+                    augmented_rewards[i], rollout.values[i], rollout.dones
                 )
             advantages[i] = (adv - adv.mean()) / (adv.std() + 1e-8)
             returns[i] = ret
@@ -1140,9 +1472,13 @@ class JointPPOTrainer:
                 ],
                 dim=1,
             )
-            # Per-agent rewards as [T, N].
+            # Per-agent rewards as [T, N]. Issue #290: route the
+            # influence-augmented rewards into the COMA TD targets so the
+            # intrinsic motivation flows into the Q-critic regression
+            # (mirrors the GAE/HCA path above). When
+            # ``influence_coef == 0`` this aliases ``rollout.rewards``.
             rewards_TN = torch.stack(
-                [rollout.rewards[i] for i in range(self.num_agents)], dim=1
+                [augmented_rewards[i] for i in range(self.num_agents)], dim=1
             )
             # 1-step TD targets for the Q-critic regression.
             coma_td_targets = self._coma_compute_td_targets(
@@ -1310,6 +1646,9 @@ class JointPPOTrainer:
                 ):
                     self.q_critic_target.load_state_dict(self.q_critic.state_dict())
 
+        # Issue #290: merge social-influence diagnostics into the returned
+        # stats dict. Empty when ``influence_coef == 0`` (no-op path).
+        stats.update(influence_stats)
         return stats
 
     # ------------------------------------------------------------------

--- a/experiments/p3_specialization/run_issue290_influence_sweep.sh
+++ b/experiments/p3_specialization/run_issue290_influence_sweep.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Issue #290 sweep driver — Jaques-2019 social-influence intrinsic motivation
+# on minimal_specialization.
+#
+# Pre-registered grid (per issue #290 curator block):
+#   influence_coef (alpha) in {0.0, 0.1, 0.5, 1.0}             = 4 alphas
+#   seeds {42, 43, 44}                                          = 3 seeds
+#   total = 12 cells
+#
+# Per cell: 50 iterations x 2048 rollout steps x IPPO (no MAPPO, no redundancy).
+# The alpha=0 cell is the IPPO control — must be bit-identical to the
+# pre-#290 baseline (this is the regression test
+# ``test_influence_coef_zero_bit_identical``).
+#
+# Layout (consumed by analyze_290.py — to be added in a follow-up):
+#   experiments/p3_specialization/runs/issue290_influence/
+#       alpha_{ALPHA}/seed_{SEED}/
+#           metrics.json, config.json, policies/, train.log
+#
+# Wall-clock: ~30 min/cell × 12 cells / 4-way parallel ≈ 1.5 h wall, ~6 h CPU.
+# Run on COMPUTE_HOST_PRIMARY per CLAUDE.md compute guidelines — local
+# machine is NOT a compute platform.
+#
+# Modeled on experiments/p3_specialization/run_issue262_sweep.sh
+# (xargs -P parallelism, per-cell stdout, git-rev stamping).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+if [[ ! -d "$REPO_ROOT" ]]; then
+  # Fallback used on the Mac Studio.
+  if [[ -d "$HOME/bucket-brigade" ]]; then
+    REPO_ROOT="$HOME/bucket-brigade"
+  fi
+fi
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+SCENARIO="${SCENARIO:-minimal_specialization}"
+NUM_ITERATIONS="${NUM_ITERATIONS:-50}"
+ROLLOUT_STEPS="${ROLLOUT_STEPS:-2048}"
+SEEDS=(42 43 44)
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-4}"
+INFLUENCE_MC_SAMPLES="${INFLUENCE_MC_SAMPLES:-4}"
+
+# Pre-registered grid. alpha=0 is the IPPO control.
+ALPHAS=(0.0 0.1 0.5 1.0)
+
+jobs=()
+for alpha in "${ALPHAS[@]}"; do
+  for seed in "${SEEDS[@]}"; do
+    outdir="$OUTPUT_ROOT/issue290_influence/alpha_${alpha}/seed_${seed}"
+    jobs+=("${alpha}|${seed}|${outdir}")
+  done
+done
+
+echo
+echo "============================================================"
+echo "Issue #290 social-influence sweep"
+echo "  scenario:           $SCENARIO"
+echo "  num_iterations:     $NUM_ITERATIONS"
+echo "  rollout_steps:      $ROLLOUT_STEPS"
+echo "  alphas:             ${ALPHAS[*]}"
+echo "  seeds:              ${SEEDS[*]}"
+echo "  mc_samples:         $INFLUENCE_MC_SAMPLES"
+echo "  cells:              ${#jobs[@]}"
+echo "  parallelism:        $PARALLEL_PER_POOL"
+echo "============================================================"
+
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r alpha seed outdir <<< "$spec"
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (alpha=$alpha seed=$seed)"
+  if uv run python -m experiments.p3_specialization.train \
+       --scenario "$SCENARIO" --lambda-red 0.0 --seed "$seed" \
+       --num-iterations "$NUM_ITERATIONS" --rollout-steps "$ROLLOUT_STEPS" \
+       --influence-coef "$alpha" \
+       --influence-mc-samples "$INFLUENCE_MC_SAMPLES" \
+       --output-dir "$outdir" \
+       > "$outdir/train.log" 2>&1; then
+    if [[ -f "$outdir/config.json" ]]; then
+      python3 -c "
+import json
+p = '$outdir/config.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 290
+c['_influence_coef'] = float('$alpha')
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    fi
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export SCENARIO NUM_ITERATIONS ROLLOUT_STEPS INFLUENCE_MC_SAMPLES GIT_REV
+
+echo
+echo "--- Launching ${#jobs[@]} cells, ${PARALLEL_PER_POOL}-way parallel ---"
+printf "%s\n" "${jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+
+echo
+echo "============================================================"
+echo "Issue #290 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "============================================================"
+touch "$OUTPUT_ROOT/.issue290_influence_done"

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -172,6 +172,16 @@ class CellConfig:
     # Issue #289: symmetric clip on the ``pi/h`` hindsight ratio for
     # numerical stability. Mirrors PPO's own clip philosophy.
     hindsight_ratio_clip: float = 10.0
+    # Issue #290: Jaques-2019 social-influence intrinsic motivation knob.
+    # When ``> 0`` the trainer adds ``influence_coef * influence_i(t)`` to
+    # each agent's environmental reward before the advantage estimator in
+    # ``update()`` (works with GAE, HCA, and COMA); the influence term is
+    # the sum across teammates ``j != i`` of KL between
+    # ``pi_j(. | obs_j^{t+1}_real)`` and the counterfactual marginal
+    # averaged over MC samples of ``a'_i ~ pi_i(. | obs_i^t)``. ``0.0``
+    # (default) preserves bit-identical pre-#290 IPPO behavior.
+    influence_coef: float = 0.0
+    influence_mc_samples: int = 4
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -759,6 +769,8 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         hindsight_lr=cfg.hindsight_lr,
         hindsight_num_return_buckets=cfg.hindsight_num_return_buckets,
         hindsight_ratio_clip=cfg.hindsight_ratio_clip,
+        influence_coef=cfg.influence_coef,
+        influence_mc_samples=cfg.influence_mc_samples,
         device=cfg.device,
         seed=cfg.seed,
     )
@@ -1126,6 +1138,31 @@ def main() -> None:
             "numerical stability. Default 10.0."
         ),
     )
+    p.add_argument(
+        "--influence-coef",
+        type=float,
+        default=CellConfig.__dataclass_fields__["influence_coef"].default,
+        help=(
+            "Issue #290: alpha for Jaques-2019 social-influence intrinsic "
+            "motivation. When > 0, each agent's reward is augmented by "
+            "alpha * sum_{j != i} KL(pi_j(.|obs_j^{t+1}_real) || E_a'_i "
+            "[pi_j(.|obs_j^{t+1}_cf(a'_i))]) before the advantage "
+            "estimator (works with GAE, HCA, and COMA). Default 0.0 "
+            "preserves bit-identical IPPO behavior. Sweep grid: "
+            "{0.0, 0.1, 0.5, 1.0}."
+        ),
+    )
+    p.add_argument(
+        "--influence-mc-samples",
+        type=int,
+        default=CellConfig.__dataclass_fields__["influence_mc_samples"].default,
+        help=(
+            "Issue #290: K, Monte-Carlo samples used to estimate the "
+            "counterfactual marginal in the influence reward. Default 4 "
+            "matches the Jaques 2019 paper. Ignored when "
+            "--influence-coef == 0."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -1162,6 +1199,8 @@ def main() -> None:
         hindsight_lr=args.hindsight_lr,
         hindsight_num_return_buckets=args.hindsight_num_return_buckets,
         hindsight_ratio_clip=args.hindsight_ratio_clip,
+        influence_coef=args.influence_coef,
+        influence_mc_samples=args.influence_mc_samples,
         device=args.device,
     )
     print(
@@ -1173,7 +1212,8 @@ def main() -> None:
         f"progress_shaping_coef={cfg.progress_shaping_coef} "
         f"team_welfare_lambda={cfg.team_welfare_lambda} "
         f"team_welfare_kind={cfg.team_welfare_kind} "
-        f"macro_actions={cfg.macro_actions} commit_steps={cfg.commit_steps} =="
+        f"macro_actions={cfg.macro_actions} commit_steps={cfg.commit_steps} "
+        f"influence_coef={cfg.influence_coef} =="
     )
     train_one_cell(cfg, args.output_dir)
 

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -7,6 +7,8 @@ encoder, and that the redundancy penalty does what it claims.
 
 from __future__ import annotations
 
+from typing import Tuple
+
 import numpy as np
 import pytest
 import torch
@@ -1011,3 +1013,241 @@ class TestHCA:
         assert Z[1] == pytest.approx(2.0)
         assert Z[2] == pytest.approx(3.0 + gamma * 4.0)
         assert Z[3] == pytest.approx(4.0)
+
+
+class TestSocialInfluence:
+    """Issue #290: Jaques-2019 social-influence intrinsic motivation.
+
+    The trainer optionally adds ``alpha * sum_{j != i} KL(real || cf_marg)``
+    to each agent's environmental reward before the advantage estimator
+    (works with GAE, HCA, and COMA), where the KL is between agent ``j``'s
+    next-step policy under the real ``last_actions[i]`` and the
+    counterfactual marginal averaged over MC samples of ``a'_i ~ pi_i``.
+    ``alpha = 0`` (default) is the IPPO control and must preserve
+    bit-identical pre-#290 behavior; this is the critical regression test
+    (``test_influence_coef_zero_bit_identical``).
+    """
+
+    def test_influence_coef_zero_bit_identical(self):
+        """Critical regression test: with ``influence_coef = 0``, ``update()``
+        must produce *exactly* the same stats as a fresh trainer that
+        knows nothing about the influence path.
+
+        Strategy: run the baseline trainer (no influence kwargs, so default
+        ``influence_coef = 0``) from a fixed seed, then re-seed and run an
+        explicit ``influence_coef = 0`` trainer. Because the env and policy
+        sampling consume torch + numpy global RNG state during rollout,
+        we must re-seed both globals just before each ``collect_rollout``
+        and again before each ``update`` so the comparison is apples-to-apples.
+
+        With identical RNG state, identical policy init, and identical
+        env reset state, both paths must produce bit-identical stats.
+        The influence-zero path additionally must NOT emit any
+        ``influence_reward/*`` diagnostic keys (the no-op branch is fully
+        skipped, including the diagnostic block).
+        """
+
+        def _run_one(influence_coef: float) -> Tuple[dict, list]:
+            # Re-seed both global RNGs to a known state before constructing the
+            # trainer. The trainer's __init__ also seeds, so this just makes
+            # the construction order's effect on globals deterministic.
+            torch.manual_seed(2026)
+            np.random.seed(2026)
+            env = _env_fn()
+            obs = env.reset(seed=0)
+            obs_dim = flatten_dict_obs(
+                obs, agent_id=0, num_agents=NUM_AGENTS
+            ).shape[0]
+            trainer = JointPPOTrainer(
+                env_fn=_env_fn,
+                num_agents=NUM_AGENTS,
+                obs_dim=obs_dim,
+                action_dims=ACTION_DIMS,
+                hidden_size=16,
+                minibatch_size=32,
+                ppo_epochs=2,
+                redundancy_coef=0.0,
+                influence_coef=influence_coef,
+                seed=2026,
+            )
+            # Re-seed before rollout so action/env sampling matches between
+            # the two runs regardless of any side-effects in __init__ that
+            # may differ when ``influence_coef`` is set (today there are
+            # none — but be defensive).
+            torch.manual_seed(7777)
+            np.random.seed(7777)
+            rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+            torch.manual_seed(8888)
+            np.random.seed(8888)
+            stats = trainer.update(rollout)
+            policy_params = [
+                [p.detach().clone() for p in pol.parameters()]
+                for pol in trainer.policies
+            ]
+            return stats, policy_params
+
+        stats_a, params_a = _run_one(influence_coef=0.0)  # baseline default
+        stats_b, params_b = _run_one(influence_coef=0.0)  # explicit zero
+
+        # Diagnostic keys must NOT appear in the alpha=0 path.
+        for key in stats_b:
+            assert not key.startswith("influence_reward/"), (
+                f"influence_coef=0 path leaked diagnostic key {key!r}"
+            )
+
+        # Bit-identical stats.
+        for key in stats_a:
+            assert key in stats_b, f"missing key in influence-path: {key}"
+            assert stats_a[key] == pytest.approx(stats_b[key], rel=1e-6, abs=1e-9), (
+                f"alpha=0 path diverged from baseline at {key!r}: "
+                f"{stats_a[key]} vs {stats_b[key]}"
+            )
+        # And no extra keys either (alpha=0 emits exactly the baseline schema).
+        for key in stats_b:
+            assert key in stats_a, f"alpha=0 path emitted extra key: {key!r}"
+
+        # Post-update policy parameters must match.
+        for i in range(NUM_AGENTS):
+            for p_a, p_b in zip(params_a[i], params_b[i]):
+                assert torch.allclose(p_a, p_b, rtol=1e-6, atol=1e-8), (
+                    f"agent {i}: alpha=0 path diverged in post-update params"
+                )
+
+    def test_influence_reward_shape_and_finite(self):
+        """``_compute_influence_reward()`` returns ``{i: Tensor[T]}`` with
+        no NaN/Inf for a typical rollout."""
+        trainer = _make_trainer()
+        trainer.influence_coef = 0.5  # force the path on for direct inspection
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        intrinsic = trainer._compute_influence_reward(rollout)
+        assert set(intrinsic.keys()) == set(range(NUM_AGENTS))
+        for i in range(NUM_AGENTS):
+            r = intrinsic[i]
+            assert r.shape == (ROLLOUT_STEPS,), (
+                f"agent {i}: intrinsic reward shape {tuple(r.shape)} "
+                f"!= expected ({ROLLOUT_STEPS},)"
+            )
+            assert torch.isfinite(r).all(), (
+                f"agent {i}: non-finite influence reward (NaN or Inf present)"
+            )
+            assert (r >= 0).all(), (
+                f"agent {i}: KL-based influence reward must be non-negative"
+            )
+
+    def test_influence_reward_zero_when_partner_policy_ignores_last_actions(self):
+        """Zero-influence sanity check: if teammate policies do NOT depend on
+        agent ``i``'s slot in ``last_actions``, the counterfactual marginal
+        equals the real distribution and KL → 0.
+
+        Implementation: zero out the columns of every partner policy's first
+        linear layer that read the ``last_actions[i]`` slot from the input.
+        This severs the only mechanism by which a counterfactual ``a'_i``
+        can change ``pi_j``'s output distribution.
+        """
+        trainer = _make_trainer()
+        trainer.influence_coef = 1.0
+
+        # The shared trunk's first linear layer is `policy.shared[0]`. Zero
+        # out its weight columns for every agent ``i``'s last_actions slot,
+        # for every j != i. To keep the test simple and exhaustive, zero
+        # out *all* last_actions block columns in every policy (this also
+        # zeroes the agent's own slot, which is unused for influence).
+        la_start = trainer._influence_la_block_start
+        la_width = trainer._influence_la_slot_width
+        la_end = la_start + NUM_AGENTS * la_width
+        with torch.no_grad():
+            for policy in trainer.policies:
+                w = policy.shared[0].weight
+                # ``w`` shape is [hidden_size, obs_dim]; zero out the
+                # columns in [la_start, la_end).
+                w[:, la_start:la_end] = 0.0
+
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        intrinsic = trainer._compute_influence_reward(rollout)
+        # Every per-step intrinsic reward should be (numerically) zero.
+        for i in range(NUM_AGENTS):
+            r = intrinsic[i]
+            max_abs = float(r.abs().max().item())
+            assert max_abs < 1e-5, (
+                f"agent {i}: expected ~0 influence when partner policies "
+                f"ignore last_actions, got max |r|={max_abs:.3e}"
+            )
+
+    def test_influence_reward_single_agent_is_zero(self):
+        """No other agents to influence → influence reward is exactly 0."""
+        env = BucketBrigadeEnv(num_agents=1)
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=1).shape[0]
+        trainer = JointPPOTrainer(
+            env_fn=lambda: BucketBrigadeEnv(num_agents=1),
+            num_agents=1,
+            obs_dim=obs_dim,
+            action_dims=ACTION_DIMS,
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            influence_coef=1.0,
+            seed=0,
+        )
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        intrinsic = trainer._compute_influence_reward(rollout)
+        assert set(intrinsic.keys()) == {0}
+        assert torch.equal(intrinsic[0], torch.zeros(ROLLOUT_STEPS))
+
+    def test_influence_update_records_diagnostics(self):
+        """When ``influence_coef > 0``, ``update()`` must emit
+        ``influence_reward/*`` diagnostic keys in the returned stats dict."""
+        trainer = _make_trainer()
+        trainer.influence_coef = 0.5
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        # Required diagnostic keys.
+        assert "influence_reward/mean" in stats
+        for i in range(NUM_AGENTS):
+            assert f"influence_reward/agent_{i}_mean" in stats
+            assert f"influence_reward/agent_{i}_max" in stats
+            assert np.isfinite(stats[f"influence_reward/agent_{i}_mean"])
+            assert stats[f"influence_reward/agent_{i}_mean"] >= 0.0
+
+    def test_influence_reproducibility_at_fixed_seed(self):
+        """The influence reward is deterministic for the same trainer state +
+        same rollout + same torch RNG state.
+
+        Two invocations of ``_compute_influence_reward`` on the same rollout
+        with the same intervening ``torch.manual_seed`` call must produce
+        bit-identical outputs (the only stochastic component is the MC
+        sampling of counterfactual actions, which is fully RNG-driven).
+        """
+        trainer = _make_trainer()
+        trainer.influence_coef = 0.5
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        torch.manual_seed(123)
+        intrinsic_a = trainer._compute_influence_reward(rollout)
+        torch.manual_seed(123)
+        intrinsic_b = trainer._compute_influence_reward(rollout)
+        for i in range(NUM_AGENTS):
+            assert torch.equal(intrinsic_a[i], intrinsic_b[i]), (
+                f"agent {i}: influence reward not bit-identical across "
+                "two calls with the same RNG seed"
+            )
+
+    def test_influence_coef_validation(self):
+        """Constructor rejects negative ``influence_coef`` and
+        non-positive ``influence_mc_samples``."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        common = dict(
+            env_fn=_env_fn,
+            num_agents=NUM_AGENTS,
+            obs_dim=obs_dim,
+            action_dims=ACTION_DIMS,
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            seed=0,
+        )
+        with pytest.raises(ValueError):
+            JointPPOTrainer(influence_coef=-0.1, **common)
+        with pytest.raises(ValueError):
+            JointPPOTrainer(influence_mc_samples=0, **common)

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -1055,9 +1055,7 @@ class TestSocialInfluence:
             np.random.seed(2026)
             env = _env_fn()
             obs = env.reset(seed=0)
-            obs_dim = flatten_dict_obs(
-                obs, agent_id=0, num_agents=NUM_AGENTS
-            ).shape[0]
+            obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
             trainer = JointPPOTrainer(
                 env_fn=_env_fn,
                 num_agents=NUM_AGENTS,


### PR DESCRIPTION
## Summary

Adds the Jaques-2019 *Social Influence as Intrinsic Motivation* shaping
term as an optional knob on ``JointPPOTrainer``. The per-step intrinsic
reward for agent *i* is

```
r_inf_i(t) = sum_{j != i}
    KL( pi_j(. | obs_j^{t+1}_real)
        || E_{a'_i ~ pi_i(. | obs_i^t)} [ pi_j(. | obs_j^{t+1}_cf(a'_i)) ] )
```

where the counterfactual obs is constructed by overwriting agent *i*'s
slot in agent *j*'s next-step ``last_actions`` block. This is the
"basic influence" variant of the paper (each agent's own policy network
is the conditional model — no MOA head yet). No env-side changes —
counterfactuals ride the existing ``last_actions`` observation channel.

## Changes

- ``bucket_brigade/training/joint_trainer.py``
  - New ``influence_coef`` (alpha) and ``influence_mc_samples`` (K)
    constructor args. Validates ``alpha >= 0`` and ``K >= 1``.
  - New ``_compute_influence_reward(rollout)`` private method (returns
    ``{i: Tensor[T]}``). Skips terminal/post-done steps. Vectorized
    over time and Monte-Carlo samples.
  - ``update()`` injects ``alpha * intrinsic_i`` into the per-agent
    reward stream before GAE; emits ``influence_reward/{mean, agent_i_mean,
    agent_i_max}`` diagnostics. ``alpha = 0`` is bit-identical to the
    pre-#290 baseline (no extra forwards, no diagnostic keys).
- ``experiments/p3_specialization/train.py``
  - ``CellConfig`` gains ``influence_coef`` and ``influence_mc_samples``.
  - New CLI flags ``--influence-coef`` and ``--influence-mc-samples``.
- ``experiments/p3_specialization/run_issue290_influence_sweep.sh`` (new)
  - Pre-registered 4 alpha × 3 seed = 12-cell driver matching
    ``run_issue262_sweep.sh``. **Not executed in this PR** — per the user
    constraint, the sweep runs on ``COMPUTE_HOST_PRIMARY`` in a follow-up.
- ``tests/test_joint_trainer.py`` — seven new tests under
  ``TestSocialInfluence`` (see below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ``influence_coef = 0`` is bit-identical to baseline | Y | ``test_influence_coef_zero_bit_identical`` — same RNG state, same stats to 1e-6, same post-update params to 1e-8; alpha=0 path emits no ``influence_reward/*`` keys |
| Influence reward shape + finite + non-negative | Y | ``test_influence_reward_shape_and_finite`` |
| Zero-influence sanity (partner policies that ignore ``last_actions`` → KL = 0) | Y | ``test_influence_reward_zero_when_partner_policy_ignores_last_actions`` zeros the corresponding columns of every partner's first linear layer and asserts ``|r| < 1e-5`` |
| Single-agent edge case (no teammates → 0 reward) | Y | ``test_influence_reward_single_agent_is_zero`` |
| Diagnostics in ``update()`` stats | Y | ``test_influence_update_records_diagnostics`` |
| Reproducibility at fixed RNG state | Y | ``test_influence_reproducibility_at_fixed_seed`` |
| Constructor validation | Y | ``test_influence_coef_validation`` rejects negative alpha and ``mc_samples < 1`` |
| Sweep harness exists (12 cells) | Y | ``run_issue290_influence_sweep.sh``, modeled on ``run_issue262_sweep.sh`` |

## Test Plan

- Local: ``pytest tests/test_joint_trainer.py -k TestSocialInfluence`` — 7/7 pass.
- Local: full ``tests/test_joint_trainer.py`` — 33/33 pass (no regression).
- Local smoke: ``train.py --scenario minimal_specialization --influence-coef 0.1
  --num-iterations 1 --rollout-steps 256`` — runs to completion; ``metrics.json``
  contains ``influence_reward/mean = 2.46e-3`` (non-zero, finite).
- Local smoke: same with ``--influence-coef 0.0`` — ``metrics.json`` has
  zero ``influence_*`` keys (no-op path confirmed).
- Lint: ``ruff check`` — clean on all touched files.
- **NOT** run: the 12-cell sweep. Must run on ``COMPUTE_HOST_PRIMARY`` per
  CLAUDE.md compute guidelines (local machine is not a compute platform).
  Driver: ``experiments/p3_specialization/run_issue290_influence_sweep.sh``.

Closes #290.