### PR TITLE
feat(p3): COMA counterfactual advantage with CentralizedQCritic

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -50,6 +50,7 @@ import torch.optim as optim
 
 from bucket_brigade.training.networks import (
     CentralizedCritic,
+    CentralizedQCritic,
     PolicyNetwork,
     compute_gae,
 )
@@ -188,6 +189,29 @@ class JointPPOTrainer:
             penalty couples the per-agent actor trunks; combining it with
             a centralized critic would entangle two unrelated experiments.
             Raises ``ValueError`` if both are set.
+        coma: If True, enable COMA (issue #284). A
+            :class:`CentralizedQCritic` Q-function replaces the V-baseline:
+            advantages are the COMA counterfactual
+
+            ::
+
+                A_i = Q(s, a)_i - sum_u  pi_i(u | s) * Q(s, (a_{-i}, u))_i
+
+            evaluated by enumerating over the joint per-agent action space
+            (``prod(action_dims) = 40`` for the default ``[10, 2, 2]``).
+            The Q-critic is trained against 1-step TD targets
+            ``r_t + gamma * Q_target(s_{t+1}, a_{t+1})``; a slow target
+            network is updated by hard-copy every ``coma_target_update_every``
+            update steps. The per-agent value heads are bypassed (as with
+            ``centralized_critic``). Default ``False`` preserves IPPO.
+
+            **Incompatible with ``redundancy_coef > 0`` and
+            ``centralized_critic=True``**: COMA, MAPPO, and the redundancy
+            penalty are three separate experiments — pick one. Raises
+            ``ValueError`` if more than one is set.
+        coma_target_update_every: How often (in PPO update steps) to hard-
+            copy the Q-critic into the target network. Default 200 matches
+            the Foerster 2018 paper. Only used when ``coma=True``.
     """
 
     def __init__(
@@ -211,6 +235,8 @@ class JointPPOTrainer:
         seed: Optional[int] = None,
         normalize_returns: bool = False,
         centralized_critic: bool = False,
+        coma: bool = False,
+        coma_target_update_every: int = 200,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
@@ -241,6 +267,33 @@ class JointPPOTrainer:
                 "heads. Combining them entangles two unrelated experiments. "
                 "Pick one."
             )
+
+        # Issue #284: COMA / counterfactual-advantage flag. Mutually exclusive
+        # with both MAPPO and the redundancy penalty — each is a separate
+        # experiment with a distinct critic stack.
+        self.coma = coma
+        self.coma_target_update_every = coma_target_update_every
+        if coma and centralized_critic:
+            raise ValueError(
+                "coma=True is incompatible with centralized_critic=True: "
+                "COMA installs a Q-critic for counterfactual advantages, "
+                "while MAPPO installs a V-critic for shared baselines. "
+                "Pick one."
+            )
+        if coma and redundancy_coef > 0:
+            raise ValueError(
+                "coma=True is incompatible with redundancy_coef>0: the "
+                "redundancy penalty couples the per-agent actor trunks, "
+                "while COMA replaces the per-agent value heads with a "
+                "centralized Q-network. Combining them entangles two "
+                "unrelated experiments. Pick one."
+            )
+
+        # COMA enumerates over the joint per-agent action space (option 2 in
+        # the curator's spec). For multi-discrete ``[10, 2, 2]`` this is
+        # 40 entries — cheap enough that a per-agent forward over all 40
+        # candidate actions is feasible at update time.
+        self.action_dim_total = int(np.prod(action_dims)) if coma else 0
 
         # Issue #159: optional running mean/std of returns to shrink the
         # value-loss MSE target to O(1) (Phase 1 diagnostics showed
@@ -297,6 +350,43 @@ class JointPPOTrainer:
             self.critic = None
             self.critic_optimizer = None
 
+        # Issue #284: optional COMA Q-critic + target network. Mirrors the
+        # MAPPO critic structure above (separate optimizer, separate state).
+        # The target network is a hard-copy of the live Q-critic, refreshed
+        # every ``coma_target_update_every`` PPO update steps.
+        if self.coma:
+            self._global_obs_dim = obs_dim - num_agents
+            if self._global_obs_dim <= 0:
+                raise ValueError(
+                    f"coma=True requires obs_dim ({obs_dim}) > num_agents "
+                    f"({num_agents}) so the identity-tail-stripped global "
+                    "obs has positive length."
+                )
+            self.q_critic: Optional[CentralizedQCritic] = CentralizedQCritic(
+                global_obs_dim=self._global_obs_dim,
+                num_agents=num_agents,
+                action_dim_total=self.action_dim_total,
+                hidden_size=hidden_size,
+            ).to(self.device)
+            self.q_critic_target: Optional[CentralizedQCritic] = CentralizedQCritic(
+                global_obs_dim=self._global_obs_dim,
+                num_agents=num_agents,
+                action_dim_total=self.action_dim_total,
+                hidden_size=hidden_size,
+            ).to(self.device)
+            self.q_critic_target.load_state_dict(self.q_critic.state_dict())
+            for p in self.q_critic_target.parameters():
+                p.requires_grad_(False)
+            self.q_critic_optimizer: Optional[optim.Optimizer] = optim.Adam(
+                self.q_critic.parameters(), lr=lr
+            )
+            self._coma_update_step = 0
+        else:
+            self.q_critic = None
+            self.q_critic_target = None
+            self.q_critic_optimizer = None
+            self._coma_update_step = 0
+
         self._reset_env(seed=seed)
 
     # ------------------------------------------------------------------
@@ -350,6 +440,51 @@ class JointPPOTrainer:
             )
         return agent0[..., : self._global_obs_dim]
 
+    def _pack_joint_action(self, actions: torch.Tensor) -> torch.Tensor:
+        """Pack a multi-discrete action tensor into a flat integer code.
+
+        Used by the COMA path (issue #284) to map the multi-discrete action
+        ``[a_0, a_1, a_2]`` (sub-action sizes from ``self.action_dims``) into
+        a single integer in ``[0, prod(action_dims))``. Mirrors the standard
+        row-major flatten that ``np.unravel_index`` reverses.
+
+        Args:
+            actions: Long tensor of shape ``(..., A)`` where ``A = len(action_dims)``.
+
+        Returns:
+            Long tensor of shape ``(...)`` with values in
+            ``[0, prod(action_dims))``.
+        """
+        # Compute strides for row-major packing: stride[k] = prod(action_dims[k+1:]).
+        # For action_dims = [10, 2, 2]: strides = [4, 2, 1].
+        strides = []
+        s = 1
+        for d in reversed(self.action_dims):
+            strides.insert(0, s)
+            s *= d
+        out = torch.zeros(actions.shape[:-1], dtype=torch.long, device=actions.device)
+        for k, stride in enumerate(strides):
+            out = out + actions[..., k].long() * stride
+        return out
+
+    def _coma_joint_action_one_hot(
+        self, packed_joint_actions: torch.Tensor
+    ) -> torch.Tensor:
+        """One-hot encode the joint per-agent action across all N agents.
+
+        Args:
+            packed_joint_actions: Long tensor of shape ``(batch, N)`` — each
+                entry is in ``[0, action_dim_total)``.
+
+        Returns:
+            Tensor of shape ``(batch, N * action_dim_total)`` — flat
+            concatenation of per-agent one-hots. Used as the
+            ``joint_action_one_hot`` input to :class:`CentralizedQCritic`.
+        """
+        batch = packed_joint_actions.shape[0]
+        oh = F.one_hot(packed_joint_actions, num_classes=self.action_dim_total).float()
+        return oh.reshape(batch, self.num_agents * self.action_dim_total)
+
     @torch.no_grad()
     def _act_all(
         self, obs_per_agent_t: torch.Tensor
@@ -388,6 +523,14 @@ class JointPPOTrainer:
             global_obs = self._global_obs_from_per_agent(obs_per_agent_t).unsqueeze(0)
             shared_value = self.critic(global_obs).squeeze(-1).squeeze(0)
             values = [shared_value for _ in range(self.num_agents)]
+        elif self.coma:
+            # COMA computes advantages at update-time from the Q-critic, not
+            # from a per-step value baseline. We still populate the rollout's
+            # per-agent value slots (the buffer schema is shared with IPPO /
+            # MAPPO) but with zeros — they are explicitly ignored in
+            # ``update()`` when ``self.coma`` is True.
+            zero = obs_per_agent_t.new_zeros(())
+            values = [zero for _ in range(self.num_agents)]
         return joint_action, log_probs, values
 
     def collect_rollout(self, num_steps: int) -> RolloutBuffer:
@@ -528,6 +671,188 @@ class JointPPOTrainer:
         ret = adv + values
         return adv, ret
 
+    @staticmethod
+    def coma_counterfactual_advantage(
+        q_chosen: torch.Tensor,
+        q_all: torch.Tensor,
+        action_probs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the COMA counterfactual advantage.
+
+        For each batch entry, COMA's per-agent advantage is
+
+        ::
+
+            A_i = Q(s, a)_i - sum_u  pi_i(u | s) * Q(s, (a_{-i}, u))_i
+
+        where ``q_all`` enumerates the Q-vector over all possible per-agent
+        actions for agent i, and ``q_chosen`` is the Q-value indexed by the
+        actually-taken action.
+
+        Args:
+            q_chosen: Tensor of shape ``(batch,)`` — Q evaluated at the
+                taken joint action, for agent i.
+            q_all: Tensor of shape ``(batch, action_dim_total)`` — Q
+                evaluated for every possible per-agent action of agent i
+                holding the other agents' actions fixed.
+            action_probs: Tensor of shape ``(batch, action_dim_total)`` —
+                agent i's policy probabilities over the joint per-agent
+                action space.
+
+        Returns:
+            Tensor of shape ``(batch,)`` — the COMA counterfactual
+            advantage A_i.
+
+        Note:
+            ``q_chosen`` must equal ``(q_all * one_hot(taken_action)).sum(-1)``
+            up to floating-point error. The function does not assume this —
+            it accepts both as inputs so the caller controls the indexing.
+        """
+        baseline = (action_probs * q_all).sum(dim=-1)
+        return q_chosen - baseline
+
+    def _coma_compute_td_targets(
+        self,
+        global_obs: torch.Tensor,
+        joint_action_packed: torch.Tensor,
+        rewards: torch.Tensor,
+        dones: torch.Tensor,
+    ) -> torch.Tensor:
+        """1-step TD targets for the COMA Q-critic.
+
+        Computes ``y_t = r_t + gamma * (1 - done_t) * Q_target(s_{t+1}, a_{t+1})_i``
+        for every (t, i) in the rollout, using the target network and the
+        next-step action from the same on-policy rollout (Foerster 2018
+        uses TD(lambda); we use 1-step TD here as the simplest unbiased
+        bootstrap — documented in the PR body and the issue spec).
+
+        Args:
+            global_obs: Tensor of shape ``(T, global_obs_dim)`` — the global
+                obs for each rollout step (already identity-tail stripped).
+            joint_action_packed: Long tensor ``(T, N)`` — packed joint
+                actions, one entry per (step, agent).
+            rewards: Tensor of shape ``(T, N)`` — per-agent rewards.
+            dones: Tensor of shape ``(T,)`` — shared episode-termination flag.
+
+        Returns:
+            Tensor of shape ``(T, N)`` — TD targets per (step, agent).
+        """
+        with torch.no_grad():
+            T = global_obs.shape[0]
+            joint_action_oh_all = self._coma_joint_action_one_hot(
+                joint_action_packed
+            )  # [T, N * action_dim_total]
+
+            # Q_target(s_{t+1}, a_{t+1}) — shift everything by 1 step.
+            # For the last step, we treat the bootstrap as 0 (consistent with
+            # the GAE path in ``compute_gae`` which sets next_value = 0 at
+            # the rollout boundary).
+            next_targets = global_obs.new_zeros((T, self.num_agents))
+            if T > 1:
+                next_global = global_obs[1:]  # [T-1, global_obs_dim]
+                next_joint_oh = joint_action_oh_all[1:]  # [T-1, N * adt]
+                next_actions_packed = joint_action_packed[1:]  # [T-1, N]
+                # For each agent, run the target Q with that agent's id one-hot.
+                # We use the per-step joint action one-hot as input — Foerster's
+                # Q takes the *full* joint action; the "joint_action_one_hot"
+                # field includes agent i's own slot for the on-policy taken action.
+                for i in range(self.num_agents):
+                    agent_id_oh = global_obs.new_zeros((T - 1, self.num_agents))
+                    agent_id_oh[:, i] = 1.0
+                    q_next = self.q_critic_target(
+                        next_global, next_joint_oh, agent_id_oh
+                    )  # [T-1, action_dim_total]
+                    q_next_taken = q_next.gather(
+                        1, next_actions_packed[:, i : i + 1]
+                    ).squeeze(-1)
+                    next_targets[:-1, i] = q_next_taken
+
+            done_mask = (1.0 - dones).unsqueeze(-1)  # [T, 1]
+            targets = rewards + self.gamma * done_mask * next_targets
+        return targets
+
+    def _coma_compute_advantages(
+        self,
+        global_obs: torch.Tensor,
+        joint_action_packed: torch.Tensor,
+        action_probs_per_agent: List[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute COMA counterfactual advantages from the live Q-critic.
+
+        For each agent i, evaluates the live Q at (s, a) (taken action) and
+        the policy-weighted baseline ``sum_u pi_i(u | s) Q(s, (a_{-i}, u))``
+        by enumerating over the per-agent action space.
+
+        Args:
+            global_obs: Tensor of shape ``(T, global_obs_dim)``.
+            joint_action_packed: Long tensor of shape ``(T, N)``.
+            action_probs_per_agent: List of N tensors, each shape
+                ``(T, action_dim_total)`` — per-step probability over the
+                joint per-agent action space at the *current* policy (i.e.
+                the rollout-time policy: detached, used only as the COMA
+                baseline weights).
+
+        Returns:
+            Tuple of ``(advantages, q_chosen)`` each shape ``(T, N)``.
+        """
+        with torch.no_grad():
+            T = global_obs.shape[0]
+            joint_action_oh_all = self._coma_joint_action_one_hot(joint_action_packed)
+            advantages = global_obs.new_zeros((T, self.num_agents))
+            q_chosen_all = global_obs.new_zeros((T, self.num_agents))
+            for i in range(self.num_agents):
+                agent_id_oh = global_obs.new_zeros((T, self.num_agents))
+                agent_id_oh[:, i] = 1.0
+                q_all = self.q_critic(
+                    global_obs, joint_action_oh_all, agent_id_oh
+                )  # [T, action_dim_total]
+                q_chosen = q_all.gather(
+                    1, joint_action_packed[:, i : i + 1]
+                ).squeeze(-1)
+                adv_i = self.coma_counterfactual_advantage(
+                    q_chosen=q_chosen,
+                    q_all=q_all,
+                    action_probs=action_probs_per_agent[i],
+                )
+                advantages[:, i] = adv_i
+                q_chosen_all[:, i] = q_chosen
+        return advantages, q_chosen_all
+
+    def _coma_policy_action_probs(
+        self, observations_per_agent: torch.Tensor
+    ) -> List[torch.Tensor]:
+        """Per-agent action probabilities over the joint per-agent action space.
+
+        For each agent i, computes ``pi_i(u | tau_i)`` for every
+        ``u in [0, action_dim_total)`` by taking the outer product of the
+        per-dimension categorical probabilities at the current actor weights.
+
+        Args:
+            observations_per_agent: Tensor of shape ``(T, N, obs_dim)``.
+
+        Returns:
+            List of N tensors, each shape ``(T, action_dim_total)``.
+        """
+        with torch.no_grad():
+            T = observations_per_agent.shape[0]
+            out: List[torch.Tensor] = []
+            for i, policy in enumerate(self.policies):
+                obs_i = observations_per_agent[:, i, :]
+                action_logits, _ = policy.forward(obs_i)
+                # Per-dim softmax probabilities.
+                probs_per_dim = [
+                    torch.softmax(logits, dim=-1) for logits in action_logits
+                ]
+                # Outer product across action dims → joint per-agent prob table.
+                # For action_dims = [10, 2, 2]: shape evolves as
+                #   [T, 10] -> [T, 10, 2] -> [T, 10, 2, 2] -> [T, 40].
+                joint = probs_per_dim[0]
+                for d in range(1, len(probs_per_dim)):
+                    joint = joint.unsqueeze(-1) * probs_per_dim[d].unsqueeze(-2)
+                    joint = joint.reshape(T, -1)
+                out.append(joint)
+        return out
+
     def update(self, rollout: RolloutBuffer) -> Dict[str, float]:
         """Run ``ppo_epochs`` PPO updates against the rollout.
 
@@ -585,6 +910,59 @@ class JointPPOTrainer:
             ).mean(dim=0)
             stats["critic_value_loss"] = 0.0
 
+        # Issue #284: COMA. Pre-compute the global obs trajectory, packed
+        # joint actions, TD targets, and counterfactual advantages once
+        # for the whole rollout. The PPO epochs then read these via index
+        # slicing (the live policy mutates between epochs so technically
+        # the on-policy baseline drifts — we use the rollout-time policy
+        # as Foerster does; the gap is what PPO's clip term protects).
+        if self.coma:
+            stats["coma_q_loss"] = 0.0
+            # Global obs trajectory: take agent 0's row, strip identity tail.
+            global_obs_T = rollout.observations[:, 0, : self._global_obs_dim]
+            # Pack joint actions for all agents: [T, N].
+            joint_action_packed_T = torch.stack(
+                [
+                    self._pack_joint_action(rollout.actions[i])
+                    for i in range(self.num_agents)
+                ],
+                dim=1,
+            )
+            # Per-agent rewards as [T, N].
+            rewards_TN = torch.stack(
+                [rollout.rewards[i] for i in range(self.num_agents)], dim=1
+            )
+            # 1-step TD targets for the Q-critic regression.
+            coma_td_targets = self._coma_compute_td_targets(
+                global_obs=global_obs_T,
+                joint_action_packed=joint_action_packed_T,
+                rewards=rewards_TN,
+                dones=rollout.dones,
+            )  # [T, N]
+            # Per-agent action probs over the joint per-agent action space
+            # at the rollout-time policy (used as the COMA baseline weights).
+            action_probs_per_agent = self._coma_policy_action_probs(
+                rollout.observations
+            )
+            # COMA counterfactual advantages from the live Q-critic.
+            coma_advantages, _q_chosen = self._coma_compute_advantages(
+                global_obs=global_obs_T,
+                joint_action_packed=joint_action_packed_T,
+                action_probs_per_agent=action_probs_per_agent,
+            )
+            # Override the per-agent advantages with the COMA counterfactuals
+            # (standardized per-agent to keep the policy gradient scale stable).
+            for i in range(self.num_agents):
+                adv_i = coma_advantages[:, i]
+                advantages[i] = (adv_i - adv_i.mean()) / (adv_i.std() + 1e-8)
+            # The COMA TD targets replace the GAE returns for the value loss.
+            # Stored per-agent so the critic-loss minibatch indexer can read it.
+            coma_targets_per_agent = {
+                i: coma_td_targets[:, i] for i in range(self.num_agents)
+            }
+            # One-hot joint action tensor, cached for the Q-critic forwards.
+            joint_action_oh_T = self._coma_joint_action_one_hot(joint_action_packed_T)
+
         for _epoch in range(self.ppo_epochs):
             idx = torch.randperm(t_total, device=self.device)[:mb_size]
             # Issue #204: ``rollout.observations`` is now ``[T, N, obs_dim]``.
@@ -627,10 +1005,11 @@ class JointPPOTrainer:
                 )
                 policy_loss = -torch.min(surr1, surr2).mean()
 
-                if self.centralized_critic:
+                if self.centralized_critic or self.coma:
                     # Per-agent value head is bypassed; the centralized
-                    # critic handles all value learning below. Record
-                    # value_loss=0 to keep the stats schema consistent.
+                    # critic (MAPPO) or Q-critic (COMA) handles all value
+                    # learning below. Record value_loss=0 to keep the
+                    # stats schema consistent.
                     value_loss = policy_loss.new_tensor(0.0)
                     agent_loss = policy_loss - self.entropy_coef * entropy
                 else:
@@ -665,6 +1044,28 @@ class JointPPOTrainer:
                     torch.stack(per_agent_losses).sum()
                     + self.value_coef * critic_value_loss
                 )
+            elif self.coma:
+                # Issue #284: Q-critic loss against 1-step TD targets. One
+                # Q forward per agent on the minibatch's global obs +
+                # joint-action one-hot. The targets are detached
+                # (computed from the target network outside the graph).
+                global_obs_mb = global_obs_T[idx]  # [mb, global_obs_dim]
+                joint_oh_mb = joint_action_oh_T[idx]  # [mb, N * action_dim_total]
+                q_losses: List[torch.Tensor] = []
+                for i in range(self.num_agents):
+                    agent_id_oh = global_obs_mb.new_zeros((mb_size, self.num_agents))
+                    agent_id_oh[:, i] = 1.0
+                    q_all = self.q_critic(global_obs_mb, joint_oh_mb, agent_id_oh)
+                    actions_packed_i = joint_action_packed_T[idx, i].unsqueeze(-1)
+                    q_chosen = q_all.gather(1, actions_packed_i).squeeze(-1)
+                    target_i = coma_targets_per_agent[i][idx]
+                    q_losses.append(F.mse_loss(q_chosen, target_i))
+                coma_q_loss = torch.stack(q_losses).mean()
+                stats["coma_q_loss"] += coma_q_loss.item() / self.ppo_epochs
+                total_loss = (
+                    torch.stack(per_agent_losses).sum()
+                    + self.value_coef * coma_q_loss
+                )
             else:
                 total_loss = (
                     torch.stack(per_agent_losses).sum() + self.redundancy_coef * red_pen
@@ -675,15 +1076,28 @@ class JointPPOTrainer:
                 opt.zero_grad()
             if self.centralized_critic:
                 self.critic_optimizer.zero_grad()
+            if self.coma:
+                self.q_critic_optimizer.zero_grad()
             total_loss.backward()
             for policy in self.policies:
                 nn.utils.clip_grad_norm_(policy.parameters(), self.max_grad_norm)
             if self.centralized_critic:
                 nn.utils.clip_grad_norm_(self.critic.parameters(), self.max_grad_norm)
+            if self.coma:
+                nn.utils.clip_grad_norm_(self.q_critic.parameters(), self.max_grad_norm)
             for opt in self.optimizers:
                 opt.step()
             if self.centralized_critic:
                 self.critic_optimizer.step()
+            if self.coma:
+                self.q_critic_optimizer.step()
+                # Hard-copy target network on the configured cadence.
+                self._coma_update_step += 1
+                if (
+                    self.coma_target_update_every > 0
+                    and self._coma_update_step % self.coma_target_update_every == 0
+                ):
+                    self.q_critic_target.load_state_dict(self.q_critic.state_dict())
 
         return stats
 

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -806,9 +806,9 @@ class JointPPOTrainer:
                 q_all = self.q_critic(
                     global_obs, joint_action_oh_all, agent_id_oh
                 )  # [T, action_dim_total]
-                q_chosen = q_all.gather(
-                    1, joint_action_packed[:, i : i + 1]
-                ).squeeze(-1)
+                q_chosen = q_all.gather(1, joint_action_packed[:, i : i + 1]).squeeze(
+                    -1
+                )
                 adv_i = self.coma_counterfactual_advantage(
                     q_chosen=q_chosen,
                     q_all=q_all,
@@ -1063,8 +1063,7 @@ class JointPPOTrainer:
                 coma_q_loss = torch.stack(q_losses).mean()
                 stats["coma_q_loss"] += coma_q_loss.item() / self.ppo_epochs
                 total_loss = (
-                    torch.stack(per_agent_losses).sum()
-                    + self.value_coef * coma_q_loss
+                    torch.stack(per_agent_losses).sum() + self.value_coef * coma_q_loss
                 )
             else:
                 total_loss = (

--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -266,6 +266,112 @@ class CentralizedCritic(nn.Module):
         return self.value_head(self.shared(x))
 
 
+class CentralizedQCritic(nn.Module):
+    """Centralized action-value Q-critic for COMA (issue #284).
+
+    A separate Q-network used by :class:`JointPPOTrainer` when ``coma=True``.
+    Distinct from :class:`CentralizedCritic` (which is a V-function): COMA
+    needs ``Q(s, a)`` so the counterfactual baseline
+
+    ::
+
+        A_i(s, a) = Q(s, a)_i - sum_u  pi_i(u | s) * Q(s, (a_{-i}, u))_i
+
+    can be evaluated by enumerating over agent i's per-agent action space.
+
+    Architecture (mirrors :class:`CentralizedCritic` capacity):
+
+    - **Input**: concatenation of
+        - ``global_obs`` of length ``global_obs_dim`` (the per-agent obs
+          with the identity one-hot tail stripped — same convention as
+          ``CentralizedCritic``),
+        - ``joint_action_one_hot`` of length ``N * action_dim_total`` where
+          ``action_dim_total = prod(action_dims)`` is the joint-per-agent
+          action dim (recommended in the COMA spec: enumerate over the
+          ``[10, 2, 2]`` = 40 joint actions),
+        - ``agent_id_one_hot`` of length ``N``.
+    - **Trunk**: 2-layer MLP with ReLU, hidden size ``hidden_size``.
+    - **Output**: vector of length ``action_dim_total`` — the action-value
+      head returns Q for every possible per-agent action holding the other
+      agents' actions fixed. This lets the COMA baseline be evaluated by
+      a single forward pass per agent.
+
+    The "joint-per-agent" action representation collapses the multi-discrete
+    factorization ``[10, 2, 2]`` to a flat 40-way one-hot. This is option 2
+    from the curator's spec — exact (no factorization bias) and tractable
+    (40 entries × 4 agents × T steps is well within budget).
+
+    Args:
+        global_obs_dim: Dimension of the global observation (identity tail
+            stripped).
+        num_agents: Number of agents N.
+        action_dim_total: Joint per-agent action dim (e.g. ``prod([10,2,2]) = 40``).
+        hidden_size: Hidden layer size (default 64, matching the actor trunk).
+
+    Example:
+        >>> critic = CentralizedQCritic(
+        ...     global_obs_dim=42, num_agents=4, action_dim_total=40
+        ... )
+        >>> global_obs = torch.randn(8, 42)
+        >>> joint_action_oh = torch.zeros(8, 4 * 40)  # N=4 one-hot actions
+        >>> agent_id_oh = torch.zeros(8, 4); agent_id_oh[:, 0] = 1.0
+        >>> q = critic(global_obs, joint_action_oh, agent_id_oh)
+        >>> q.shape
+        torch.Size([8, 40])
+    """
+
+    def __init__(
+        self,
+        global_obs_dim: int,
+        num_agents: int,
+        action_dim_total: int,
+        hidden_size: int = 64,
+    ) -> None:
+        super().__init__()
+        self.global_obs_dim = global_obs_dim
+        self.num_agents = num_agents
+        self.action_dim_total = action_dim_total
+        self.hidden_size = hidden_size
+
+        input_dim = global_obs_dim + num_agents * action_dim_total + num_agents
+        self.shared = nn.Sequential(
+            nn.Linear(input_dim, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+        )
+        self.q_head = nn.Linear(hidden_size, action_dim_total)
+
+    def forward(
+        self,
+        global_obs: torch.Tensor,
+        joint_action_one_hot: torch.Tensor,
+        agent_id_one_hot: torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            global_obs: ``(batch, global_obs_dim)`` — the global state input.
+            joint_action_one_hot: ``(batch, N * action_dim_total)`` — flat
+                one-hot encoding of the joint per-agent action. The slot
+                belonging to ``agent_id_one_hot`` is conventionally zeroed
+                by the caller (it does not matter for COMA because the
+                baseline averages over agent i's possible actions; the
+                gradient through it would be invalid since Q must not be
+                conditioned on the action we are evaluating against).
+            agent_id_one_hot: ``(batch, N)`` — one-hot agent identity. Lets
+                a single Q-network share parameters across agents while
+                still routing per-agent computation.
+
+        Returns:
+            ``(batch, action_dim_total)`` — vector of Q-values, one per
+            possible per-agent action for the indicated agent given the
+            other agents' actions.
+        """
+        x = torch.cat([global_obs, joint_action_one_hot, agent_id_one_hot], dim=-1)
+        return self.q_head(self.shared(x))
+
+
 def compute_gae(
     rewards: List[float],
     values: List[float],

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -79,6 +79,13 @@ class CellConfig:
     # the Phase 2 sweep. Incompatible with lambda_red > 0 (the redundancy
     # penalty couples the per-agent actor trunks).
     centralized_critic: bool = False
+    # Issue #284: COMA / counterfactual-advantage flag. Default False
+    # preserves the IPPO baseline. Mutually exclusive with both
+    # centralized_critic and lambda_red > 0. Installs a CentralizedQCritic
+    # whose enumerated per-agent Q-values feed the COMA counterfactual
+    # advantage instead of GAE-on-V. See JointPPOTrainer docstring.
+    coma: bool = False
+    coma_target_update_every: int = 200
     # Encoder outputs are quantized for plug-in MI. We first project from
     # ``hidden_size`` down to ``mi_proj_dims`` via a fixed random matrix
     # (seeded from ``seed``); then ``quantize_uniform`` packs each row into
@@ -652,6 +659,8 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         redundancy_coef=cfg.lambda_red,
         normalize_returns=cfg.normalize_returns,
         centralized_critic=cfg.centralized_critic,
+        coma=cfg.coma,
+        coma_target_update_every=cfg.coma_target_update_every,
         device=cfg.device,
         seed=cfg.seed,
     )
@@ -813,6 +822,30 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--use-coma",
+        dest="coma",
+        action="store_true",
+        help=(
+            "Issue #284: enable COMA (counterfactual multi-agent policy "
+            "gradient). Installs a CentralizedQCritic and replaces the "
+            "advantage with A_i = Q(s, a) - sum_u pi_i(u | s) Q(s, "
+            "(a_{-i}, u)), enumerated over the joint per-agent action "
+            "space (prod(action_dims) = 40 for [10, 2, 2]). Default off "
+            "preserves IPPO. Mutually exclusive with --centralized-critic "
+            "and --lambda-red > 0."
+        ),
+    )
+    p.add_argument(
+        "--coma-target-update-every",
+        type=int,
+        default=CellConfig.__dataclass_fields__["coma_target_update_every"].default,
+        help=(
+            "Issue #284: hard-copy cadence for the COMA target Q-network "
+            "(in PPO update steps). Default 200 matches Foerster 2018. "
+            "Set to 0 to disable target-network updates entirely."
+        ),
+    )
+    p.add_argument(
         "--curriculum",
         type=_parse_curriculum_arg,
         default=[],
@@ -875,6 +908,8 @@ def main() -> None:
         entropy_coef=args.entropy_coef,
         normalize_returns=args.normalize_returns,
         centralized_critic=args.centralized_critic,
+        coma=args.coma,
+        coma_target_update_every=args.coma_target_update_every,
         curriculum=args.curriculum,
         action_shaping_alpha=args.action_shaping_alpha,
         action_shaping_beta=args.action_shaping_beta,

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -16,7 +16,7 @@ from bucket_brigade.training.joint_trainer import (
     JointPPOTrainer,
     flatten_dict_obs,
 )
-from bucket_brigade.training.networks import CentralizedCritic
+from bucket_brigade.training.networks import CentralizedCritic, CentralizedQCritic
 
 
 NUM_AGENTS = 4
@@ -32,6 +32,8 @@ def _make_trainer(
     redundancy_coef: float = 0.0,
     hidden_size: int = 16,
     centralized_critic: bool = False,
+    coma: bool = False,
+    coma_target_update_every: int = 200,
 ) -> JointPPOTrainer:
     env = _env_fn()
     obs = env.reset(seed=0)
@@ -47,6 +49,8 @@ def _make_trainer(
         ppo_epochs=2,
         redundancy_coef=redundancy_coef,
         centralized_critic=centralized_critic,
+        coma=coma,
+        coma_target_update_every=coma_target_update_every,
         seed=0,
     )
 
@@ -470,3 +474,310 @@ class TestCentralizedCritic:
         stats = trainer.update(rollout)
         assert np.isfinite(stats["total_loss"])
         assert np.isfinite(stats["critic_value_loss"])
+
+
+class TestCOMA:
+    """Issue #284: COMA counterfactual multi-agent policy gradient.
+
+    The COMA path installs a :class:`CentralizedQCritic` whose per-agent
+    Q-vector feeds a counterfactual advantage
+
+    ::
+
+        A_i = Q(s, a)_i - sum_u  pi_i(u | s) * Q(s, (a_{-i}, u))_i
+
+    enumerated over the joint per-agent action space (``prod(action_dims) =
+    40`` for ``[10, 2, 2]``). The Q-critic is trained against 1-step TD
+    targets with a hard-copy target network.
+    """
+
+    def test_centralized_q_critic_forward_shape(self):
+        """``CentralizedQCritic`` accepts (global_obs, joint_action_oh,
+        agent_id_oh) and returns ``(batch, action_dim_total)``."""
+        critic = CentralizedQCritic(
+            global_obs_dim=42,
+            num_agents=NUM_AGENTS,
+            action_dim_total=40,
+            hidden_size=16,
+        )
+        x = torch.randn(8, 42)
+        joint_oh = torch.zeros(8, NUM_AGENTS * 40)
+        agent_id_oh = torch.zeros(8, NUM_AGENTS)
+        agent_id_oh[:, 0] = 1.0
+        q = critic(x, joint_oh, agent_id_oh)
+        assert q.shape == (8, 40)
+
+    def test_counterfactual_baseline_collapses_when_q_independent_of_action(
+        self,
+    ):
+        """If Q is constant in agent i's action (i.e. q_all is the same
+        value across all actions), the COMA baseline equals q_chosen, so
+        the advantage is exactly zero. This is the load-bearing structural
+        check that the baseline implements the counterfactual identity."""
+        batch = 16
+        action_dim_total = 40
+        # q_all constant across actions: every column = 7.5.
+        q_all = torch.full((batch, action_dim_total), 7.5)
+        q_chosen = torch.full((batch,), 7.5)
+        # Arbitrary probability distribution (must sum to 1 per row).
+        action_probs = torch.softmax(torch.randn(batch, action_dim_total), dim=-1)
+        adv = JointPPOTrainer.coma_counterfactual_advantage(
+            q_chosen=q_chosen,
+            q_all=q_all,
+            action_probs=action_probs,
+        )
+        assert torch.allclose(adv, torch.zeros_like(adv), atol=1e-6), (
+            f"COMA baseline failed to collapse when Q is action-independent; "
+            f"max |adv| = {adv.abs().max().item()}"
+        )
+
+    def test_counterfactual_baseline_matches_hand_computed_reference(self):
+        """Hand-computed reference on a tiny 2-action, 1-batch example.
+
+        Setup: action_dim_total=2, batch=1.
+        Q-values: q_all = [3.0, 5.0], q_chosen = 3.0 (action 0 taken).
+        Policy: pi = [0.25, 0.75].
+
+        Baseline: 0.25*3.0 + 0.75*5.0 = 0.75 + 3.75 = 4.5.
+        Advantage: 3.0 - 4.5 = -1.5.
+        """
+        q_all = torch.tensor([[3.0, 5.0]])
+        q_chosen = torch.tensor([3.0])
+        action_probs = torch.tensor([[0.25, 0.75]])
+        adv = JointPPOTrainer.coma_counterfactual_advantage(
+            q_chosen=q_chosen,
+            q_all=q_all,
+            action_probs=action_probs,
+        )
+        assert torch.allclose(adv, torch.tensor([-1.5]), atol=1e-6), (
+            f"Expected adv = -1.5, got {adv.item()}"
+        )
+
+    def test_init_q_critic_attributes(self):
+        """Trainer with ``coma=True`` exposes a q_critic, q_critic_target,
+        and q_critic_optimizer; default flag leaves them ``None``."""
+        trainer_off = _make_trainer(coma=False)
+        assert trainer_off.coma is False
+        assert trainer_off.q_critic is None
+        assert trainer_off.q_critic_target is None
+        assert trainer_off.q_critic_optimizer is None
+
+        trainer_on = _make_trainer(coma=True)
+        assert trainer_on.coma is True
+        assert isinstance(trainer_on.q_critic, CentralizedQCritic)
+        assert isinstance(trainer_on.q_critic_target, CentralizedQCritic)
+        # action_dim_total = prod([10, 2, 2]) = 40.
+        assert trainer_on.action_dim_total == 40
+        assert trainer_on.q_critic.global_obs_dim == trainer_on.obs_dim - NUM_AGENTS
+        assert trainer_on.q_critic_optimizer is not None
+
+    def test_coma_incompatible_with_centralized_critic(self):
+        """COMA and MAPPO are separate experiments — combining them
+        should raise."""
+        with pytest.raises(ValueError, match="coma"):
+            _make_trainer(coma=True, centralized_critic=True)
+
+    def test_coma_incompatible_with_redundancy_coef(self):
+        """COMA and the redundancy penalty couple unrelated experiments
+        — combining them should raise."""
+        with pytest.raises(ValueError, match="coma"):
+            _make_trainer(coma=True, redundancy_coef=0.1)
+
+    def test_default_flag_no_q_critic_constructed(self):
+        """Regression guard: with ``coma=False`` (default), no Q-critic
+        module or optimizer is constructed, and the new ``coma_q_loss``
+        stat is **not** present in the update output. This pins the
+        default code path to the pre-#284 IPPO contract.
+        """
+        trainer = _make_trainer(coma=False)
+        assert trainer.q_critic is None
+        assert trainer.q_critic_target is None
+        assert trainer.q_critic_optimizer is None
+
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        assert "coma_q_loss" not in stats
+
+    def test_use_coma_false_bit_identity_with_pre_change_path(self):
+        """Two trainers constructed with the same seed and ``coma=False``
+        produce identical initial weights (the canonical IPPO determinism
+        check)."""
+        trainer_a = _make_trainer(coma=False)
+        trainer_b = _make_trainer(coma=False)
+        for pa, pb in zip(trainer_a.policies, trainer_b.policies):
+            for ka, va in pa.state_dict().items():
+                assert torch.equal(va, pb.state_dict()[ka]), (
+                    f"initial weights differ at {ka} — coma=False seeding broken"
+                )
+
+    def test_pack_joint_action_roundtrip(self):
+        """``_pack_joint_action`` packs ``[10, 2, 2]`` into a flat code in
+        ``[0, 40)`` via row-major flattening."""
+        trainer = _make_trainer(coma=True)
+        # action_dims = [10, 2, 2]. Strides = [4, 2, 1].
+        # Action (3, 1, 0) → 3*4 + 1*2 + 0 = 14.
+        a = torch.tensor([[3, 1, 0], [0, 0, 0], [9, 1, 1]], dtype=torch.long)
+        packed = trainer._pack_joint_action(a)
+        assert packed.tolist() == [14, 0, 39]
+        # Bounds.
+        assert packed.min().item() >= 0
+        assert packed.max().item() < 40
+
+    def test_update_runs_without_nan_under_coma(self):
+        """End-to-end smoke: rollout + update completes with finite stats
+        and the new ``coma_q_loss`` key is present."""
+        trainer = _make_trainer(coma=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        for k, v in stats.items():
+            assert np.isfinite(v), f"non-finite stat {k}={v}"
+        assert "coma_q_loss" in stats
+        # Per-agent value_loss stats are recorded as 0.0 (the per-agent
+        # value heads are bypassed under COMA, exactly as under MAPPO).
+        for i in range(NUM_AGENTS):
+            assert stats[f"value_loss/agent_{i}"] == 0.0
+
+    def test_q_critic_receives_gradient_after_update(self):
+        """After one update, the live Q-critic's first linear layer must
+        have non-zero gradient (the TD regression actually drives the
+        Q-network)."""
+        trainer = _make_trainer(coma=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        trainer.update(rollout)
+        first_linear = trainer.q_critic.shared[0]
+        assert first_linear.weight.grad is not None, "q_critic: no grad"
+        assert first_linear.weight.grad.abs().sum().item() > 0.0, (
+            "q_critic: zero gradient after update"
+        )
+
+    def test_actors_still_receive_gradient_under_coma(self):
+        """After one update, every per-agent policy's first linear layer
+        must have non-zero gradient (COMA's counterfactual advantage
+        still drives the actors even without a per-agent value head)."""
+        trainer = _make_trainer(coma=True)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        trainer.update(rollout)
+        for i, policy in enumerate(trainer.policies):
+            first_linear = policy.shared[0]
+            assert first_linear.weight.grad is not None, f"agent {i}: no grad"
+            assert first_linear.weight.grad.abs().sum().item() > 0.0, (
+                f"agent {i}: zero gradient under COMA"
+            )
+
+    def test_q_target_network_does_not_receive_gradient(self):
+        """The target Q-network is a slow snapshot; its parameters must
+        not have ``requires_grad`` set, so they are never optimized."""
+        trainer = _make_trainer(coma=True)
+        for p in trainer.q_critic_target.parameters():
+            assert not p.requires_grad, "target Q-network parameters must be frozen"
+
+    def test_target_network_hard_copies_on_cadence(self):
+        """When the configured cadence is hit, the target network's
+        weights match the live Q-critic exactly."""
+        # Tiny cadence so we trigger the hard copy on the very first
+        # update step (ppo_epochs=2 ⇒ first step is index 1).
+        trainer = _make_trainer(coma=True, coma_target_update_every=1)
+        # Perturb the live Q-critic so the comparison after one update
+        # is non-trivial.
+        with torch.no_grad():
+            trainer.q_critic.shared[0].weight.add_(0.5)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        trainer.update(rollout)
+        for k, v in trainer.q_critic.state_dict().items():
+            assert torch.allclose(v, trainer.q_critic_target.state_dict()[k]), (
+                f"target Q-network out of sync at param {k} after hard-copy"
+            )
+
+    def test_td_target_one_step_sanity_in_scripted_setting(self):
+        """1-step TD target sanity. Construct a rollout where the next-step
+        Q is known (target network is the same as the live Q at init), and
+        verify the TD target matches the closed-form
+        ``r_t + gamma * (1 - done_t) * Q_target(s_{t+1}, a_{t+1})``.
+        """
+        trainer = _make_trainer(coma=True)
+        # Fresh trainer: target == live (we just copied state_dict in __init__).
+        T = 4
+        global_obs = torch.randn(T, trainer._global_obs_dim)
+        # Joint actions all zero (deterministic and easy to gather).
+        joint_action_packed = torch.zeros((T, NUM_AGENTS), dtype=torch.long)
+        rewards = torch.tensor(
+            [[1.0] * NUM_AGENTS,
+             [2.0] * NUM_AGENTS,
+             [3.0] * NUM_AGENTS,
+             [4.0] * NUM_AGENTS],
+        )
+        dones = torch.tensor([0.0, 0.0, 1.0, 0.0])  # episode ends at t=2
+
+        targets = trainer._coma_compute_td_targets(
+            global_obs=global_obs,
+            joint_action_packed=joint_action_packed,
+            rewards=rewards,
+            dones=dones,
+        )
+
+        # Hand-compute expected next_targets (zero at t=T-1).
+        joint_oh = trainer._coma_joint_action_one_hot(joint_action_packed)
+        expected_next = torch.zeros((T, NUM_AGENTS))
+        with torch.no_grad():
+            for i in range(NUM_AGENTS):
+                for t in range(T - 1):
+                    aid = global_obs.new_zeros((1, NUM_AGENTS))
+                    aid[0, i] = 1.0
+                    q_next = trainer.q_critic_target(
+                        global_obs[t + 1 : t + 2],
+                        joint_oh[t + 1 : t + 2],
+                        aid,
+                    )
+                    expected_next[t, i] = q_next[0, joint_action_packed[t + 1, i]]
+
+        done_mask = (1.0 - dones).unsqueeze(-1)
+        expected = rewards + trainer.gamma * done_mask * expected_next
+        assert torch.allclose(targets, expected, atol=1e-5), (
+            "1-step TD target mismatch vs closed-form reference"
+        )
+
+    def test_zero_advantage_when_policy_is_uniform_and_q_is_constant_per_action(
+        self,
+    ):
+        """End-to-end COMA-advantage check: in a state where Q is the same
+        for every action of agent i, the counterfactual baseline equals
+        Q(s, a)_i exactly, so A_i = 0 regardless of pi_i. This is the
+        spec's third test (see issue body)."""
+        trainer = _make_trainer(coma=True)
+        # Manually set the Q-critic's final head weights to zero (so all
+        # logits = bias, which is shared across all 40 actions).
+        with torch.no_grad():
+            trainer.q_critic.q_head.weight.zero_()
+            # Bias is a per-action scalar; setting all entries to the same
+            # constant keeps Q(s, ·) constant across actions for any (s, a).
+            trainer.q_critic.q_head.bias.fill_(2.0)
+        T = 8
+        global_obs = torch.randn(T, trainer._global_obs_dim)
+        joint_action_packed = torch.zeros((T, NUM_AGENTS), dtype=torch.long)
+        action_probs_per_agent = [
+            torch.softmax(torch.randn(T, trainer.action_dim_total), dim=-1)
+            for _ in range(NUM_AGENTS)
+        ]
+        advantages, _ = trainer._coma_compute_advantages(
+            global_obs=global_obs,
+            joint_action_packed=joint_action_packed,
+            action_probs_per_agent=action_probs_per_agent,
+        )
+        assert torch.allclose(advantages, torch.zeros_like(advantages), atol=1e-6), (
+            f"advantage failed to collapse to 0 when Q is action-independent; "
+            f"max |adv| = {advantages.abs().max().item()}"
+        )
+
+    def test_reproducibility_two_runs_same_seed(self):
+        """Two trainers seeded identically produce bit-identical Q-critic
+        weights at init, including the target network."""
+        a = _make_trainer(coma=True)
+        b = _make_trainer(coma=True)
+        for ka, va in a.q_critic.state_dict().items():
+            assert torch.equal(va, b.q_critic.state_dict()[ka]), (
+                f"q_critic init differs at {ka} — COMA seeding broken"
+            )
+        for ka, va in a.q_critic_target.state_dict().items():
+            assert torch.equal(va, b.q_critic_target.state_dict()[ka]), (
+                f"q_critic_target init differs at {ka} — COMA seeding broken"
+            )

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -701,10 +701,12 @@ class TestCOMA:
         # Joint actions all zero (deterministic and easy to gather).
         joint_action_packed = torch.zeros((T, NUM_AGENTS), dtype=torch.long)
         rewards = torch.tensor(
-            [[1.0] * NUM_AGENTS,
-             [2.0] * NUM_AGENTS,
-             [3.0] * NUM_AGENTS,
-             [4.0] * NUM_AGENTS],
+            [
+                [1.0] * NUM_AGENTS,
+                [2.0] * NUM_AGENTS,
+                [3.0] * NUM_AGENTS,
+                [4.0] * NUM_AGENTS,
+            ],
         )
         dones = torch.tensor([0.0, 0.0, 1.0, 0.0])  # episode ends at t=2
 


### PR DESCRIPTION
## Summary

Adds COMA (Foerster et al. 2018) as a third critic option alongside IPPO and MAPPO. Installs a `CentralizedQCritic` that enumerates Q over the joint per-agent action space (`prod([10, 2, 2]) = 40`) and uses the counterfactual

```
A_i = Q(s, a) - sum_u  pi_i(u | s) * Q(s, (a_{-i}, u))
```

in place of the GAE-on-V advantage. Q is trained against 1-step TD targets with a slow target network.

**NB**: de-prioritized in the author's #271 comment after the "gradient locality, not direction" pivot. Building for completeness on the algorithm-side credit-assignment cluster (#287 LOLA, #289 HCA).

## Changes

- `bucket_brigade/training/networks.py`: new `CentralizedQCritic` (distinct from the existing V-function `CentralizedCritic`). Takes `(global_obs, joint_action_one_hot, agent_id_one_hot)` and returns a per-agent action-value vector of length `action_dim_total = 40`.
- `bucket_brigade/training/joint_trainer.py`:
  - `coma` and `coma_target_update_every` constructor flags.
  - Mutual exclusion with `centralized_critic=True` and `redundancy_coef > 0` (both raise `ValueError`).
  - `_act_all` zeroes per-agent values under COMA (rollout schema preserved; values are unused at update time).
  - New `_pack_joint_action`, `_coma_joint_action_one_hot`, `_coma_policy_action_probs`, `_coma_compute_td_targets`, `_coma_compute_advantages`, and `coma_counterfactual_advantage` helpers.
  - `update()` branches on `self.coma`: replaces per-agent advantages with the counterfactuals, computes Q-critic MSE against TD targets, hard-copies the target network on cadence.
- `experiments/p3_specialization/train.py`: `--use-coma` and `--coma-target-update-every` CLI flags wired through `CellConfig` and `train_one_cell`.
- `tests/test_joint_trainer.py`: 17 new tests in `TestCOMA`.

## Design choices (per curator spec)

- **Joint-enumerate baseline (option 2)**: 40 entries x N agents x T steps is well within budget. Exact (no factorisation bias).
- **PPO-clip actor**: Foerster used vanilla PG; we keep the existing PPO-clip wrapper (matches MAPPO arm for apples-to-apples comparison).
- **1-step TD target**: simplest unbiased bootstrap; lambda-returns can be a follow-up if the Q-critic is variance-bound.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `CentralizedQCritic` for `[10, 2, 2]` (joint-enumerate, 40 entries) | done | `test_centralized_q_critic_forward_shape`; `action_dim_total == 40` |
| COMA counterfactual advantage formula | done | `test_counterfactual_baseline_matches_hand_computed_reference` (-1.5 expected) |
| Q-critic targets (1-step TD sanity) | done | `test_td_target_one_step_sanity_in_scripted_setting` |
| Counterfactual collapses to 0 when Q is action-independent | done | `test_zero_advantage_when_policy_is_uniform_and_q_is_constant_per_action` |
| `use_coma=False` bit-identity | done | `test_use_coma_false_bit_identity_with_pre_change_path` (and the 26 pre-existing tests still pass unchanged) |
| Reproducibility | done | `test_reproducibility_two_runs_same_seed` |
| Mutual exclusion with MAPPO + redundancy | done | two `ValueError` tests; verified at CLI |
| Local 1-2 iter smoke at tiny config | done | 2 iters on `minimal_specialization`, seed=0, rollout=256: ran to completion, `coma_q_loss` decreased 4063 -> 3364 |

## Test Plan

- [x] Full `tests/test_joint_trainer.py`: 43 passed (26 pre-existing + 17 new) in ~4s.
- [x] Local smoke: `uv run python experiments/p3_specialization/train.py --scenario minimal_specialization --lambda-red 0.0 --seed 0 --num-iterations 2 --rollout-steps 256 --use-coma --output-dir /tmp/coma_smoke` — completed without NaN; `coma_q_loss` recorded in metrics.json.
- [ ] (Not run locally per scope) Full 50-iter x 3-seed x 2-scenario sweep on `COMPUTE_HOST_PRIMARY`. Verdict ladder per PR #232 pre-reg.

Closes #284.