### PR TITLE
diag(p3): hidden_size sweep driver + analyzer for BC-fit capacity probe (#280)

### DIFF
--- a/experiments/p3_specialization/analyze_280.py
+++ b/experiments/p3_specialization/analyze_280.py
@@ -1,0 +1,279 @@
+"""Analysis for issue #280 — hidden_size capacity probe for BC-fit.
+
+Aggregates per-cell results from
+``experiments/p3_specialization/runs/issue280_hidden_size/hs_{HS}/seed_{SEED}/result.json``
+and applies the curator's verdict matrix from the issue body.
+
+Headline metric: ``result.house_acc_on_work_subset`` — eval-set accuracy of
+the house head on rows where the specialist labeled mode=WORK. Chance level
+≈ 0.354 (3 owned houses out of 10). Success threshold ≥ 0.90.
+
+Verdict matrix (capacity-vs-data interpretation, from the issue body):
+
+| Pattern across cells                                  | Verdict                |
+|-------------------------------------------------------|------------------------|
+| hs=64 already saturates (≥0.90) at short budget       | capacity_not_gap       |
+| Monotonic improvement with hidden_size, plateau ≥0.90 | capacity_bound         |
+| Plateau below 0.90 even at 512                        | architecture_mismatch  |
+| No cell exceeds chance (~0.35)                        | information_gap        |
+
+Usage:
+
+    uv run python experiments/p3_specialization/analyze_280.py
+    uv run python experiments/p3_specialization/analyze_280.py \\
+        --runs-root experiments/p3_specialization/runs/issue280_hidden_size \\
+        --hidden-sizes 64 128 \\
+        --output-dir experiments/p3_specialization/diagnostics/results/issue280_hidden_size
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# Discriminating-subtask reference points (issue body).
+# 3 owned houses out of (typically) 10 -> chance is 3/10 = 0.30 for argmax,
+# or ~0.354 if the specialist's label distribution over owned houses is
+# non-uniform. We use the issue body's stated chance of 0.354 as the
+# floor and 0.90 as the success threshold.
+HOUSE_ON_WORK_CHANCE = 0.354
+HOUSE_ON_WORK_SUCCESS = 0.90
+
+
+def _load_cell(path: Path) -> Optional[dict]:
+    f = path / "result.json"
+    if not f.exists():
+        return None
+    return json.loads(f.read_text())
+
+
+def aggregate_cell(cells: List[Path], hidden_size: int) -> Dict:
+    """Average headline metrics across seeds for a single hidden_size."""
+    seeds_data = []
+    house_acc_work = []
+    eval_loss = []
+    house_acc = []
+    joint_acc = []
+    n_params = None
+
+    for cell in cells:
+        payload = _load_cell(cell)
+        if payload is None:
+            seeds_data.append({"cell": str(cell), "missing": True})
+            continue
+        result = payload.get("result", {})
+        final = result.get("final", {})
+        h = result.get("house_acc_on_work_subset", float("nan"))
+        seeds_data.append(
+            {
+                "cell": str(cell),
+                "eval_loss": float(final.get("eval_loss", float("nan"))),
+                "house_acc": float(final.get("house_acc", float("nan"))),
+                "mode_acc": float(final.get("mode_acc", float("nan"))),
+                "signal_acc": float(final.get("signal_acc", float("nan"))),
+                "joint_acc": float(final.get("joint_acc", float("nan"))),
+                "house_acc_on_work_subset": float(h),
+                "eval_work_rows": int(result.get("eval_work_rows", 0)),
+                "n_params": int(result.get("n_params", 0)),
+                "verdict_bc": payload.get("verdict", None),
+            }
+        )
+        if not np.isnan(h):
+            house_acc_work.append(h)
+        if not np.isnan(final.get("eval_loss", float("nan"))):
+            eval_loss.append(float(final["eval_loss"]))
+        if not np.isnan(final.get("house_acc", float("nan"))):
+            house_acc.append(float(final["house_acc"]))
+        if not np.isnan(final.get("joint_acc", float("nan"))):
+            joint_acc.append(float(final["joint_acc"]))
+        if n_params is None:
+            n_params = int(result.get("n_params", 0))
+
+    if not house_acc_work:
+        return {
+            "hidden_size": hidden_size,
+            "n_seeds": 0,
+            "seeds": seeds_data,
+        }
+
+    return {
+        "hidden_size": hidden_size,
+        "n_seeds": len(house_acc_work),
+        "n_params": n_params,
+        "house_acc_on_work_subset_mean": float(np.mean(house_acc_work)),
+        "house_acc_on_work_subset_std": float(
+            np.std(house_acc_work) if len(house_acc_work) > 1 else 0.0
+        ),
+        "eval_loss_mean": float(np.mean(eval_loss)) if eval_loss else float("nan"),
+        "house_acc_mean": float(np.mean(house_acc)) if house_acc else float("nan"),
+        "joint_acc_mean": float(np.mean(joint_acc)) if joint_acc else float("nan"),
+        "seeds": seeds_data,
+    }
+
+
+def classify_verdict(rows: List[Dict]) -> Tuple[str, str]:
+    """Apply the verdict matrix from the issue body to the per-cell rollup."""
+    completed = [r for r in rows if r.get("n_seeds", 0) > 0]
+    if not completed:
+        return "no_data", "No cells produced result.json"
+
+    by_hs = {r["hidden_size"]: r["house_acc_on_work_subset_mean"] for r in completed}
+    hs_sorted = sorted(by_hs.keys())
+    acc_sorted = [by_hs[h] for h in hs_sorted]
+
+    smallest = hs_sorted[0]
+    smallest_acc = by_hs[smallest]
+    max_acc = max(acc_sorted)
+    largest_hs = hs_sorted[-1]
+    largest_acc = by_hs[largest_hs]
+
+    # 1. Smallest hidden_size already saturates -> capacity is not the gap.
+    if smallest_acc >= HOUSE_ON_WORK_SUCCESS:
+        return "capacity_not_gap", (
+            f"hidden_size={smallest} already reaches house-on-WORK="
+            f"{smallest_acc:.3f} >= {HOUSE_ON_WORK_SUCCESS}. Capacity is not "
+            "the bottleneck. If #279 (class-balanced BC) also passed, this "
+            "ladder is resolved by class-balancing. If #279 failed, the "
+            "specialist may rely on information not present in the obs — "
+            "reframe research direction."
+        )
+
+    # 2. No cell exceeds chance -> information gap.
+    if max_acc <= HOUSE_ON_WORK_CHANCE + 0.05:
+        return "information_gap", (
+            f"No cell exceeds chance (max house-on-WORK={max_acc:.3f}, "
+            f"chance≈{HOUSE_ON_WORK_CHANCE}). Neither capacity nor "
+            "class-balancing (#279) is the limiting factor. Information for "
+            "the specialist's argmax over burning-owned houses may not be in "
+            "the observation. Reframe: inspect obs structure; specialist may "
+            "use privileged info."
+        )
+
+    # 3. Monotone improvement and at least one cell crosses success.
+    monotone = all(
+        acc_sorted[i + 1] >= acc_sorted[i] - 0.01 for i in range(len(acc_sorted) - 1)
+    )
+    if monotone and max_acc >= HOUSE_ON_WORK_SUCCESS:
+        winning_hs = next(h for h, a in zip(hs_sorted, acc_sorted) if a >= HOUSE_ON_WORK_SUCCESS)
+        return "capacity_bound", (
+            f"Monotone improvement with hidden_size; plateau >= "
+            f"{HOUSE_ON_WORK_SUCCESS} reached at hidden_size={winning_hs} "
+            f"(house-on-WORK={by_hs[winning_hs]:.3f}). Confirmed capacity "
+            "bound at short budget. PPO's default-64 actor is undersized for "
+            f"this discriminating sub-task. File production-PPO follow-up "
+            f"with hidden_size={winning_hs}."
+        )
+
+    # 4. Largest cell still below success -> architecture mismatch.
+    if largest_acc < HOUSE_ON_WORK_SUCCESS:
+        return "architecture_mismatch", (
+            f"Largest hidden_size={largest_hs} only reaches house-on-WORK="
+            f"{largest_acc:.3f} < {HOUSE_ON_WORK_SUCCESS}. Architecture "
+            "mismatch isn't pure capacity — it's *kind* of capacity (depth? "
+            "attention? non-linearity?). Promote #281 "
+            "(TransformerPolicyNetwork)."
+        )
+
+    return "partial", (
+        f"Mixed pattern across cells: house-on-WORK by hidden_size = "
+        f"{dict(zip(hs_sorted, [round(a, 3) for a in acc_sorted]))}. "
+        "Verdict is inconclusive; consider adding seeds or extending to Path B."
+    )
+
+
+def render_markdown(rows: List[Dict], verdict: str, reasoning: str) -> str:
+    lines = [
+        "# Issue #280 — hidden_size capacity probe for BC-fit",
+        "",
+        f"**Verdict**: `{verdict}`",
+        "",
+        f"**Reasoning**: {reasoning}",
+        "",
+        "## Per-cell results",
+        "",
+        "| hidden_size | n_params | n_seeds | eval_loss | house_acc | "
+        "house_acc_on_work_subset | joint_acc |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda x: x["hidden_size"]):
+        if r.get("n_seeds", 0) == 0:
+            lines.append(
+                f"| {r['hidden_size']} | - | 0 | - | - | - | - |"
+            )
+            continue
+        lines.append(
+            f"| {r['hidden_size']} | {r.get('n_params', '-')} | "
+            f"{r['n_seeds']} | {r['eval_loss_mean']:.4f} | "
+            f"{r['house_acc_mean']:.3f} | "
+            f"{r['house_acc_on_work_subset_mean']:.3f} | "
+            f"{r['joint_acc_mean']:.3f} |"
+        )
+    lines += [
+        "",
+        f"Chance level (house-on-WORK): {HOUSE_ON_WORK_CHANCE}",
+        f"Success threshold (house-on-WORK): {HOUSE_ON_WORK_SUCCESS}",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--runs-root",
+        type=Path,
+        default=Path("experiments/p3_specialization/runs/issue280_hidden_size"),
+        help="Root containing hs_{HS}/seed_{SEED}/result.json cells.",
+    )
+    p.add_argument(
+        "--hidden-sizes",
+        type=int,
+        nargs="+",
+        default=[64, 128],
+        help="Cells to load (Path A: 64 128; Path B: 64 128 256 512).",
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[0])
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/diagnostics/results/issue280_hidden_size"
+        ),
+    )
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: List[Dict] = []
+    for hs in args.hidden_sizes:
+        cells = [args.runs_root / f"hs_{hs}" / f"seed_{s}" for s in args.seeds]
+        rows.append(aggregate_cell(cells, hs))
+
+    verdict, reasoning = classify_verdict(rows)
+
+    out = {
+        "issue": 280,
+        "verdict": verdict,
+        "reasoning": reasoning,
+        "rows": rows,
+        "references": {
+            "house_on_work_chance": HOUSE_ON_WORK_CHANCE,
+            "house_on_work_success": HOUSE_ON_WORK_SUCCESS,
+            "hidden_sizes": args.hidden_sizes,
+            "seeds": args.seeds,
+        },
+    }
+    (args.output_dir / "analysis.json").write_text(json.dumps(out, indent=2))
+    (args.output_dir / "verdict.md").write_text(
+        render_markdown(rows, verdict, reasoning)
+    )
+
+    print(f"\nverdict: {verdict}")
+    print(f"reasoning: {reasoning}")
+    print(f"\nartifacts written to {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/run_issue280_hidden_size_sweep.sh
+++ b/experiments/p3_specialization/run_issue280_hidden_size_sweep.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Issue #280 — hidden_size capacity probe for BC-fit (Phase 1.5 escalation).
+#
+# Path A (default — recommended after PR #278's cross-finding):
+#   hidden_size in {64, 128} at short budget (10k pairs x 10 epochs).
+#
+# Path B (fallback — only run if Path A is inconclusive):
+#   Set HIDDEN_SIZES="64 128 256 512" via env var.
+#
+# Curator note (in issue body): PR #278 already hit gap_closed=0.934 at the
+# default hidden_size=64 with 40k pairs x 30 epochs. The capacity hypothesis
+# may already be settled. Path A cheaply confirms whether widening helps at
+# the *short-budget* regime where #272/PR #276 first saw failure.
+#
+# Layout (consumed by analyze_280.py):
+#   experiments/p3_specialization/runs/issue280_hidden_size/
+#       hs_{HS}/seed_{SEED}/result.json
+#
+# Wall-clock estimate (CPU): ~15-30 min per cell. Path A (2 cells x 1 seed)
+# ~30-60 min total. Path B (4 cells x 1 seed) ~2-3 h total.
+#
+# Run on COMPUTE_HOST_PRIMARY per CLAUDE.md. Do NOT run locally.
+#
+# Modeled on experiments/p3_specialization/run_issue262_sweep.sh.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/GitHub/bucket-brigade}"
+if [[ ! -d "$REPO_ROOT" ]]; then
+  if [[ -d "$HOME/bucket-brigade" ]]; then
+    REPO_ROOT="$HOME/bucket-brigade"
+  fi
+fi
+cd "$REPO_ROOT"
+
+GIT_REV="$(git rev-parse HEAD)"
+echo "Pinned to commit: $GIT_REV"
+
+OUTPUT_ROOT="experiments/p3_specialization/runs"
+SCENARIO="${SCENARIO:-minimal_specialization}"
+NUM_AGENTS="${NUM_AGENTS:-4}"
+# Short budget — matches #272/PR #276 regime that first reported the failure.
+NUM_STEPS="${NUM_STEPS:-2500}"     # 2500 env steps x 4 agents = 10k pairs
+EPOCHS="${EPOCHS:-10}"
+SEEDS=(${SEEDS:-0})                # single seed by default; pass SEEDS="0 1 2" to add
+# Path A: 2-cell probe. Override to "64 128 256 512" for Path B.
+HIDDEN_SIZES=(${HIDDEN_SIZES:-64 128})
+PARALLEL_PER_POOL="${PARALLEL_PER_POOL:-2}"
+
+jobs=()
+for hs in "${HIDDEN_SIZES[@]}"; do
+  for seed in "${SEEDS[@]}"; do
+    outdir="$OUTPUT_ROOT/issue280_hidden_size/hs_${hs}/seed_${seed}"
+    jobs+=("${hs}|${seed}|${outdir}")
+  done
+done
+
+echo
+echo "============================================================"
+echo "Issue #280 hidden_size BC-fit sweep"
+echo "  scenario:        $SCENARIO"
+echo "  num_agents:      $NUM_AGENTS"
+echo "  num_steps:       $NUM_STEPS  (pairs = num_steps * num_agents)"
+echo "  epochs:          $EPOCHS"
+echo "  hidden_sizes:    ${HIDDEN_SIZES[*]}"
+echo "  seeds:           ${SEEDS[*]}"
+echo "  cells:           ${#jobs[@]}"
+echo "  parallelism:     $PARALLEL_PER_POOL"
+echo "============================================================"
+
+run_cell() {
+  local spec="$1"
+  IFS='|' read -r hs seed outdir <<< "$spec"
+  mkdir -p "$outdir"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) START $outdir (hidden_size=$hs seed=$seed)"
+  if uv run python experiments/p3_specialization/bc_fit_only.py \
+       --scenario "$SCENARIO" --num-agents "$NUM_AGENTS" \
+       --num-steps "$NUM_STEPS" --epochs "$EPOCHS" \
+       --hidden-size "$hs" --seed "$seed" \
+       --out "$outdir/result.json" \
+       > "$outdir/train.log" 2>&1; then
+    # Stamp git rev into the result JSON for provenance.
+    python3 -c "
+import json
+p = '$outdir/result.json'
+with open(p) as f: c = json.load(f)
+c['_git_rev'] = '$GIT_REV'
+c['_issue'] = 280
+c['_hidden_size'] = int('$hs')
+with open(p, 'w') as f: json.dump(c, f, indent=2)
+"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) DONE  $outdir"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL  $outdir (see train.log)" >&2
+    return 1
+  fi
+}
+
+export -f run_cell
+export SCENARIO NUM_AGENTS NUM_STEPS EPOCHS GIT_REV
+
+echo
+echo "--- Launching ${#jobs[@]} cells, ${PARALLEL_PER_POOL}-way parallel ---"
+printf "%s\n" "${jobs[@]}" | xargs -n1 -P "$PARALLEL_PER_POOL" -I{} bash -c 'run_cell "$@"' _ {}
+
+echo
+echo "============================================================"
+echo "Issue #280 sweep complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Next: uv run python experiments/p3_specialization/analyze_280.py"
+echo "============================================================"
+touch "$OUTPUT_ROOT/.issue280_hidden_size_done"

--- a/tests/test_bc_fit_only_hidden_size.py
+++ b/tests/test_bc_fit_only_hidden_size.py
@@ -1,0 +1,162 @@
+"""Tests for ``experiments/p3_specialization/bc_fit_only.py`` ``--hidden-size``.
+
+Issue #280: Phase 1.5 capacity probe — adds a thin layer of tests on top of the
+existing ``bc_fit_only.py`` script verifying that:
+
+1. ``PolicyNetwork`` accepts each hidden_size in the sweep grid {64, 128, 256,
+   512} and produces shape-correct logits and values for the
+   ``minimal_specialization`` action space ``[10, 2, 2]``.
+2. ``train_bc`` at the default ``hidden_size=64`` is bit-deterministic for a
+   fixed seed (regression guard — the sweep's interpretation hinges on the
+   baseline cell being reproducible). A tiny dataset (256 rows, 1 epoch)
+   keeps the test fast.
+3. The CLI exposes ``--hidden-size`` and routes it through to the network
+   trunk (parser-level smoke).
+
+Pure-CPU. Total runtime targeted < 5s on a laptop.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "experiments" / "p3_specialization"))
+
+import bc_fit_only  # type: ignore[import-not-found]  # noqa: E402
+from bucket_brigade.training.networks import PolicyNetwork  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# PolicyNetwork shape sanity at each sweep cell
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch_required
+@pytest.mark.parametrize("hidden_size", [64, 128, 256, 512])
+def test_policy_network_accepts_hidden_size(hidden_size: int) -> None:
+    """Shape-sanity: the PolicyNetwork trunk works at every sweep cell.
+
+    The headline metric in #280 (``house_acc_on_work_subset``) is computed
+    from the 10-way house head. Verify all three heads + value head emit
+    the expected batch shapes at each capacity level.
+    """
+    obs_dim = 42  # minimal_specialization flat-obs dim (4 agents x 10 houses x 4 + global)
+    action_dims = [10, 2, 2]
+    batch = 8
+
+    net = PolicyNetwork(
+        obs_dim=obs_dim, action_dims=action_dims, hidden_size=hidden_size
+    )
+    x = torch.zeros(batch, obs_dim)
+    logits, value = net(x)
+
+    assert len(logits) == 3
+    assert logits[0].shape == (batch, 10)
+    assert logits[1].shape == (batch, 2)
+    assert logits[2].shape == (batch, 2)
+    assert value.shape == (batch, 1)
+
+    # encoder_output exposes the shared trunk for joint-trainer redundancy
+    # penalties; widening hidden_size must still emit shape (batch, hidden).
+    z = net.encoder_output(x)
+    assert z.shape == (batch, hidden_size)
+
+
+# ---------------------------------------------------------------------------
+# Bit-identity regression at the default hidden_size
+# ---------------------------------------------------------------------------
+
+
+def _tiny_dataset(rng: np.random.RandomState, n: int, obs_dim: int):
+    obs = rng.randn(n, obs_dim).astype(np.float32)
+    labels = np.zeros((n, 3), dtype=np.int64)
+    labels[:, 0] = rng.randint(0, 10, size=n)
+    labels[:, 1] = rng.randint(0, 2, size=n)
+    labels[:, 2] = rng.randint(0, 2, size=n)
+    return obs, labels
+
+
+@pytest.mark.torch_required
+def test_train_bc_default_hidden_size_is_deterministic() -> None:
+    """Bit-identity at hidden_size=64 across two calls with the same seed.
+
+    The sweep's verdict matrix compares cells against the default 64 baseline.
+    If training at the default size were non-deterministic for a fixed seed,
+    cross-cell comparisons would be noise-bound. This guards against that.
+    """
+    rng = np.random.RandomState(7)
+    obs, labels = _tiny_dataset(rng, n=256, obs_dim=42)
+
+    common_kwargs = dict(
+        obs=obs,
+        labels=labels,
+        num_houses=10,
+        hidden_size=64,
+        lr=3e-4,
+        batch_size=64,
+        epochs=1,
+        train_frac=0.8,
+        seed=0,
+    )
+
+    r1 = bc_fit_only.train_bc(**common_kwargs)
+    r2 = bc_fit_only.train_bc(**common_kwargs)
+
+    # Critical headline metrics must match bit-for-bit.
+    assert r1["n_params"] == r2["n_params"]
+    assert r1["final"]["eval_loss"] == r2["final"]["eval_loss"]
+    assert r1["final"]["house_acc"] == r2["final"]["house_acc"]
+    assert r1["final"]["mode_acc"] == r2["final"]["mode_acc"]
+    assert r1["final"]["signal_acc"] == r2["final"]["signal_acc"]
+    assert r1["final"]["joint_acc"] == r2["final"]["joint_acc"]
+    # NaN-aware comparison for the conditional house_acc_on_work_subset:
+    # tiny random labels may produce no WORK rows in eval; both runs must
+    # then equally produce NaN.
+    h1 = r1["house_acc_on_work_subset"]
+    h2 = r2["house_acc_on_work_subset"]
+    if np.isnan(h1):
+        assert np.isnan(h2)
+    else:
+        assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# Param count grows with hidden_size (capacity-vs-data sanity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch_required
+def test_train_bc_param_count_grows_with_hidden_size() -> None:
+    """Larger hidden_size yields strictly more trainable parameters.
+
+    The analyzer plots ``n_params`` against ``house_acc_on_work_subset``.
+    Verify the relation is monotone so that an apparent plateau in accuracy
+    cannot be confused with a plateau in capacity.
+    """
+    rng = np.random.RandomState(0)
+    obs, labels = _tiny_dataset(rng, n=128, obs_dim=42)
+
+    counts = []
+    for hs in [64, 128, 256, 512]:
+        r = bc_fit_only.train_bc(
+            obs=obs,
+            labels=labels,
+            num_houses=10,
+            hidden_size=hs,
+            lr=3e-4,
+            batch_size=64,
+            epochs=1,
+            train_frac=0.8,
+            seed=0,
+        )
+        counts.append((hs, r["n_params"]))
+
+    for (_, a), (_, b) in zip(counts, counts[1:]):
+        assert b > a, f"n_params must grow strictly with hidden_size: {counts}"


