### PR TITLE
exp(p3): PBT orchestrator + smoke test (issue #288)

### DIFF
--- a/experiments/p3_specialization/analyze_288.py
+++ b/experiments/p3_specialization/analyze_288.py
@@ -1,0 +1,207 @@
+"""Analysis for issue #288 — PBT basin-escape verdict.
+
+Mirrors ``analyze_270.py`` structure. Reads each PBT seed's ``gen_<G>/lineage_<L>/
+metrics.json``, computes the best-of-population trailing-5 gap_closed at the
+final generation per seed, averages across seeds, and applies the curator's
+success-criterion table:
+
+| best-of-pop trailing-5 gap_closed (mean over PBT seeds) | Verdict                    |
+|---|---|
+| ≥ 0.7  | ``population_escape`` (cooperative basin reachable via diversity) |
+| 0.2 – 0.7 | ``partial`` (population biases toward basin but doesn't fully land) |
+| < 0.2 | ``basin_globally_unreachable`` (re-elevate gradient-direction interventions) |
+
+Baselines (random / specialist team reward per step) are imported from
+``analyze_270`` so the gap_closed conversion is bit-identical with the #270
+verdict pipeline. The analyzer also exposes a pure
+``classify_verdict(best_of_pop_gap_closed)`` function so it can be unit-tested
+without a real PBT run on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# Reuse the gap_closed conversion and trailing-N from analyze_270 so the #288
+# verdict is directly comparable to #270/#271 outcomes (same scenario, same
+# reference baselines). Keeping these constants here as fallbacks lets the
+# analyzer be invoked standalone if analyze_270 is ever refactored.
+try:
+    from experiments.p3_specialization.analyze_270 import (
+        MINSPEC_RANDOM,
+        MINSPEC_SPECIALIST,
+        TRAILING_N,
+        gap_closed,
+    )
+except ImportError:  # pragma: no cover
+    MINSPEC_RANDOM = -96.07
+    MINSPEC_SPECIALIST = -22.07
+    TRAILING_N = 5
+
+    def gap_closed(per_step_team: float) -> float:
+        return (per_step_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+# Verdict thresholds from the curator's success-criterion table. Adjusting
+# these is a research-policy decision; do not touch without updating the
+# issue body.
+VERDICT_ESCAPE_THRESHOLD = 0.7
+VERDICT_PARTIAL_THRESHOLD = 0.2
+
+
+def classify_verdict(best_of_pop_gap_closed: float) -> Tuple[str, str]:
+    """Pure function: map a best-of-pop trailing-5 gap_closed to a verdict tier.
+
+    Public for unit testing.
+    """
+    if best_of_pop_gap_closed >= VERDICT_ESCAPE_THRESHOLD:
+        return "population_escape", (
+            f"best-of-pop trailing-5 gap_closed = {best_of_pop_gap_closed:.3f} "
+            f">= {VERDICT_ESCAPE_THRESHOLD}. Cooperative basin reachable via "
+            "population diversity. Phase-2 success — PBT escapes the random-"
+            "init basin trap confirmed by #270/#271."
+        )
+    if best_of_pop_gap_closed >= VERDICT_PARTIAL_THRESHOLD:
+        return "partial", (
+            f"best-of-pop trailing-5 gap_closed = {best_of_pop_gap_closed:.3f} "
+            f"sits in [{VERDICT_PARTIAL_THRESHOLD}, {VERDICT_ESCAPE_THRESHOLD}). "
+            "Population biases toward the cooperative basin but doesn't fully "
+            "land. Consider larger population, more generations, or stronger "
+            "mutation."
+        )
+    return "basin_globally_unreachable", (
+        f"best-of-pop trailing-5 gap_closed = {best_of_pop_gap_closed:.3f} "
+        f"< {VERDICT_PARTIAL_THRESHOLD}. Cooperative basin unreachable from "
+        "random init under local-search-with-diversity. Re-elevate gradient-"
+        "direction interventions (#284 COMA, #287 LOLA, #283 potential "
+        "shaping)."
+    )
+
+
+def _trailing5_team(metrics_path: Path) -> Optional[float]:
+    if not metrics_path.exists():
+        return None
+    rows = json.loads(metrics_path.read_text())
+    if not rows:
+        return None
+    tail = rows[-TRAILING_N:]
+    return float(sum(r["mean_step_reward_team"] for r in tail) / max(1, len(tail)))
+
+
+def aggregate_seed(seed_dir: Path) -> Dict:
+    """For one PBT seed, find the final generation and report best-of-pop."""
+    gen_dirs = sorted(
+        [d for d in seed_dir.glob("gen_*") if d.is_dir()],
+        key=lambda d: int(d.name.split("_")[1]),
+    )
+    if not gen_dirs:
+        return {"seed_dir": str(seed_dir), "n_generations": 0, "missing": True}
+
+    final_gen = gen_dirs[-1]
+    lineage_scores: List[Dict] = []
+    for cell in sorted(final_gen.glob("lineage_*")):
+        score = _trailing5_team(cell / "metrics.json")
+        lineage_scores.append(
+            {
+                "lineage_id": int(cell.name.split("_")[1]),
+                "trailing5_team_reward": score,
+                "trailing5_gap_closed": gap_closed(score)
+                if score is not None
+                else None,
+            }
+        )
+
+    valid = [
+        s["trailing5_gap_closed"]
+        for s in lineage_scores
+        if s["trailing5_gap_closed"] is not None
+    ]
+    best = max(valid) if valid else None
+
+    return {
+        "seed_dir": str(seed_dir),
+        "n_generations": len(gen_dirs),
+        "final_gen": final_gen.name,
+        "lineage_scores": lineage_scores,
+        "best_of_pop_gap_closed": best,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--runs-root",
+        type=Path,
+        default=Path("experiments/p3_specialization/runs/issue288_pbt"),
+        help="Root containing seed_<N>/ PBT trial directories.",
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("experiments/p3_specialization/diagnostics/results/issue288_pbt"),
+    )
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    seed_summaries = [aggregate_seed(args.runs_root / f"seed_{s}") for s in args.seeds]
+    valid_bests = [
+        s["best_of_pop_gap_closed"]
+        for s in seed_summaries
+        if s.get("best_of_pop_gap_closed") is not None
+    ]
+    if not valid_bests:
+        verdict, reasoning = "no_data", "No completed PBT seeds found."
+        mean_best = float("nan")
+    else:
+        mean_best = float(np.mean(valid_bests))
+        verdict, reasoning = classify_verdict(mean_best)
+
+    out = {
+        "issue": 288,
+        "verdict": verdict,
+        "reasoning": reasoning,
+        "mean_best_of_pop_gap_closed": mean_best,
+        "per_seed": seed_summaries,
+        "references": {
+            "minspec_random": MINSPEC_RANDOM,
+            "minspec_specialist": MINSPEC_SPECIALIST,
+            "trailing_n": TRAILING_N,
+            "verdict_escape_threshold": VERDICT_ESCAPE_THRESHOLD,
+            "verdict_partial_threshold": VERDICT_PARTIAL_THRESHOLD,
+        },
+    }
+    (args.output_dir / "analysis.json").write_text(json.dumps(out, indent=2))
+
+    md = [
+        "# Issue #288 — PBT basin-escape verdict",
+        "",
+        f"**Verdict**: `{verdict}`",
+        "",
+        f"**Reasoning**: {reasoning}",
+        "",
+        f"- mean best-of-pop trailing-5 gap_closed: {mean_best:.3f}",
+        f"- n PBT seeds with data: {len(valid_bests)} / {len(seed_summaries)}",
+        "",
+        "## Per-seed best-of-pop",
+    ]
+    for s in seed_summaries:
+        md.append(
+            f"- `{Path(s['seed_dir']).name}` "
+            f"({s.get('n_generations', 0)} gens): "
+            f"best_gap_closed = {s.get('best_of_pop_gap_closed')}"
+        )
+    (args.output_dir / "verdict.md").write_text("\n".join(md))
+
+    print(f"\nverdict: {verdict}")
+    print(f"reasoning: {reasoning}")
+    print(f"\nartifacts written to {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue288_pbt.py
+++ b/experiments/p3_specialization/run_issue288_pbt.py
@@ -1,0 +1,494 @@
+"""Issue #288 — Population-Based Training (PBT) orchestrator.
+
+Thin wrapper (Option A per curator) over ``experiments/p3_specialization/train.py``.
+Spawns ``population_size`` independent PPO lineages on ``minimal_specialization``,
+runs ``generations`` * ``iters_per_gen`` PPO iterations per lineage, and between
+generations applies Jaderberg-style truncation selection + weight/hyperparameter
+mutation:
+
+- **Exploit**: bottom 25% (rounded down) of lineages, ranked by trailing-5 mean
+  step team-reward over the most recent generation, are replaced by perturbed
+  copies of randomly-chosen top-25% donors.
+- **Explore (weights)**: donor checkpoints are loaded, additive Gaussian noise
+  ``σ = weight_noise * std(layer)`` is added to every tensor, and the perturbed
+  state dicts are saved to a per-lineage ``perturbed_init/`` directory which
+  becomes the next generation's ``--bc-init-checkpoint-dir``.
+- **Explore (hyperparams)**: ``lr`` is multiplied by uniform({0.8, 1.25}) with
+  probability 0.5; ``entropy_coef`` is multiplied by uniform({0.5, 2.0}) with
+  probability 0.5. Surviving (top 75%) lineages keep their hyperparameters and
+  warm-start from their own previous generation's policies.
+
+Layout on disk::
+
+    <output_dir>/
+        seed_<PBT_SEED>/
+            gen_0/
+                lineage_0/{metrics.json,config.json,policies/agent_*.pt,train.log}
+                ...
+                lineage_<P-1>/...
+                ranking.json          # post-generation ranking + exploit plan
+            gen_1/
+                lineage_0/
+                    perturbed_init/agent_*.pt   # (only if this lineage was replaced)
+                    metrics.json
+                    ...
+                ...
+            lineage_state.json        # final per-lineage hyperparams + history
+
+This script is **safe to run locally only as a smoke test** (e.g.,
+``--population-size 4 --generations 2 --iters-per-gen 5``). The full
+``--population-size 16 --generations 6 --iters-per-gen 50`` run is CPU-heavy
+and MUST go on ``COMPUTE_HOST_PRIMARY`` per ``CLAUDE.md`` guidelines; see
+``run_issue288_pbt.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRAIN_SCRIPT = REPO_ROOT / "experiments" / "p3_specialization" / "train.py"
+
+# Trailing-N for selection criterion. Mirrors analyze_270.py's TRAILING_N
+# so the orchestrator's ranking signal matches the verdict-classifier's input.
+TRAILING_N = 5
+
+# Jaderberg-style multiplicative perturbation factors. Applied with prob
+# ``mutation_prob`` independently per knob per replaced lineage.
+LR_PERTURB_CHOICES: Sequence[float] = (0.8, 1.25)
+ENTROPY_PERTURB_CHOICES: Sequence[float] = (0.5, 2.0)
+MUTATION_PROB = 0.5
+
+
+@dataclass
+class LineageState:
+    """Mutable per-lineage state carried across generations."""
+
+    lineage_id: int
+    seed: int
+    lr: float
+    entropy_coef: float
+    # If non-None, this is the directory containing agent_{i}.pt files to load
+    # into trainer.policies before PPO starts. After the first generation,
+    # surviving lineages point at their own previous gen's ``policies/`` dir;
+    # exploited lineages point at a ``perturbed_init/`` dir written by
+    # ``_apply_exploit_explore``.
+    init_checkpoint_dir: Optional[str] = None
+    # Per-generation trailing-5 mean step team reward (for diagnostics + final
+    # verdict). Indexed by generation number.
+    trailing5_team_history: List[float] = field(default_factory=list)
+    # Provenance: which donor lineage we were spawned from at each generation
+    # (None = survived, no replacement).
+    donor_history: List[Optional[int]] = field(default_factory=list)
+
+
+def _trailing5_team_reward(metrics_path: Path) -> Optional[float]:
+    """Read metrics.json, return mean of last TRAILING_N mean_step_reward_team.
+
+    Returns None when the file is missing or empty (subprocess crashed). Caller
+    treats None as the worst possible score so crashed lineages get replaced.
+    """
+    if not metrics_path.exists():
+        return None
+    try:
+        rows = json.loads(metrics_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    if not rows:
+        return None
+    tail = rows[-TRAILING_N:]
+    return float(sum(r["mean_step_reward_team"] for r in tail) / max(1, len(tail)))
+
+
+def _run_lineage_cell(
+    state: LineageState,
+    scenario: str,
+    lambda_red: float,
+    num_agents: int,
+    rollout_steps: int,
+    iters: int,
+    output_dir: Path,
+) -> int:
+    """Spawn train.py for one lineage's generation. Returns exit code."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(TRAIN_SCRIPT),
+        "--scenario",
+        scenario,
+        "--lambda-red",
+        str(lambda_red),
+        "--seed",
+        str(state.seed),
+        "--num-iterations",
+        str(iters),
+        "--rollout-steps",
+        str(rollout_steps),
+        "--num-agents",
+        str(num_agents),
+        "--lr",
+        str(state.lr),
+        "--entropy-coef",
+        str(state.entropy_coef),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if state.init_checkpoint_dir is not None:
+        cmd.extend(["--bc-init-checkpoint-dir", state.init_checkpoint_dir])
+
+    log_path = output_dir / "train.log"
+    with log_path.open("w") as logf:
+        proc = subprocess.run(cmd, stdout=logf, stderr=subprocess.STDOUT)
+    return proc.returncode
+
+
+def _perturb_checkpoint_dir(
+    src_dir: Path, dst_dir: Path, sigma: float, rng: random.Random
+) -> None:
+    """Copy donor checkpoints to ``dst_dir`` and add Gaussian noise in-place.
+
+    Noise scale is ``sigma * std(tensor)`` per-tensor (per-layer). The "layer"
+    granularity is whatever the donor's ``state_dict`` keys carve up — for the
+    MLP policies in this stack that's one entry per ``weight``/``bias``. Zero-std
+    tensors (e.g., zero-init biases) get plain ``N(0, sigma)`` noise so the
+    perturbation isn't silently a no-op.
+
+    Pickle compatibility: torch saves+loads the perturbed tensors via the same
+    code path the trainer uses for ``--bc-init-checkpoint-dir``, so the only
+    failure mode is shape/dtype drift (which load_state_dict catches strictly).
+    """
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    ckpts = sorted(src_dir.glob("agent_*.pt"))
+    if not ckpts:
+        raise FileNotFoundError(f"no agent_*.pt under {src_dir}")
+    for src_ckpt in ckpts:
+        sd = torch.load(src_ckpt, map_location="cpu", weights_only=True)
+        for key, tensor in sd.items():
+            if not torch.is_floating_point(tensor):
+                continue
+            std = float(tensor.std().item()) if tensor.numel() > 1 else 0.0
+            # rng -> torch generator: a single seed per tensor so the noise is
+            # reproducible from the orchestrator's RNG state.
+            g = torch.Generator()
+            g.manual_seed(rng.randint(0, 2**31 - 1))
+            scale = sigma * std if std > 0.0 else sigma
+            noise = torch.randn(tensor.shape, generator=g) * scale
+            sd[key] = tensor + noise.to(tensor.dtype)
+        torch.save(sd, dst_dir / src_ckpt.name)
+
+
+def _apply_exploit_explore(
+    lineages: List[LineageState],
+    gen_dir: Path,
+    next_gen_dir: Path,
+    weight_noise: float,
+    rng: random.Random,
+    truncation_frac: float = 0.25,
+) -> Dict:
+    """Rank lineages by their just-completed generation, exploit/explore the
+    bottom ``truncation_frac``.
+
+    For each lineage:
+
+    - If it survived (ranked above the truncation cutoff), update its
+      ``init_checkpoint_dir`` to point at this generation's ``policies/`` dir.
+      Hyperparameters stay as-is.
+    - If it was exploited (below the cutoff), pick a top-25% donor uniformly
+      at random, write a perturbed copy of the donor's checkpoints to
+      ``next_gen_dir/lineage_<id>/perturbed_init/``, and mutate ``lr`` and
+      ``entropy_coef`` per Jaderberg perturbation factors with probability
+      ``MUTATION_PROB`` each.
+
+    Returns the ranking dict for the on-disk ``ranking.json`` audit trail.
+    """
+    pop_size = len(lineages)
+    if pop_size == 0:
+        return {"population_size": 0, "ranking": [], "replacements": []}
+
+    # Score every lineage from its just-finished generation cell.
+    scored: List[Dict] = []
+    for lineage in lineages:
+        cell_dir = gen_dir / f"lineage_{lineage.lineage_id}"
+        score = _trailing5_team_reward(cell_dir / "metrics.json")
+        # Track the trailing-5 score history regardless of replacement.
+        lineage.trailing5_team_history.append(float("-inf") if score is None else score)
+        scored.append(
+            {
+                "lineage_id": lineage.lineage_id,
+                "trailing5_team_reward": score,
+                "missing_metrics": score is None,
+            }
+        )
+
+    # Sort descending; None scores go to the bottom (replaced).
+    def sort_key(entry: Dict) -> float:
+        s = entry["trailing5_team_reward"]
+        return float("-inf") if s is None else s
+
+    ranked = sorted(scored, key=sort_key, reverse=True)
+    n_bottom = max(1, math.floor(truncation_frac * pop_size))
+    # Top-25%: at least 1, symmetric with bottom.
+    n_top = max(1, math.floor(truncation_frac * pop_size))
+    top_ids = [entry["lineage_id"] for entry in ranked[:n_top]]
+    bottom_ids = {entry["lineage_id"] for entry in ranked[-n_bottom:]}
+
+    replacements: List[Dict] = []
+    for lineage in lineages:
+        gen_cell = gen_dir / f"lineage_{lineage.lineage_id}"
+        survived_policies = gen_cell / "policies"
+        if lineage.lineage_id in bottom_ids:
+            donor_id = rng.choice(top_ids)
+            donor_policies = gen_dir / f"lineage_{donor_id}" / "policies"
+            perturbed_dir = (
+                next_gen_dir / f"lineage_{lineage.lineage_id}" / "perturbed_init"
+            )
+            _perturb_checkpoint_dir(donor_policies, perturbed_dir, weight_noise, rng)
+            lineage.init_checkpoint_dir = str(perturbed_dir)
+
+            # Inherit donor's hyperparams as the basis for mutation.
+            donor_state = next(s for s in lineages if s.lineage_id == donor_id)
+            new_lr = donor_state.lr
+            new_entropy = donor_state.entropy_coef
+            lr_factor: Optional[float] = None
+            ent_factor: Optional[float] = None
+            if rng.random() < MUTATION_PROB:
+                lr_factor = rng.choice(LR_PERTURB_CHOICES)
+                new_lr = donor_state.lr * lr_factor
+            if rng.random() < MUTATION_PROB:
+                ent_factor = rng.choice(ENTROPY_PERTURB_CHOICES)
+                new_entropy = donor_state.entropy_coef * ent_factor
+            lineage.lr = new_lr
+            lineage.entropy_coef = new_entropy
+            lineage.donor_history.append(donor_id)
+            replacements.append(
+                {
+                    "lineage_id": lineage.lineage_id,
+                    "donor_lineage_id": donor_id,
+                    "lr_perturb_factor": lr_factor,
+                    "entropy_perturb_factor": ent_factor,
+                    "new_lr": new_lr,
+                    "new_entropy_coef": new_entropy,
+                }
+            )
+        else:
+            # Surviving lineage: warm-start the next generation from its own
+            # final policies. Hyperparameters unchanged.
+            lineage.init_checkpoint_dir = str(survived_policies)
+            lineage.donor_history.append(None)
+
+    return {
+        "population_size": pop_size,
+        "n_top": n_top,
+        "n_bottom": n_bottom,
+        "ranking": ranked,
+        "replacements": replacements,
+    }
+
+
+def run_pbt(
+    *,
+    output_root: Path,
+    pbt_seed: int,
+    population_size: int,
+    generations: int,
+    iters_per_gen: int,
+    scenario: str,
+    lambda_red: float,
+    num_agents: int,
+    rollout_steps: int,
+    initial_lr: float,
+    initial_entropy_coef: float,
+    weight_noise: float,
+    truncation_frac: float = 0.25,
+) -> Dict:
+    """Run one PBT trial (one ``pbt_seed``). Returns a summary dict."""
+    seed_root = output_root / f"seed_{pbt_seed}"
+    seed_root.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(pbt_seed)
+
+    # Distinct per-lineage PPO seeds. Using ``pbt_seed * 1000 + i`` keeps the
+    # numbering human-readable in the per-cell config.json.
+    lineages: List[LineageState] = [
+        LineageState(
+            lineage_id=i,
+            seed=pbt_seed * 1000 + i,
+            lr=initial_lr,
+            entropy_coef=initial_entropy_coef,
+        )
+        for i in range(population_size)
+    ]
+
+    for gen in range(generations):
+        gen_dir = seed_root / f"gen_{gen}"
+        gen_dir.mkdir(parents=True, exist_ok=True)
+
+        # Sequential lineage runs. Parallelism comes from the launcher script
+        # (xargs -P N) on the remote host; running parallel here would double-
+        # parallelize and starve CPU on a single workstation.
+        for lineage in lineages:
+            cell_dir = gen_dir / f"lineage_{lineage.lineage_id}"
+            rc = _run_lineage_cell(
+                state=lineage,
+                scenario=scenario,
+                lambda_red=lambda_red,
+                num_agents=num_agents,
+                rollout_steps=rollout_steps,
+                iters=iters_per_gen,
+                output_dir=cell_dir,
+            )
+            if rc != 0:
+                # Log but don't abort: the missing-metrics sentinel sinks the
+                # lineage to the bottom of the ranking so it gets replaced.
+                print(
+                    f"  [WARN] lineage {lineage.lineage_id} gen {gen} "
+                    f"exited with code {rc} — will be exploited",
+                    flush=True,
+                )
+
+        # Exploit + explore unless this was the last generation (no need to
+        # mutate after the final cell — surviving best is the verdict).
+        next_gen_dir = seed_root / f"gen_{gen + 1}"
+        if gen < generations - 1:
+            ranking = _apply_exploit_explore(
+                lineages,
+                gen_dir,
+                next_gen_dir,
+                weight_noise=weight_noise,
+                rng=rng,
+                truncation_frac=truncation_frac,
+            )
+        else:
+            # Final generation: no mutation applied. Score every lineage from
+            # its just-finished cell and append to history so analyzers see a
+            # uniformly-shaped trailing5 trajectory across all generations.
+            for lineage in lineages:
+                cell_dir = gen_dir / f"lineage_{lineage.lineage_id}"
+                score = _trailing5_team_reward(cell_dir / "metrics.json")
+                lineage.trailing5_team_history.append(
+                    float("-inf") if score is None else score
+                )
+            ranking = {
+                "population_size": len(lineages),
+                "ranking": [
+                    {
+                        "lineage_id": lin.lineage_id,
+                        "trailing5_team_reward": lin.trailing5_team_history[-1],
+                    }
+                    for lin in sorted(
+                        lineages,
+                        key=lambda x: x.trailing5_team_history[-1],
+                        reverse=True,
+                    )
+                ],
+                "replacements": [],
+            }
+
+        (gen_dir / "ranking.json").write_text(json.dumps(ranking, indent=2))
+        print(
+            f"== seed {pbt_seed} gen {gen}/{generations - 1}: "
+            f"best trailing5 = {ranking['ranking'][0].get('trailing5_team_reward')}",
+            flush=True,
+        )
+
+    # Persist final per-lineage state so analyze_288.py / verdict notebook can
+    # recover hyperparameter trajectories without re-walking every gen dir.
+    state_path = seed_root / "lineage_state.json"
+    state_path.write_text(json.dumps([asdict(lin) for lin in lineages], indent=2))
+
+    summary = {
+        "pbt_seed": pbt_seed,
+        "population_size": population_size,
+        "generations": generations,
+        "iters_per_gen": iters_per_gen,
+        "final_best_trailing5": max(
+            (lin.trailing5_team_history[-1] for lin in lineages),
+            default=float("-inf"),
+        ),
+    }
+    return summary
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT
+        / "experiments"
+        / "p3_specialization"
+        / "runs"
+        / "issue288_pbt",
+        help="Root output dir. Per-seed dirs land at <output-dir>/seed_<S>/.",
+    )
+    p.add_argument(
+        "--seeds",
+        type=int,
+        nargs="+",
+        default=[42, 43, 44],
+        help="PBT-trial seeds. Each is an independent population.",
+    )
+    p.add_argument("--population-size", type=int, default=16)
+    p.add_argument("--generations", type=int, default=6)
+    p.add_argument("--iters-per-gen", type=int, default=50)
+    p.add_argument("--scenario", default="minimal_specialization")
+    p.add_argument("--lambda-red", type=float, default=0.0)
+    p.add_argument("--num-agents", type=int, default=4)
+    p.add_argument("--rollout-steps", type=int, default=2048)
+    p.add_argument("--initial-lr", type=float, default=3e-4)
+    p.add_argument("--initial-entropy-coef", type=float, default=0.01)
+    p.add_argument(
+        "--weight-noise",
+        type=float,
+        default=0.01,
+        help=(
+            "Std multiplier for additive Gaussian weight perturbation: noise = "
+            "weight_noise * std(layer). Jaderberg-equivalent σ=0.01 keeps "
+            "one mutation step from destroying a working policy."
+        ),
+    )
+    p.add_argument(
+        "--truncation-frac",
+        type=float,
+        default=0.25,
+        help="Fraction of population replaced per generation (default 25%).",
+    )
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summaries = []
+    for s in args.seeds:
+        summary = run_pbt(
+            output_root=args.output_dir,
+            pbt_seed=s,
+            population_size=args.population_size,
+            generations=args.generations,
+            iters_per_gen=args.iters_per_gen,
+            scenario=args.scenario,
+            lambda_red=args.lambda_red,
+            num_agents=args.num_agents,
+            rollout_steps=args.rollout_steps,
+            initial_lr=args.initial_lr,
+            initial_entropy_coef=args.initial_entropy_coef,
+            weight_noise=args.weight_noise,
+            truncation_frac=args.truncation_frac,
+        )
+        summaries.append(summary)
+        print(f"\n== PBT seed {s} done. Summary: {summary}\n", flush=True)
+
+    (args.output_dir / "summary.json").write_text(json.dumps(summaries, indent=2))
+    print(f"All PBT trials complete. Summary -> {args.output_dir / 'summary.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue288_pbt.sh
+++ b/experiments/p3_specialization/run_issue288_pbt.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Issue #288: Population-Based Training (PBT) basin-escape probe.
+#
+# Wraps experiments/p3_specialization/run_issue288_pbt.py with the curator's
+# default knobs (pop=16, gen=6, iters=50, 3 PBT seeds). MUST run on
+# COMPUTE_HOST_PRIMARY per CLAUDE.md guidelines — ~18-27 wall-clock hours.
+#
+# Usage (remote, in tmux):
+#   ./run_issue288_pbt.sh [seed1 seed2 ...]
+#
+# Outputs land at:
+#   experiments/p3_specialization/runs/issue288_pbt/seed_<S>/gen_<G>/lineage_<L>/
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  set -- 42 43 44
+fi
+
+OUT_ROOT="experiments/p3_specialization/runs/issue288_pbt"
+mkdir -p "$OUT_ROOT"
+
+python experiments/p3_specialization/run_issue288_pbt.py \
+  --output-dir "$OUT_ROOT" \
+  --seeds "$@" \
+  --population-size 16 \
+  --generations 6 \
+  --iters-per-gen 50 \
+  --rollout-steps 2048 \
+  --num-agents 4 \
+  --scenario minimal_specialization \
+  --lambda-red 0.0 \
+  --initial-lr 3e-4 \
+  --initial-entropy-coef 0.01 \
+  --weight-noise 0.01 \
+  --truncation-frac 0.25 2>&1 | tee "$OUT_ROOT/pbt_$(date +%Y%m%d_%H%M%S).log"
+
+echo "PBT run complete. Run analyze_288.py to produce the verdict."

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -1163,6 +1163,16 @@ def main() -> None:
             "--influence-coef == 0."
         ),
     )
+    p.add_argument(
+        "--lr",
+        type=float,
+        default=CellConfig.__dataclass_fields__["lr"].default,
+        help=(
+            "PPO Adam learning rate. Default matches CellConfig.lr (3e-4). "
+            "Exposed as CLI for issue #288 PBT mutation (Jaderberg-style "
+            "lr perturbation factor in {0.8, 1.25} applied between generations)."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -1178,6 +1188,7 @@ def main() -> None:
         num_iterations=args.num_iterations,
         rollout_steps=args.rollout_steps,
         num_agents=args.num_agents,
+        lr=args.lr,
         value_coef=args.value_coef,
         entropy_coef=args.entropy_coef,
         normalize_returns=args.normalize_returns,

--- a/tests/test_p3_pbt_issue288.py
+++ b/tests/test_p3_pbt_issue288.py
@@ -1,0 +1,205 @@
+"""Tests for the issue #288 PBT orchestrator and verdict classifier.
+
+Three concerns covered:
+
+1. **Verdict classifier (unit, no I/O)**: ``analyze_288.classify_verdict``
+   maps the three success-criterion tier boundaries to the correct verdict
+   strings. Pure function; the test does not touch disk.
+
+2. **Perturbed-checkpoint pickle round-trip**: ``_perturb_checkpoint_dir``
+   produces ``agent_*.pt`` files that ``torch.load`` can read back with
+   ``weights_only=True`` (the same code path ``train.py``'s
+   ``--bc-init-checkpoint-dir`` uses). Validates that mutation does not break
+   the on-disk format and that the perturbation is non-trivial (>0 std
+   difference vs the donor).
+
+3. **End-to-end smoke**: tiny PBT run (population=4, generations=2,
+   iters_per_gen=2, rollout_steps=128, num_agents=4) on
+   ``minimal_specialization`` (the scenario requires exactly 4 agents — its
+   ``reward_own_house_survives`` vector is length-4). Verifies:
+     - directory layout under ``output_dir/seed_<S>/gen_<G>/lineage_<L>/``
+     - ``metrics.json`` written per lineage cell
+     - ranking.json written per generation
+     - at least one lineage was replaced (bottom 25% of 4 = 1)
+     - the replaced lineage has a ``perturbed_init/`` dir at gen 1
+
+The smoke test takes <60s on a laptop CPU; ``pytest -k pbt`` is the local
+verification path that the worker actually runs before pushing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from experiments.p3_specialization.analyze_288 import (
+    VERDICT_ESCAPE_THRESHOLD,
+    VERDICT_PARTIAL_THRESHOLD,
+    classify_verdict,
+)
+from experiments.p3_specialization.run_issue288_pbt import (
+    LineageState,
+    _perturb_checkpoint_dir,
+    run_pbt,
+)
+
+
+# --- Verdict classifier (no I/O) --------------------------------------------
+
+
+def test_classify_verdict_population_escape():
+    """At/above the escape threshold returns the escape verdict."""
+    verdict, _ = classify_verdict(VERDICT_ESCAPE_THRESHOLD)
+    assert verdict == "population_escape"
+    verdict, _ = classify_verdict(0.85)
+    assert verdict == "population_escape"
+
+
+def test_classify_verdict_partial():
+    """In the [partial, escape) band returns ``partial``."""
+    verdict, _ = classify_verdict(VERDICT_PARTIAL_THRESHOLD)
+    assert verdict == "partial"
+    verdict, _ = classify_verdict(0.45)
+    assert verdict == "partial"
+    # Just below the escape threshold is still partial.
+    verdict, _ = classify_verdict(VERDICT_ESCAPE_THRESHOLD - 1e-9)
+    assert verdict == "partial"
+
+
+def test_classify_verdict_basin_globally_unreachable():
+    """Below the partial threshold returns the unreachable verdict."""
+    verdict, _ = classify_verdict(0.10)
+    assert verdict == "basin_globally_unreachable"
+    verdict, _ = classify_verdict(VERDICT_PARTIAL_THRESHOLD - 1e-9)
+    assert verdict == "basin_globally_unreachable"
+    # Curator's stated boundary cases: 0.75 (escape), 0.45 (partial), 0.10 (unreachable).
+    assert classify_verdict(0.75)[0] == "population_escape"
+    assert classify_verdict(0.45)[0] == "partial"
+    assert classify_verdict(0.10)[0] == "basin_globally_unreachable"
+
+
+# --- Perturbation pickle round-trip -----------------------------------------
+
+
+def test_perturb_checkpoint_round_trip(tmp_path: Path):
+    """Donor checkpoints round-trip through perturbation + torch.load."""
+    donor_dir = tmp_path / "donor_policies"
+    donor_dir.mkdir()
+    # Two synthetic per-agent state dicts. Mix of weight + bias keys, one with
+    # zero std (constant bias) to exercise the fallback noise scale.
+    torch.manual_seed(0)
+    for i in range(2):
+        sd = {
+            "fc1.weight": torch.randn(4, 3),
+            "fc1.bias": torch.zeros(4),  # zero-std -> falls back to plain sigma noise
+            "fc2.weight": torch.randn(2, 4) * 0.5,
+        }
+        torch.save(sd, donor_dir / f"agent_{i}.pt")
+
+    dst_dir = tmp_path / "perturbed_init"
+    rng_seed = 123
+    import random as pyrand
+
+    _perturb_checkpoint_dir(donor_dir, dst_dir, sigma=0.01, rng=pyrand.Random(rng_seed))
+
+    for i in range(2):
+        src = torch.load(donor_dir / f"agent_{i}.pt", weights_only=True)
+        dst = torch.load(dst_dir / f"agent_{i}.pt", weights_only=True)
+        assert set(src.keys()) == set(dst.keys())
+        for key in src:
+            assert src[key].shape == dst[key].shape
+            assert src[key].dtype == dst[key].dtype
+        # Perturbation is non-trivial: at least one float tensor must differ.
+        any_diff = any(
+            not torch.equal(src[k], dst[k])
+            for k in src
+            if torch.is_floating_point(src[k])
+        )
+        assert any_diff, "perturbation produced an identical checkpoint"
+
+
+# --- End-to-end smoke -------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_pbt_smoke_end_to_end(tmp_path: Path):
+    """Tiny PBT run validates directory layout, replacement, and metrics."""
+    output_root = tmp_path / "issue288_smoke"
+    summary = run_pbt(
+        output_root=output_root,
+        pbt_seed=42,
+        population_size=4,
+        generations=2,
+        iters_per_gen=2,
+        scenario="minimal_specialization",
+        lambda_red=0.0,
+        num_agents=4,
+        rollout_steps=128,
+        initial_lr=3e-4,
+        initial_entropy_coef=0.01,
+        weight_noise=0.01,
+        truncation_frac=0.25,
+    )
+
+    seed_dir = output_root / "seed_42"
+    assert seed_dir.is_dir()
+
+    # gen_0 and gen_1 directories with one cell per lineage.
+    for gen in (0, 1):
+        gen_dir = seed_dir / f"gen_{gen}"
+        assert gen_dir.is_dir(), f"missing {gen_dir}"
+        for lineage in range(4):
+            cell = gen_dir / f"lineage_{lineage}"
+            assert cell.is_dir(), f"missing {cell}"
+            assert (cell / "metrics.json").exists(), f"metrics.json missing for {cell}"
+            metrics = json.loads((cell / "metrics.json").read_text())
+            assert len(metrics) == 2, "expected 2 iters per generation"
+
+        ranking_path = gen_dir / "ranking.json"
+        assert ranking_path.exists()
+        ranking = json.loads(ranking_path.read_text())
+        assert ranking["population_size"] == 4
+        # gen_0 ranking should record at least one replacement (bottom 25% of 4 = 1).
+        if gen == 0:
+            assert len(ranking["replacements"]) >= 1, (
+                "expected at least one bottom-25% replacement after gen_0"
+            )
+            replaced_ids = {r["lineage_id"] for r in ranking["replacements"]}
+            # Each replaced lineage should have a perturbed_init dir in gen_1.
+            for lid in replaced_ids:
+                perturbed = seed_dir / "gen_1" / f"lineage_{lid}" / "perturbed_init"
+                assert perturbed.is_dir(), (
+                    f"replaced lineage {lid} missing perturbed_init dir"
+                )
+                # And the perturbed_init should contain per-agent checkpoints.
+                agent_ckpts = list(perturbed.glob("agent_*.pt"))
+                assert len(agent_ckpts) == 4, (
+                    f"expected 4 perturbed agent ckpts for lineage {lid}, "
+                    f"got {len(agent_ckpts)}"
+                )
+
+    # Final per-seed state file must round-trip.
+    state_path = seed_dir / "lineage_state.json"
+    assert state_path.exists()
+    states = json.loads(state_path.read_text())
+    assert len(states) == 4
+    for s in states:
+        assert "lr" in s and "entropy_coef" in s
+        assert len(s["trailing5_team_history"]) == 2
+
+    assert summary["population_size"] == 4
+    assert summary["generations"] == 2
+    assert summary["final_best_trailing5"] != float("-inf"), (
+        "all lineages crashed — smoke is broken, see train.log per cell"
+    )
+
+
+def test_lineage_state_defaults():
+    """LineageState constructs with the expected defaults and types."""
+    s = LineageState(lineage_id=3, seed=42_003, lr=3e-4, entropy_coef=0.01)
+    assert s.init_checkpoint_dir is None
+    assert s.trailing5_team_history == []
+    assert s.donor_history == []


### PR DESCRIPTION
Closes #288. Smoke verified pop=4 gen=2; full pop=16 sweep deferred to COMPUTE_HOST_PRIMARY.

## Summary

Implements Option A (curator recommended): a thin PBT wrapper over the existing per-cell trainer rather than extending ``bucket_brigade/training/population_trainer.py``.

- ``experiments/p3_specialization/run_issue288_pbt.py`` — PBT orchestrator. Spawns N independent lineages running ``train.py`` per generation, ranks by trailing-5 mean step team reward, applies 25% truncation selection with Jaderberg-style perturbation: weight noise ``sigma=0.01 * std(layer)`` per tensor + multiplicative ``lr in {0.8, 1.25}`` / ``entropy_coef in {0.5, 2.0}`` with prob 0.5 each.
- ``experiments/p3_specialization/analyze_288.py`` — verdict classifier reusing ``analyze_270``'s ``gap_closed`` baselines. Public ``classify_verdict(gap_closed)`` for unit testing.
- ``experiments/p3_specialization/run_issue288_pbt.sh`` — launcher with curator defaults (pop=16, gen=6, iters=50, 3 PBT seeds). MUST run on COMPUTE_HOST_PRIMARY per CLAUDE.md.
- ``experiments/p3_specialization/train.py`` — minimal touch: exposes ``--lr`` CLI flag (was only in ``CellConfig``) so PBT can mutate it. Default unchanged (3e-4 = ``CellConfig.lr``).
- ``tests/test_p3_pbt_issue288.py`` — 6 tests covering verdict tier boundaries (0.75/0.45/0.10 and threshold cases), perturbed-checkpoint pickle round-trip, ``LineageState`` defaults, end-to-end smoke (pop=4, gen=2, iters=2, num_agents=4 — scenario requires 4).

## Test plan

- [x] ``pytest tests/test_p3_pbt_issue288.py -v --run-slow`` — 6/6 PASS in ~17s locally.
- [x] Existing ``tests/test_p3_curriculum.py`` — 19/19 PASS (verifies ``--lr`` touch didn't break ``train.py``).
- [x] ``ruff check`` on all new/modified files — clean.
- [ ] **Deferred (remote)**: full pop=16 gen=6 iters=50 × 3 seeds run on ``COMPUTE_HOST_PRIMARY`` (~18-27h per ``CLAUDE.md``). Launch via ``./experiments/p3_specialization/run_issue288_pbt.sh`` in tmux on the remote, then ``analyze_288.py`` for the verdict notebook.

## Scope notes

- New code is orchestration + analysis + tests only. No changes to ``bucket_brigade/training/`` (Option B explicitly rejected by curator).
- PR is ~970 lines including extensive docstrings; pure executable code is closer to ~400 across orchestrator + analyzer + tests. No algorithm blending — straight Jaderberg PBT.
- Curator notebook (``research_notebook/2026-05-17_issue288_pbt_verdict.md``) intentionally deferred until the remote sweep produces results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)