### PR DESCRIPTION
## Summary

Adds the Path A 2-cell sweep driver, verdict-matrix analyzer, and tests for issue #280's BC-fit capacity probe. `bc_fit_only.py` already exposes `--hidden-size` (lines 287, 333), so no changes to the experiment script itself.

Closes #280. Note: #278's 0.934 at hidden_size=64 suggests capacity is not the bottleneck — Path A 2-cell probe will confirm cheaply.

## Changes

- `experiments/p3_specialization/run_issue280_hidden_size_sweep.sh` — Path A default: `HIDDEN_SIZES="64 128"`, `NUM_STEPS=2500`, `EPOCHS=10` (10k pairs × 10 epochs — the short budget where #272/PR #276 first saw failure). Path B accessible via `HIDDEN_SIZES="64 128 256 512"` env override. Modeled on `run_issue262_sweep.sh`: xargs `-P` parallelism, per-cell `train.log`, git-rev stamping into result JSON.
- `experiments/p3_specialization/analyze_280.py` — Aggregator that reads `runs/issue280_hidden_size/hs_{HS}/seed_{SEED}/result.json` and emits `analysis.json` + `verdict.md`. Verdict matrix tied to `house_acc_on_work_subset` (chance ≈ 0.354, success ≥ 0.90), classifies one of: `capacity_not_gap`, `capacity_bound`, `architecture_mismatch`, `information_gap`, `partial`, `no_data`.
- `tests/test_bc_fit_only_hidden_size.py` — 6 tests, all pure-CPU, < 5s total:
  - PolicyNetwork shape sanity (logits + value + encoder_output) at `{64, 128, 256, 512}` × parametrize.
  - Bit-identity regression: `train_bc(hidden_size=64)` produces identical `eval_loss` / per-head accuracies / `joint_acc` on a tiny synthetic dataset across two calls with the same seed.
  - Monotone param-count growth across `{64, 128, 256, 512}` (guards the analyzer's `n_params` axis).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Path A 2-cell `{64, 128}` driver | done | `run_issue280_hidden_size_sweep.sh` defaults to `HIDDEN_SIZES=(64 128)`, short budget |
| Path B accessible as fallback | done | `HIDDEN_SIZES="64 128 256 512" bash run_issue280_hidden_size_sweep.sh` |
| Analyzer keyed on `house_acc_on_work_subset` | done | `analyze_280.py:HOUSE_ON_WORK_CHANCE/SUCCESS`, `classify_verdict()` |
| Bit-identity test at default `hidden_size=64` | done | `test_train_bc_default_hidden_size_is_deterministic` |
| PolicyNetwork shape sanity at `{64, 128, 256, 512}` | done | `test_policy_network_accepts_hidden_size[*]` |
| Smoke test at `hidden_size=128` | done | Ran locally: 200 pairs / 2 epochs, n_params=23951, valid result.json |

## Test Plan

- All 6 unit tests pass locally: `python -m pytest tests/test_bc_fit_only_hidden_size.py -v`
- Verdict matrix verified by hand on synthetic rollups (capacity_not_gap, capacity_bound, information_gap, architecture_mismatch all classify correctly).
- bc_fit_only smoke at hidden_size=128 (50 env-steps × 2 epochs) runs cleanly and writes the expected JSON shape.
- Per user constraint, the sweep itself was NOT executed locally — it is intended for `COMPUTE_HOST_PRIMARY`.

## Notes for reviewer / executor

- This PR is built from `main`. PR #297 (#279, class-balanced BC) is still open. If #297 lands first and ships a `--class-balanced` flag, the executor can pass it through both the sweep driver and the verdict logic; the current PR is orthogonal to that axis.
- The `loom:blocked` label on #280 is informational (per user direction). Builder intentionally left it.

Closes #280