### PR TITLE
exp(p3): single-controller joint-action wrapper for issue #291

### DIFF
--- a/bucket_brigade/envs/single_agent_wrapper.py
+++ b/bucket_brigade/envs/single_agent_wrapper.py
@@ -230,7 +230,5 @@ class SingleAgentJointWrapper:
                     f"expected ({self.num_agents}, {_ACTION_DIM_PER_AGENT})"
                 )
         else:
-            raise ValueError(
-                f"joint_action must be 1-D or 2-D, got ndim={arr.ndim}"
-            )
+            raise ValueError(f"joint_action must be 1-D or 2-D, got ndim={arr.ndim}")
         return arr.astype(np.int64, copy=False)

--- a/bucket_brigade/envs/single_agent_wrapper.py
+++ b/bucket_brigade/envs/single_agent_wrapper.py
@@ -1,0 +1,236 @@
+"""Single-agent joint-action wrapper over ``BucketBrigadeEnv`` (issue #291).
+
+This wrapper collapses the multi-agent decomposition of
+:class:`BucketBrigadeEnv` into a *single* controller that emits the joint
+action for all ``num_agents`` sub-agents each step. The underlying environment
+mechanics, scenario, observation contents, episode length, fire dynamics, and
+per-agent reward components are **unchanged**; only the question of "who
+decides the actions" changes.
+
+This is the scope-determining experiment for the misaligned-gradient thesis
+(see ``research_notebook/2026-05-17_thesis_misaligned_gradients.md`` open
+question #1 and issue #291): does the basin trap survive when multi-agent
+credit assignment is removed as a confound?
+
+NB on scope:
+
+- This is **not** :issue:`286` (macro-action wrapper). :issue:`286` coarsens
+  a *single* agent into temporally-extended options; this issue removes the
+  multi-agent decomposition entirely so that one controller emits the joint
+  action vector for *all* 4 sub-agents simultaneously. Different mechanic.
+
+- This is **not** :issue:`292` (toy 2-agent iterated dilemma). :issue:`292`
+  reduces the env itself; this wrapper keeps ``minimal_specialization``
+  intact and reduces only the *training* decomposition.
+
+API:
+
+- :meth:`SingleAgentJointWrapper.reset` returns the concatenated per-agent
+  observation as a single flat vector (the same flattened representation
+  used by :func:`bucket_brigade.training.joint_trainer.flatten_dict_obs`,
+  one row per sub-agent stacked end-to-end).
+
+- :meth:`SingleAgentJointWrapper.step` accepts a joint action either as a
+  flat ``[N*A]`` vector or a ``[N, A]`` array. The flat layout matches the
+  factorized joint head produced by a single :class:`PolicyNetwork` with
+  ``action_dims = [10, 2, 2] * num_agents``. The wrapper splits the joint
+  action into per-agent ``[N, A]`` chunks, steps the underlying env, and
+  returns ``(obs, sum_team_reward, all_done, info)``.
+
+The single returned obs is a 2-D ``[N, obs_dim_per_agent]`` array (matching
+the shape that :class:`JointPPOTrainer` already expects), so the existing
+trainer can consume the wrapper unchanged when configured with
+``num_agents=1`` and a sub-agent-aware ``flatten`` step (see the companion
+training script ``experiments/p3_specialization/train_single_agent.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.training.joint_trainer import flatten_dict_obs
+
+
+__all__ = ["SingleAgentJointWrapper"]
+
+
+# Per-sub-agent action layout. Mirrors the post-#235 ``[house, mode, signal]``
+# vector consumed by ``BucketBrigadeEnv.step``. Hard-coded here (rather than
+# pulled from the env) because the wrapper exposes a flat joint action space
+# whose shape is fixed at construction time.
+_ACTION_DIM_PER_AGENT = 3
+
+
+class SingleAgentJointWrapper:
+    """Wrap a multi-agent ``BucketBrigadeEnv`` as a single-agent joint-action env.
+
+    The wrapper holds one :class:`BucketBrigadeEnv` instance. From the
+    controller's perspective:
+
+    - One observation per step: the per-agent flattened observation rows
+      stacked into a ``[num_agents, obs_dim_per_agent]`` array. The per-agent
+      flattening uses the existing :func:`flatten_dict_obs` with the
+      ``agent_id`` one-hot tail (issue #204), so each sub-agent row remains
+      distinguishable to a controller that processes them jointly.
+
+    - One scalar reward per step: the **team sum** ``sum(per_agent_rewards)``.
+      This eliminates the per-agent credit-assignment signal that IPPO would
+      otherwise route to per-agent advantage estimators; a single controller
+      training against the team sum cannot blame "the other agent" for low
+      reward.
+
+    - One done flag per step: ``True`` iff the underlying env signaled done
+      on any agent (the env signals done uniformly; this is the standard
+      convention).
+
+    Args:
+        env: A :class:`BucketBrigadeEnv` instance to wrap. The wrapper takes
+            ownership of stepping/resetting it. Construct with the desired
+            scenario before passing in.
+
+    Attributes:
+        env: The wrapped multi-agent env.
+        num_agents: Cached sub-agent count from the wrapped env.
+        action_dims_per_agent: The post-#235 ``[house, mode, signal]`` layout
+            for a single sub-agent. Always ``[num_houses, 2, 2]``.
+        joint_action_dims: The flat factorized joint action layout consumed by
+            a single-controller :class:`PolicyNetwork`. Length
+            ``num_agents * 3``: ``[house_0, mode_0, signal_0, house_1, ...]``.
+        joint_action_size: The product of ``joint_action_dims`` — the
+            cardinality of the joint discrete action space. For
+            ``minimal_specialization`` (10 houses, 4 agents) this is
+            ``(10 * 2 * 2) ** 4 = 2_560_000``.
+        obs_dim_per_agent: Length of one sub-agent's flattened observation
+            (with the identity one-hot tail).
+    """
+
+    def __init__(self, env: BucketBrigadeEnv) -> None:
+        self.env = env
+        self.num_agents = int(env.num_agents)
+        # Per-sub-agent multi-discrete layout: [house, mode, signal].
+        # ``num_houses`` is scenario-dependent (10 for minimal_specialization,
+        # 2 for v2_minimal); ``mode`` and ``signal`` are binary.
+        self.action_dims_per_agent: List[int] = [int(env.num_houses), 2, 2]
+        # Flat joint factorized action layout: concat of per-agent dims.
+        self.joint_action_dims: List[int] = (
+            list(self.action_dims_per_agent) * self.num_agents
+        )
+        # Cardinality of the joint discrete action space (informational; the
+        # factorized head doesn't enumerate it).
+        self.joint_action_size: int = int(np.prod(self.action_dims_per_agent)) ** int(
+            self.num_agents
+        )
+        # Probe obs_dim from a single reset so callers can size their policy
+        # network without re-deriving the flatten layout. We use a fixed seed
+        # for the probe and rely on the caller to re-seed via ``reset(seed=)``
+        # before training begins.
+        probe_obs = env.reset(seed=0)
+        self.obs_dim_per_agent: int = flatten_dict_obs(
+            probe_obs, agent_id=0, num_agents=self.num_agents
+        ).shape[0]
+
+    # ------------------------------------------------------------------
+    # Gym-like API
+    # ------------------------------------------------------------------
+
+    def reset(self, seed: Optional[int] = None) -> np.ndarray:
+        """Reset the wrapped env and return the flat per-agent observation stack.
+
+        Args:
+            seed: Optional seed forwarded to the underlying env.
+
+        Returns:
+            Observation array of shape ``[num_agents, obs_dim_per_agent]``.
+            Row ``i`` is the post-#204 per-agent flattened obs for sub-agent
+            ``i`` (with the identity one-hot tail). The controller is
+            expected to flatten further (e.g., concatenate rows) before
+            feeding to a single policy network.
+        """
+        obs_dict = self.env.reset(seed=seed)
+        return self._flatten_per_agent(obs_dict)
+
+    def step(
+        self, joint_action: np.ndarray
+    ) -> Tuple[np.ndarray, float, bool, Dict[str, np.ndarray]]:
+        """Step the wrapped env with a joint action.
+
+        Args:
+            joint_action: Either a flat ``[N * 3]`` ``int`` array
+                (``[house_0, mode_0, signal_0, house_1, ...]``) or a
+                ``[N, 3]`` ``int`` array. Both shapes split into the same
+                per-agent action tensor before being passed to the env.
+
+        Returns:
+            Tuple ``(obs, team_reward, done, info)`` where:
+
+            - ``obs`` is shape ``[N, obs_dim_per_agent]`` (same layout as
+              :meth:`reset`).
+            - ``team_reward`` is the scalar ``sum(per_agent_rewards)``
+              produced by the wrapped env this step. This is the
+              credit-assignment-free reward signal the single controller
+              trains against.
+            - ``done`` is a Python ``bool`` — ``True`` iff the wrapped env
+              flagged any agent done (the env signals done uniformly).
+            - ``info`` is a small dict echoing the per-agent rewards
+              vector (``"per_agent_rewards"``) so analyzers can decompose
+              the team reward if they wish.
+        """
+        per_agent_action = self._split_joint_action(joint_action)
+        obs_dict, rewards, dones, _info = self.env.step(per_agent_action)
+        team_reward = float(np.asarray(rewards, dtype=np.float64).sum())
+        done = bool(np.asarray(dones).any())
+        next_obs = self._flatten_per_agent(obs_dict)
+        info: Dict[str, np.ndarray] = {
+            "per_agent_rewards": np.asarray(rewards, dtype=np.float32).copy()
+        }
+        return next_obs, team_reward, done, info
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _flatten_per_agent(self, obs_dict: Dict[str, np.ndarray]) -> np.ndarray:
+        """Stack per-agent flattened obs rows into ``[N, obs_dim_per_agent]``.
+
+        Each row uses the post-#204 per-agent flattening (with the identity
+        one-hot tail) so a downstream controller that flattens the stack
+        further still sees per-sub-agent distinguishability.
+        """
+        rows = [
+            flatten_dict_obs(obs_dict, agent_id=i, num_agents=self.num_agents)
+            for i in range(self.num_agents)
+        ]
+        return np.stack(rows, axis=0).astype(np.float32)
+
+    def _split_joint_action(self, joint_action: np.ndarray) -> np.ndarray:
+        """Split a joint action vector into a ``[N, 3]`` per-agent array.
+
+        Accepts both flat ``[N * 3]`` and pre-shaped ``[N, 3]`` inputs.
+        Validates shape and dtype; raises ``ValueError`` on mismatch so
+        upstream bugs surface immediately instead of silently corrupting
+        per-agent action assignment.
+        """
+        arr = np.asarray(joint_action)
+        if arr.ndim == 1:
+            expected = self.num_agents * _ACTION_DIM_PER_AGENT
+            if arr.size != expected:
+                raise ValueError(
+                    f"flat joint_action has size {arr.size}, expected "
+                    f"{expected} = num_agents({self.num_agents}) * "
+                    f"action_dim_per_agent({_ACTION_DIM_PER_AGENT})"
+                )
+            arr = arr.reshape(self.num_agents, _ACTION_DIM_PER_AGENT)
+        elif arr.ndim == 2:
+            if arr.shape != (self.num_agents, _ACTION_DIM_PER_AGENT):
+                raise ValueError(
+                    f"2-D joint_action has shape {tuple(arr.shape)}, "
+                    f"expected ({self.num_agents}, {_ACTION_DIM_PER_AGENT})"
+                )
+        else:
+            raise ValueError(
+                f"joint_action must be 1-D or 2-D, got ndim={arr.ndim}"
+            )
+        return arr.astype(np.int64, copy=False)

--- a/experiments/p3_specialization/analyze_291.py
+++ b/experiments/p3_specialization/analyze_291.py
@@ -1,0 +1,300 @@
+"""Analysis for issue #291 — multi-agent vs horizon basin-trap verdict.
+
+Compares per-iteration team rewards from:
+
+- **Joint-control single-controller PPO** (this issue): cells under
+  ``experiments/p3_specialization/runs/issue291_joint_control/minimal_specialization/seed_{42,43,44}/``.
+- **Random-init IPPO baseline** (#270/#271 reference): cells under
+  ``experiments/p3_specialization/runs/issue231/ippo/minimal_specialization/seed_{42,43,44}/``.
+
+Emits a markdown summary + JSON to
+``experiments/p3_specialization/diagnostics/results/issue291_joint_control/``
+and applies the H0/H1 verdict matrix from the curator-enhanced issue body:
+
+| trailing-5 gap_closed (joint-control) | Verdict |
+|---|---|
+| >= 0.5 | H0 — basin trap is multi-agent-specific (credit assignment).
+|        | Paper scope narrows to cooperative MARL.
+| <= 0.25 | H1 — basin trap is horizon-based, survives single-controller
+|         | reduction. Paper scope expands to long-horizon RL generally.
+| in between | undecided / mixed — horizon contributes, multi-agent compounds.
+
+NB: the curator-enhanced thresholds require K=200 re-evaluation of the
+top checkpoint per seed, not the phase-1 training-time estimates. The
+``--k200-reeval`` flag is a stability gate; this analyzer asserts it
+either ran (presence of ``k200_gap_closed`` in the metrics.json) or is
+explicitly disabled (``--allow-phase1-only``). Phase-1 numbers drifted
+-46 points in #271 — do NOT report them as the verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# Hardcoded references (mirror analyze_270.py:39-40 — same scenario, so
+# the same random/specialist baselines apply).
+MINSPEC_RANDOM = -96.07
+MINSPEC_SPECIALIST = -22.07
+TRAILING_N = 5
+
+# Verdict thresholds (curator-enhanced issue body):
+#   gap_closed >= H0_THRESH        -> H0  (multi-agent-specific)
+#   gap_closed <= H1_THRESH        -> H1  (horizon-based)
+#   in between                     -> undecided
+H0_THRESH = 0.5
+H1_THRESH = 0.25
+
+
+def gap_closed(per_step_team: float) -> float:
+    return (per_step_team - MINSPEC_RANDOM) / (MINSPEC_SPECIALIST - MINSPEC_RANDOM)
+
+
+def _load_metrics(path: Path) -> Optional[List[dict]]:
+    f = path / "metrics.json"
+    if not f.exists():
+        return None
+    return json.loads(f.read_text())
+
+
+def _trajectory(metrics: List[dict]) -> np.ndarray:
+    """Per-iteration mean_step_reward_team as a 1-D array."""
+    return np.asarray(
+        [row["mean_step_reward_team"] for row in metrics], dtype=np.float64
+    )
+
+
+def aggregate_arm(cells: List[Path], label: str) -> Dict:
+    seeds_data = []
+    trajectories = []
+    for cell in cells:
+        metrics = _load_metrics(cell)
+        if metrics is None:
+            seeds_data.append({"cell": str(cell), "missing": True})
+            continue
+        traj = _trajectory(metrics)
+        seeds_data.append(
+            {
+                "cell": str(cell),
+                "n_iters": int(traj.size),
+                "iter0_team": float(traj[0]),
+                "iter0_gap_closed": float(gap_closed(float(traj[0]))),
+                "trailing5_team": float(traj[-TRAILING_N:].mean()),
+                "trailing5_gap_closed": float(
+                    gap_closed(float(traj[-TRAILING_N:].mean()))
+                ),
+                "min_iter_team": float(traj.min()),
+                "max_iter_team": float(traj.max()),
+            }
+        )
+        trajectories.append(traj)
+
+    if not trajectories:
+        return {"label": label, "seeds": seeds_data, "n_seeds": 0}
+    min_len = min(t.size for t in trajectories)
+    stacked = np.stack([t[:min_len] for t in trajectories], axis=0)  # [S, T]
+    mean_traj_step = stacked.mean(axis=0)
+    mean_traj_gc = (mean_traj_step - MINSPEC_RANDOM) / (
+        MINSPEC_SPECIALIST - MINSPEC_RANDOM
+    )
+
+    return {
+        "label": label,
+        "seeds": seeds_data,
+        "n_seeds": len(trajectories),
+        "n_iters": int(min_len),
+        "iter0_team_mean": float(mean_traj_step[0]),
+        "iter0_gap_closed_mean": float(mean_traj_gc[0]),
+        "trailing5_team_mean": float(mean_traj_step[-TRAILING_N:].mean()),
+        "trailing5_gap_closed_mean": float(mean_traj_gc[-TRAILING_N:].mean()),
+        "min_iter_gap_closed_mean": float(mean_traj_gc.min()),
+        "max_iter_gap_closed_mean": float(mean_traj_gc.max()),
+        "mean_traj_step_reward": mean_traj_step.tolist(),
+        "mean_traj_gap_closed": mean_traj_gc.tolist(),
+    }
+
+
+def classify_verdict(joint_arm: Dict) -> Tuple[str, str]:
+    """Apply the curator-enhanced H0/H1 verdict matrix.
+
+    Returns ``(label, reasoning)``. Labels:
+
+    - ``H0_multi_agent_specific``: joint-control PPO succeeds on
+      ``minimal_specialization`` (trailing-5 gap_closed >= 0.5). Paper scope
+      narrows to cooperative MARL.
+    - ``H1_horizon_based``: joint-control PPO also plateaus (trailing-5
+      gap_closed <= 0.25). Paper scope expands.
+    - ``undecided``: trailing-5 sits between the H0 and H1 thresholds. Mixed
+      cause — horizon contributes, multi-agent compounds.
+    """
+    if joint_arm.get("n_seeds", 0) == 0:
+        return "no_data", "joint-control arm has no completed seeds"
+    trail_gc = joint_arm["trailing5_gap_closed_mean"]
+    if trail_gc >= H0_THRESH:
+        return "H0_multi_agent_specific", (
+            f"trailing-5 gap_closed = {trail_gc:.3f} >= {H0_THRESH:.2f}. "
+            "Single-controller joint-action PPO closes >= half of the "
+            "random->specialist gap, while IPPO plateaus near 0.18 (#270/#271). "
+            "The basin trap is therefore tied to multi-agent credit "
+            "assignment, not to the long-horizon reward structure. Paper "
+            "scope narrows to cooperative MARL."
+        )
+    if trail_gc <= H1_THRESH:
+        return "H1_horizon_based", (
+            f"trailing-5 gap_closed = {trail_gc:.3f} <= {H1_THRESH:.2f}. "
+            "Single-controller joint-action PPO is also trapped in the "
+            "greedy basin — removing the multi-agent decomposition does "
+            "not rescue cooperation. The basin trap is therefore a "
+            "general-RL long-horizon phenomenon, connecting directly to "
+            "the specification-gaming literature. Paper scope expands."
+        )
+    return "undecided", (
+        f"trailing-5 gap_closed = {trail_gc:.3f} sits between H1 "
+        f"({H1_THRESH:.2f}) and H0 ({H0_THRESH:.2f}). Joint-control helps "
+        "partially but does not solve the basin trap. Horizon contributes, "
+        "multi-agent compounds. Document and discuss in the paper as "
+        "'credit assignment is a partial cause.'"
+    )
+
+
+def _enforce_k200_gate(joint_arm: Dict, allow_phase1_only: bool) -> Optional[str]:
+    """Verdict-gate check: require K=200 re-eval before reporting verdict.
+
+    Phase-1 estimates drifted -46 points in #271. The curator-enhanced
+    success criterion requires the top checkpoint per seed to be
+    re-evaluated for K=200 episodes before the gap_closed verdict is
+    counted. This analyzer cannot run the re-eval (it only consumes
+    training-time metrics.json) — but it asserts that one of these holds:
+
+    - Every per-seed entry has a ``k200_gap_closed`` field (provided by
+      a separate re-eval pass that writes back into metrics.json).
+    - The caller explicitly opted out via ``--allow-phase1-only``.
+
+    Returns ``None`` if the gate passes; a string explaining the failure
+    otherwise.
+    """
+    if allow_phase1_only:
+        return None
+    missing = [
+        s.get("cell", "?") for s in joint_arm.get("seeds", [])
+        if not s.get("missing", False) and "k200_gap_closed" not in s
+    ]
+    if missing:
+        return (
+            "K=200 re-eval gate failed: no `k200_gap_closed` field on "
+            f"{len(missing)} seed cells. The curator-enhanced success "
+            "criterion requires top-checkpoint K=200 re-evaluation before "
+            "any verdict is reported (#271 showed phase-1 estimates drift "
+            "-46 points). Run the K=200 re-eval (separate script) first, "
+            "or pass --allow-phase1-only to explicitly bypass the gate "
+            "(numbers should NOT be reported as the result in that mode)."
+        )
+    return None
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--joint-runs-root",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/runs/issue291_joint_control/minimal_specialization"
+        ),
+        help="Root containing seed_{42,43,44} cells from the joint-control PPO sweep.",
+    )
+    p.add_argument(
+        "--baseline-runs-root",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/runs/issue231/ippo/minimal_specialization"
+        ),
+        help="Root containing seed_{42,43,44} cells from the random-init IPPO baseline.",
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(
+            "experiments/p3_specialization/diagnostics/results/issue291_joint_control"
+        ),
+    )
+    p.add_argument(
+        "--allow-phase1-only",
+        action="store_true",
+        help=(
+            "Bypass the K=200 stability-gate check. The training-time "
+            "phase-1 gap_closed should NOT be reported as the final "
+            "verdict — #271 drifted -46 points between phase-1 and K=200. "
+            "Provided for development/iteration only."
+        ),
+    )
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    joint_cells = [args.joint_runs_root / f"seed_{s}" for s in args.seeds]
+    baseline_cells = [args.baseline_runs_root / f"seed_{s}" for s in args.seeds]
+
+    joint_arm = aggregate_arm(joint_cells, "joint_control_ppo")
+    baseline_arm = aggregate_arm(baseline_cells, "random_init_ippo")
+
+    gate_failure = _enforce_k200_gate(joint_arm, args.allow_phase1_only)
+    if gate_failure is not None:
+        verdict, reasoning = "gate_failed", gate_failure
+    else:
+        verdict, reasoning = classify_verdict(joint_arm)
+
+    out = {
+        "issue": 291,
+        "verdict": verdict,
+        "reasoning": reasoning,
+        "joint_control_arm": joint_arm,
+        "random_init_arm": baseline_arm,
+        "thresholds": {"H0": H0_THRESH, "H1": H1_THRESH},
+        "references": {
+            "minspec_random": MINSPEC_RANDOM,
+            "minspec_specialist": MINSPEC_SPECIALIST,
+            "trailing_n": TRAILING_N,
+        },
+        "k200_gate_bypassed": bool(args.allow_phase1_only),
+    }
+    (args.output_dir / "analysis.json").write_text(json.dumps(out, indent=2))
+
+    md = [
+        "# Issue #291 — single-controller (joint-action) basin-trap verdict",
+        "",
+        f"**Verdict**: `{verdict}`",
+        "",
+        f"**Reasoning**: {reasoning}",
+        "",
+        "## Joint-control PPO arm (this issue)",
+        f"- n_seeds: {joint_arm.get('n_seeds', 0)}",
+        f"- iter 0 gap_closed: {joint_arm.get('iter0_gap_closed_mean', float('nan')):.3f}",
+        f"- trailing-5 gap_closed: {joint_arm.get('trailing5_gap_closed_mean', float('nan')):.3f}",
+        f"- max-iter gap_closed: {joint_arm.get('max_iter_gap_closed_mean', float('nan')):.3f}",
+        "",
+        "## Random-init IPPO baseline (#270/#271)",
+        f"- n_seeds: {baseline_arm.get('n_seeds', 0)}",
+        f"- trailing-5 gap_closed: {baseline_arm.get('trailing5_gap_closed_mean', float('nan')):.3f}",
+        "",
+        "## Thresholds",
+        f"- H0 (multi-agent-specific): trailing-5 gap_closed >= {H0_THRESH:.2f}",
+        f"- H1 (horizon-based): trailing-5 gap_closed <= {H1_THRESH:.2f}",
+        "",
+        "## References",
+        f"- random baseline: {MINSPEC_RANDOM:.2f}",
+        f"- specialist baseline: {MINSPEC_SPECIALIST:.2f}",
+        f"- K=200 stability gate bypassed: {bool(args.allow_phase1_only)}",
+    ]
+    (args.output_dir / "verdict.md").write_text("\n".join(md))
+
+    print(f"\nverdict: {verdict}")
+    print(f"reasoning: {reasoning}")
+    print(f"\nartifacts written to {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/analyze_291.py
+++ b/experiments/p3_specialization/analyze_291.py
@@ -180,7 +180,8 @@ def _enforce_k200_gate(joint_arm: Dict, allow_phase1_only: bool) -> Optional[str
     if allow_phase1_only:
         return None
     missing = [
-        s.get("cell", "?") for s in joint_arm.get("seeds", [])
+        s.get("cell", "?")
+        for s in joint_arm.get("seeds", [])
         if not s.get("missing", False) and "k200_gap_closed" not in s
     ]
     if missing:

--- a/experiments/p3_specialization/run_issue291_joint_control.sh
+++ b/experiments/p3_specialization/run_issue291_joint_control.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Issue #291: single-controller (joint-action) PPO on minimal_specialization.
+#
+# Budget matches the #270 IPPO continuation sweep: 50 iter * 2048 steps * 3
+# seeds on minimal_specialization. The single change is the env wrapper —
+# one controller emits the joint action for all 4 sub-agents.
+#
+# CPU-bound workload per CLAUDE.md compute guidelines — run on
+# COMPUTE_HOST_PRIMARY (Mac Studio class) in tmux. Do NOT run on localhost.
+#
+# Usage:
+#   ./run_issue291_joint_control.sh [seed1 seed2 ...]
+#
+# Defaults to seeds 42 43 44. Output cells land at:
+#   experiments/p3_specialization/runs/issue291_joint_control/minimal_specialization/seed_<S>/
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  set -- 42 43 44
+fi
+
+OUT_ROOT="experiments/p3_specialization/runs/issue291_joint_control/minimal_specialization"
+mkdir -p "$OUT_ROOT"
+export OUT_ROOT
+
+run_one() {
+  local s="$1"
+  local out="$OUT_ROOT/seed_$s"
+  mkdir -p "$out"
+  python experiments/p3_specialization/train_single_agent.py \
+    --scenario minimal_specialization \
+    --seed "$s" \
+    --num-iterations 50 \
+    --rollout-steps 2048 \
+    --num-subagents 4 \
+    --joint-control \
+    --output-dir "$out" 2>&1 | tee "$out/train.log"
+}
+export -f run_one
+
+# Two seeds at a time, matching the #270 driver's parallelism budget.
+printf "%s\n" "$@" | xargs -P 2 -I{} bash -c 'run_one "$@"' _ {}
+
+echo "All seeds finished."

--- a/experiments/p3_specialization/train_single_agent.py
+++ b/experiments/p3_specialization/train_single_agent.py
@@ -40,7 +40,7 @@ import argparse
 import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import torch
@@ -94,9 +94,7 @@ def _flatten_controller_obs(stacked: np.ndarray) -> np.ndarray:
     return stacked.reshape(-1).astype(np.float32, copy=False)
 
 
-def train_single_agent_cell(
-    cfg: SingleAgentCellConfig, output_dir: Path
-) -> None:
+def train_single_agent_cell(cfg: SingleAgentCellConfig, output_dir: Path) -> None:
     """Run one (scenario, seed) cell of single-controller joint-action PPO."""
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/experiments/p3_specialization/train_single_agent.py
+++ b/experiments/p3_specialization/train_single_agent.py
@@ -1,0 +1,288 @@
+"""Single-controller (joint-action) PPO trainer for issue #291.
+
+This is the scope-determining experiment for the misaligned-gradient thesis
+(``research_notebook/2026-05-17_thesis_misaligned_gradients.md`` open question
+#1). The question: does the basin trap that IPPO hits on
+``minimal_specialization`` (#270/#271 verdicts) survive when multi-agent
+credit-assignment is removed as a confound?
+
+The training setup matches IPPO's budget exactly (50 iter * 2048 steps * 3
+seeds) except that:
+
+- The env is wrapped in :class:`SingleAgentJointWrapper` so a single
+  controller emits the joint action for all 4 sub-agents.
+- A single :class:`PolicyNetwork` produces a factorized joint distribution
+  with ``action_dims = [num_houses, 2, 2] * num_subagents`` (12 heads for
+  ``minimal_specialization``: 4 sub-agents x [house, mode, signal]).
+- The reward signal is the **team sum** of per-sub-agent rewards (no
+  per-agent advantage decomposition).
+
+NB: this is **not** the macro-action wrapper from #286 (which coarsens a
+single agent into temporally-extended options) and not the toy reduction
+from #292. The env mechanics — episode length, fire dynamics, ignition,
+ownership rewards — are bit-exact identical to the IPPO baseline.
+
+CLI:
+
+    python experiments/p3_specialization/train_single_agent.py \\
+        --scenario minimal_specialization \\
+        --seed 42 --num-iterations 50 --rollout-steps 2048 \\
+        --output-dir runs/issue291/seed_42 --joint-control
+
+Defaults match the #270 budget. The ``--joint-control`` flag is accepted
+but ignored (this script is the joint-control path); it is preserved so
+the run driver and docs can pass it explicitly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.envs.single_agent_wrapper import SingleAgentJointWrapper
+from bucket_brigade.training.networks import PolicyNetwork, compute_gae
+
+
+@dataclass
+class SingleAgentCellConfig:
+    scenario: str
+    seed: int
+    num_iterations: int = 50
+    rollout_steps: int = 2048
+    num_subagents: int = 4
+    hidden_size: int = 64
+    lr: float = 3e-4
+    gamma: float = 0.99
+    gae_lambda: float = 0.95
+    clip_epsilon: float = 0.2
+    value_coef: float = 0.5
+    entropy_coef: float = 0.01
+    max_grad_norm: float = 0.5
+    ppo_epochs: int = 4
+    minibatch_size: int = 256
+    device: str = "cpu"
+    # Action layout per sub-agent. Matches the post-#235 ``[house, mode,
+    # signal]`` MultiDiscrete([num_houses, 2, 2]). The joint factorized head
+    # is built as ``per_agent * num_subagents``.
+    per_agent_action_dims: List[int] = field(default_factory=lambda: [10, 2, 2])
+
+
+def _build_env(scenario_name: str, num_subagents: int) -> SingleAgentJointWrapper:
+    """Construct the joint-action wrapper over ``BucketBrigadeEnv``."""
+    scenario = get_scenario_by_name(scenario_name, num_agents=num_subagents)
+    inner = BucketBrigadeEnv(scenario=scenario)
+    return SingleAgentJointWrapper(inner)
+
+
+def _joint_obs_dim(env: SingleAgentJointWrapper) -> int:
+    """Length of the controller's flattened observation (concat per-sub-agent rows)."""
+    return int(env.num_agents * env.obs_dim_per_agent)
+
+
+def _flatten_controller_obs(stacked: np.ndarray) -> np.ndarray:
+    """Concatenate ``[N, obs_dim_per_agent]`` rows into a single controller vector."""
+    return stacked.reshape(-1).astype(np.float32, copy=False)
+
+
+def train_single_agent_cell(
+    cfg: SingleAgentCellConfig, output_dir: Path
+) -> None:
+    """Run one (scenario, seed) cell of single-controller joint-action PPO."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(cfg.seed)
+    np.random.seed(cfg.seed)
+    device = torch.device(cfg.device)
+
+    env = _build_env(cfg.scenario, cfg.num_subagents)
+    # The wrapper exposes ``joint_action_dims`` already laid out as
+    # [house_0, mode_0, signal_0, house_1, mode_1, signal_1, ...]. Use it
+    # directly so the policy heads match the wrapper's split convention.
+    joint_action_dims = list(env.joint_action_dims)
+    obs_dim = _joint_obs_dim(env)
+
+    policy = PolicyNetwork(
+        obs_dim=obs_dim,
+        action_dims=joint_action_dims,
+        hidden_size=cfg.hidden_size,
+    ).to(device)
+    optimizer = optim.Adam(policy.parameters(), lr=cfg.lr)
+
+    stacked = env.reset(seed=cfg.seed)
+    obs = _flatten_controller_obs(stacked)
+
+    metrics_log = []
+
+    for it in range(cfg.num_iterations):
+        # ---------- rollout ----------
+        T = cfg.rollout_steps
+        rollout_obs = np.zeros((T, obs_dim), dtype=np.float32)
+        rollout_actions = np.zeros((T, len(joint_action_dims)), dtype=np.int64)
+        rollout_log_probs = np.zeros(T, dtype=np.float32)
+        rollout_values = np.zeros(T, dtype=np.float32)
+        rollout_rewards = np.zeros(T, dtype=np.float32)
+        rollout_dones = np.zeros(T, dtype=np.float32)
+
+        for t in range(T):
+            obs_t = torch.from_numpy(obs).to(device).unsqueeze(0)  # [1, obs_dim]
+            with torch.no_grad():
+                actions, log_prob, _entropy, value = policy.get_action_and_value(obs_t)
+            joint_action = actions[0].cpu().numpy()  # [12] flat joint action
+
+            next_stacked, team_reward, done, _info = env.step(joint_action)
+
+            rollout_obs[t] = obs
+            rollout_actions[t] = joint_action
+            rollout_log_probs[t] = float(log_prob[0].item())
+            rollout_values[t] = float(value[0].item())
+            rollout_rewards[t] = float(team_reward)
+            rollout_dones[t] = float(done)
+
+            if done:
+                next_stacked = env.reset()
+            obs = _flatten_controller_obs(next_stacked)
+
+        # ---------- GAE + returns ----------
+        adv = np.asarray(
+            compute_gae(
+                rollout_rewards.tolist(),
+                rollout_values.tolist(),
+                rollout_dones.astype(bool).tolist(),
+                cfg.gamma,
+                cfg.gae_lambda,
+            ),
+            dtype=np.float32,
+        )
+        returns = adv + rollout_values
+        # Per-batch advantage standardization, matching JointPPOTrainer.update.
+        adv_std = (adv - adv.mean()) / (adv.std() + 1e-8)
+
+        # ---------- PPO update ----------
+        obs_tensor = torch.from_numpy(rollout_obs).to(device)
+        act_tensor = torch.from_numpy(rollout_actions).to(device)
+        old_lp_tensor = torch.from_numpy(rollout_log_probs).to(device)
+        adv_tensor = torch.from_numpy(adv_std).to(device)
+        ret_tensor = torch.from_numpy(returns).to(device)
+
+        mb_size = min(cfg.minibatch_size, T)
+
+        epoch_policy_loss = 0.0
+        epoch_value_loss = 0.0
+        epoch_entropy = 0.0
+        for _ in range(cfg.ppo_epochs):
+            idx = torch.randperm(T, device=device)[:mb_size]
+            obs_mb = obs_tensor[idx]
+            act_mb = act_tensor[idx]
+            old_lp_mb = old_lp_tensor[idx]
+            adv_mb = adv_tensor[idx]
+            ret_mb = ret_tensor[idx]
+
+            _new_acts, new_lp, entropy, value = policy.get_action_and_value(
+                obs_mb, action=act_mb
+            )
+
+            ratio = torch.exp(new_lp - old_lp_mb)
+            surr1 = ratio * adv_mb
+            surr2 = (
+                torch.clamp(ratio, 1.0 - cfg.clip_epsilon, 1.0 + cfg.clip_epsilon)
+                * adv_mb
+            )
+            policy_loss = -torch.min(surr1, surr2).mean()
+            value_loss = 0.5 * (value - ret_mb).pow(2).mean()
+            entropy_mean = entropy.mean()
+
+            loss = (
+                policy_loss
+                + cfg.value_coef * value_loss
+                - cfg.entropy_coef * entropy_mean
+            )
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(policy.parameters(), cfg.max_grad_norm)
+            optimizer.step()
+
+            epoch_policy_loss += float(policy_loss.item())
+            epoch_value_loss += float(value_loss.item())
+            epoch_entropy += float(entropy_mean.item())
+
+        n_e = max(1, cfg.ppo_epochs)
+        # Match the IPPO trainer's "mean per-step team reward" metric so
+        # downstream analyzers (gap_closed) can compare arms directly.
+        mean_step_reward_team = float(rollout_rewards.mean())
+        record = {
+            "iteration": it,
+            "mean_step_reward_team": mean_step_reward_team,
+            "policy_loss": epoch_policy_loss / n_e,
+            "value_loss": epoch_value_loss / n_e,
+            "entropy": epoch_entropy / n_e,
+        }
+        metrics_log.append(record)
+
+        if it % max(1, cfg.num_iterations // 10) == 0 or it == cfg.num_iterations - 1:
+            print(
+                f"  iter {it:4d} | team_reward {mean_step_reward_team:8.3f} | "
+                f"policy_loss {record['policy_loss']:.4f} | "
+                f"value_loss {record['value_loss']:.4f} | "
+                f"entropy {record['entropy']:.4f}"
+            )
+
+    # Save final policy + metrics + config.
+    pol_dir = output_dir / "policies"
+    pol_dir.mkdir(exist_ok=True)
+    torch.save(policy.state_dict(), pol_dir / "controller.pt")
+    with (output_dir / "metrics.json").open("w") as f:
+        json.dump(metrics_log, f, indent=2)
+    with (output_dir / "config.json").open("w") as f:
+        json.dump(asdict(cfg), f, indent=2)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--scenario", required=True)
+    p.add_argument("--seed", type=int, required=True)
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--num-iterations", type=int, default=50)
+    p.add_argument("--rollout-steps", type=int, default=2048)
+    p.add_argument("--num-subagents", type=int, default=4)
+    p.add_argument(
+        "--joint-control",
+        action="store_true",
+        help=(
+            "Issue #291: opt into the joint-action single-controller training "
+            "path. This script implements only that path; the flag is "
+            "accepted for explicitness and forward compatibility with the "
+            "sweep driver. Future revisions may multiplex this script with "
+            "other reductions (#286 macro actions, #292 toy dilemma)."
+        ),
+    )
+    p.add_argument("--device", default="cpu")
+    args = p.parse_args()
+
+    cfg = SingleAgentCellConfig(
+        scenario=args.scenario,
+        seed=args.seed,
+        num_iterations=args.num_iterations,
+        rollout_steps=args.rollout_steps,
+        num_subagents=args.num_subagents,
+        device=args.device,
+    )
+    print(
+        f"== Issue #291 single-controller cell: scenario={cfg.scenario} "
+        f"seed={cfg.seed} num_subagents={cfg.num_subagents} "
+        f"joint_control={args.joint_control} =="
+    )
+    train_single_agent_cell(cfg, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_single_agent_wrapper.py
+++ b/tests/test_single_agent_wrapper.py
@@ -1,0 +1,280 @@
+"""Unit + smoke tests for the issue #291 single-agent joint-action wrapper.
+
+Covers:
+
+- Wrapper action-space sanity: joint action space equals product of
+  per-agent action sizes; joint actions split correctly into per-agent
+  actions and reach the underlying env unmodified.
+- Reward aggregation: wrapped scalar reward equals the sum of per-agent
+  rewards on every step.
+- Specialist-ceiling smoke: driving the wrapper with the hand-tuned
+  specialist policy beats the random floor by a wide margin (the upper
+  bound is representable under the new action space).
+- Random-floor smoke: uniform-random joint actions produce reward in a
+  known floor range.
+- K=200 re-eval stability gate: the analyzer enforces a K=200 gate
+  before reporting a verdict; we test the gate's existence (it triggers
+  on missing ``k200_gap_closed`` field) without running K=200.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from bucket_brigade.baselines import specialist_action_joint
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.envs.single_agent_wrapper import SingleAgentJointWrapper
+
+
+SCENARIO = "minimal_specialization"
+NUM_SUBAGENTS = 4
+ACTION_DIM_PER_AGENT = 3
+SMOKE_EPISODES = 5  # tiny budget so the unit-test suite stays fast
+
+
+def _build_wrapper(seed: int = 0) -> SingleAgentJointWrapper:
+    scenario = get_scenario_by_name(SCENARIO, num_agents=NUM_SUBAGENTS)
+    env = BucketBrigadeEnv(scenario=scenario)
+    wrapper = SingleAgentJointWrapper(env)
+    wrapper.reset(seed=seed)
+    return wrapper
+
+
+class TestActionSpace:
+    """The wrapper's joint action space must equal the product of per-agent sizes."""
+
+    def test_joint_action_size_equals_product(self):
+        wrapper = _build_wrapper()
+        per_agent = int(np.prod(wrapper.action_dims_per_agent))
+        # 10 houses, 2 modes, 2 signals -> 40 per sub-agent.
+        assert per_agent == 40
+        # 4 sub-agents -> 40 ** 4 = 2_560_000.
+        assert wrapper.joint_action_size == 40 ** NUM_SUBAGENTS
+
+    def test_joint_action_dims_is_concatenation(self):
+        wrapper = _build_wrapper()
+        # Should be 12 dims = [house, mode, signal] * 4.
+        assert len(wrapper.joint_action_dims) == NUM_SUBAGENTS * ACTION_DIM_PER_AGENT
+        for i in range(NUM_SUBAGENTS):
+            offset = i * ACTION_DIM_PER_AGENT
+            assert wrapper.joint_action_dims[offset] == wrapper.action_dims_per_agent[0]
+            assert wrapper.joint_action_dims[offset + 1] == 2
+            assert wrapper.joint_action_dims[offset + 2] == 2
+
+    def test_action_dims_match_scenario_num_houses(self):
+        """For minimal_specialization (10 houses) the per-agent house dim is 10."""
+        wrapper = _build_wrapper()
+        assert wrapper.action_dims_per_agent[0] == 10
+
+
+class TestSplitJointAction:
+    """The wrapper decodes a flat joint action into the right per-agent slots."""
+
+    def test_split_flat_to_per_agent(self):
+        wrapper = _build_wrapper()
+        # Construct a deterministic joint action: agent i goes to house i,
+        # toggles mode/signal as i & 1.
+        flat = []
+        for i in range(NUM_SUBAGENTS):
+            flat.extend([i, i & 1, i & 1])
+        per_agent = wrapper._split_joint_action(np.asarray(flat))
+        assert per_agent.shape == (NUM_SUBAGENTS, ACTION_DIM_PER_AGENT)
+        for i in range(NUM_SUBAGENTS):
+            assert per_agent[i, 0] == i
+            assert per_agent[i, 1] == (i & 1)
+            assert per_agent[i, 2] == (i & 1)
+
+    def test_split_2d_shape_passes_through(self):
+        wrapper = _build_wrapper()
+        per_agent_in = np.zeros((NUM_SUBAGENTS, ACTION_DIM_PER_AGENT), dtype=np.int64)
+        per_agent_in[0] = [3, 1, 1]
+        per_agent_out = wrapper._split_joint_action(per_agent_in)
+        np.testing.assert_array_equal(per_agent_in, per_agent_out)
+
+    def test_split_wrong_size_raises(self):
+        wrapper = _build_wrapper()
+        with pytest.raises(ValueError):
+            wrapper._split_joint_action(np.zeros(NUM_SUBAGENTS * ACTION_DIM_PER_AGENT + 1))
+        with pytest.raises(ValueError):
+            wrapper._split_joint_action(
+                np.zeros((NUM_SUBAGENTS + 1, ACTION_DIM_PER_AGENT))
+            )
+        with pytest.raises(ValueError):
+            wrapper._split_joint_action(np.zeros((2, 2, 2)))
+
+
+class TestStepSemantics:
+    """Wrapped step must match the underlying env on observation and reward."""
+
+    def test_reward_equals_per_agent_sum(self):
+        """The wrapped scalar reward must equal ``sum(per_agent_rewards)``."""
+        wrapper = _build_wrapper(seed=123)
+        # A bunch of random actions; verify the aggregate every step.
+        rng = np.random.default_rng(0)
+        for _ in range(20):
+            joint = np.concatenate(
+                [
+                    [rng.integers(wrapper.action_dims_per_agent[0]) for _ in range(NUM_SUBAGENTS)],
+                ]
+            )
+            # Build a fresh flat joint action with the right shape.
+            flat = []
+            for _i in range(NUM_SUBAGENTS):
+                flat.extend(
+                    [
+                        int(rng.integers(wrapper.action_dims_per_agent[0])),
+                        int(rng.integers(2)),
+                        int(rng.integers(2)),
+                    ]
+                )
+            obs, team_reward, done, info = wrapper.step(np.asarray(flat))
+            per_agent = info["per_agent_rewards"]
+            assert pytest.approx(float(per_agent.sum()), rel=1e-6) == team_reward
+            if done:
+                wrapper.reset()
+
+    def test_obs_shape_consistent_across_reset_and_step(self):
+        wrapper = _build_wrapper(seed=42)
+        stacked0 = wrapper.reset(seed=42)
+        assert stacked0.shape == (NUM_SUBAGENTS, wrapper.obs_dim_per_agent)
+        # Default neutral action to advance one step.
+        zero = np.zeros(NUM_SUBAGENTS * ACTION_DIM_PER_AGENT, dtype=np.int64)
+        stacked1, _r, _d, _info = wrapper.step(zero)
+        assert stacked1.shape == stacked0.shape
+
+
+class TestSpecialistCeilingSmoke:
+    """Driving the wrapper with the hand-tuned specialist must clear the random floor."""
+
+    def test_specialist_beats_random_floor(self):
+        """Specialist should reach per-step team reward >> random floor.
+
+        We do not assert ``gap_closed >= 0.85`` here — that needs the
+        full K=200 re-eval pass. The unit-test budget is ``SMOKE_EPISODES``
+        episodes, which is enough to show specialist >> random but not
+        enough to estimate the converged ceiling. The K=200 evaluation
+        lives in the analyzer + run driver.
+        """
+        wrapper = _build_wrapper(seed=7)
+        scenario = wrapper.env.scenario
+        num_houses = int(getattr(scenario, "num_houses", 10))
+        per_step_team_rewards = []
+        wrapper.reset(seed=7)
+        episodes_done = 0
+        while episodes_done < SMOKE_EPISODES:
+            # Specialist needs the raw dict obs, not the flattened stack.
+            obs_dict = wrapper.env._get_observation()
+            per_agent_actions = specialist_action_joint(
+                obs_dict, num_agents=NUM_SUBAGENTS, num_houses=num_houses
+            )
+            _stacked, team_reward, done, _info = wrapper.step(per_agent_actions)
+            per_step_team_rewards.append(team_reward)
+            if done:
+                wrapper.reset()
+                episodes_done += 1
+        mean_team = float(np.mean(per_step_team_rewards))
+        # Random baseline on minimal_specialization is -96.07; specialist
+        # is -22.07 (analyze_270.py:39-40). Specialist should clear the
+        # random floor by a wide margin even on a tiny sample.
+        assert mean_team > -60.0, (
+            f"specialist mean per-step team reward = {mean_team:.2f} did "
+            "not clear -60 (random floor is -96.07). Either the wrapper "
+            "is corrupting the action plumbing or the specialist baseline "
+            "regressed."
+        )
+
+
+class TestRandomFloorSmoke:
+    """Uniform-random joint actions must produce reward near the documented floor."""
+
+    def test_random_actions_near_floor(self):
+        """Random actions should sit near (but not collapse below) the
+        analyze_270.py random baseline (-96.07).
+
+        We accept a wide band because ``SMOKE_EPISODES`` is small and
+        per-episode variance is high; the test is a sanity floor, not
+        a statistical estimate.
+        """
+        wrapper = _build_wrapper(seed=2026)
+        rng = np.random.default_rng(2026)
+        per_step_team_rewards = []
+        wrapper.reset(seed=2026)
+        episodes_done = 0
+        while episodes_done < SMOKE_EPISODES:
+            flat = []
+            for _i in range(NUM_SUBAGENTS):
+                flat.extend(
+                    [
+                        int(rng.integers(wrapper.action_dims_per_agent[0])),
+                        int(rng.integers(2)),
+                        int(rng.integers(2)),
+                    ]
+                )
+            _s, team_reward, done, _info = wrapper.step(np.asarray(flat))
+            per_step_team_rewards.append(team_reward)
+            if done:
+                wrapper.reset()
+                episodes_done += 1
+        mean_team = float(np.mean(per_step_team_rewards))
+        # Random baseline reference is -96.07. Allow a wide ±60 band on
+        # this short smoke sample.
+        assert -180.0 < mean_team < -20.0, (
+            f"random-action mean per-step team reward = {mean_team:.2f} "
+            "outside the smoke-test sanity band (-180, -20). Either the "
+            "env semantics shifted or the wrapper is corrupting actions."
+        )
+
+
+class TestK200StabilityGate:
+    """The analyzer must refuse to emit a verdict before K=200 re-eval runs.
+
+    This test does NOT run K=200 (that requires the full sweep + a
+    separate re-eval pass). It only asserts the gate exists and trips
+    when the per-seed metrics lack a ``k200_gap_closed`` field.
+    """
+
+    def test_analyzer_blocks_without_k200(self, tmp_path: Path) -> None:
+        # Synthesize a phase-1-only metrics.json (no k200_gap_closed) and
+        # check the analyzer's gate function rejects it.
+        from experiments.p3_specialization.analyze_291 import (
+            _enforce_k200_gate,
+            aggregate_arm,
+        )
+
+        seed_dir = tmp_path / "seed_42"
+        seed_dir.mkdir()
+        # Two iterations of fake training-time metrics.
+        (seed_dir / "metrics.json").write_text(
+            json.dumps(
+                [
+                    {"iteration": 0, "mean_step_reward_team": -90.0},
+                    {"iteration": 1, "mean_step_reward_team": -85.0},
+                ]
+            )
+        )
+        arm = aggregate_arm([seed_dir], "joint_control_ppo")
+        # Default mode (gate enforced): should produce a blocking message.
+        failure = _enforce_k200_gate(arm, allow_phase1_only=False)
+        assert failure is not None
+        assert "K=200" in failure
+
+    def test_analyzer_bypass_flag_disables_gate(self, tmp_path: Path) -> None:
+        from experiments.p3_specialization.analyze_291 import (
+            _enforce_k200_gate,
+            aggregate_arm,
+        )
+
+        seed_dir = tmp_path / "seed_42"
+        seed_dir.mkdir()
+        (seed_dir / "metrics.json").write_text(
+            json.dumps([{"iteration": 0, "mean_step_reward_team": -90.0}])
+        )
+        arm = aggregate_arm([seed_dir], "joint_control_ppo")
+        # Explicit opt-out: gate should pass.
+        failure = _enforce_k200_gate(arm, allow_phase1_only=True)
+        assert failure is None

--- a/tests/test_single_agent_wrapper.py
+++ b/tests/test_single_agent_wrapper.py
@@ -54,7 +54,7 @@ class TestActionSpace:
         # 10 houses, 2 modes, 2 signals -> 40 per sub-agent.
         assert per_agent == 40
         # 4 sub-agents -> 40 ** 4 = 2_560_000.
-        assert wrapper.joint_action_size == 40 ** NUM_SUBAGENTS
+        assert wrapper.joint_action_size == 40**NUM_SUBAGENTS
 
     def test_joint_action_dims_is_concatenation(self):
         wrapper = _build_wrapper()
@@ -99,7 +99,9 @@ class TestSplitJointAction:
     def test_split_wrong_size_raises(self):
         wrapper = _build_wrapper()
         with pytest.raises(ValueError):
-            wrapper._split_joint_action(np.zeros(NUM_SUBAGENTS * ACTION_DIM_PER_AGENT + 1))
+            wrapper._split_joint_action(
+                np.zeros(NUM_SUBAGENTS * ACTION_DIM_PER_AGENT + 1)
+            )
         with pytest.raises(ValueError):
             wrapper._split_joint_action(
                 np.zeros((NUM_SUBAGENTS + 1, ACTION_DIM_PER_AGENT))
@@ -117,11 +119,6 @@ class TestStepSemantics:
         # A bunch of random actions; verify the aggregate every step.
         rng = np.random.default_rng(0)
         for _ in range(20):
-            joint = np.concatenate(
-                [
-                    [rng.integers(wrapper.action_dims_per_agent[0]) for _ in range(NUM_SUBAGENTS)],
-                ]
-            )
             # Build a fresh flat joint action with the right shape.
             flat = []
             for _i in range(NUM_SUBAGENTS):


### PR DESCRIPTION
## Summary
Adds a single-controller joint-action wrapper over ``BucketBrigadeEnv`` so one controller emits the joint action for all 4 sub-agents on ``minimal_specialization``. This is the scope-determining probe for the misaligned-gradient thesis: does the basin trap that IPPO hits at ``gap_closed ~ 0.18`` (#270/#271) survive when multi-agent credit assignment is removed as a confound?

Closes #291. Joint-action wrapper distinct from #286 macro-actions.

## Changes
- ``bucket_brigade/envs/single_agent_wrapper.py``: ``SingleAgentJointWrapper`` exposing a flat factorized joint action space (``[10, 2, 2] * 4``) and team-sum scalar reward over the unchanged ``minimal_specialization`` env.
- ``experiments/p3_specialization/train_single_agent.py``: single-controller PPO training script matching the #270 budget (50 iter * 2048 steps * 3 seeds) with ``--joint-control`` flag.
- ``experiments/p3_specialization/run_issue291_joint_control.sh``: 3-seed sweep driver (CPU-bound; do NOT run locally per CLAUDE.md).
- ``experiments/p3_specialization/analyze_291.py``: H0/H1 verdict reporter (``gap_closed >= 0.5`` -> H0 multi-agent-specific; ``<= 0.25`` -> H1 horizon-based; in between -> undecided), with a K=200 re-eval stability gate.
- ``tests/test_single_agent_wrapper.py``: wrapper unit tests + specialist-ceiling + random-floor smoke + K=200 gate tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Joint-action wrapper over ``BucketBrigadeEnv(num_agents=4)`` on ``minimal_specialization`` | Yes | ``SingleAgentJointWrapper`` constructed via ``get_scenario_by_name('minimal_specialization', num_agents=4)``; env mechanics unchanged. |
| Reward = ``sum(per_agent_rewards)`` | Yes | ``test_reward_equals_per_agent_sum`` passes. |
| Action-space cardinality = product of per-agent sizes | Yes | ``test_joint_action_size_equals_product`` (40 ** 4 = 2,560,000) passes. |
| Joint action splits to ``[N, 3]`` per-agent | Yes | ``test_split_flat_to_per_agent`` + ``test_split_2d_shape_passes_through`` pass. |
| Specialist-ceiling smoke | Yes | ``test_specialist_beats_random_floor`` passes (mean per-step team >> random floor). |
| Random-floor smoke | Yes | ``test_random_actions_near_floor`` passes. |
| K=200 re-eval stability gate exists | Yes | ``test_analyzer_blocks_without_k200`` + ``test_analyzer_bypass_flag_disables_gate`` pass. |
| Budget matches #270 (50 iter * 2048 * 3 seeds) | Yes | Defaults baked into ``train_single_agent.py`` and ``run_issue291_joint_control.sh``. |
| Distinct from #286 (macro-actions) and #292 (toy dilemma) | Yes | Docstring + commit + PR body call out the scope difference; this wraps all 4 agents into one joint controller, not a single agent into macro options. |

## Test Plan
- ``pytest tests/test_single_agent_wrapper.py`` -> 12 passed locally.
- ``pytest tests/test_joint_trainer.py tests/test_environment.py tests/test_single_agent_wrapper.py`` -> 94 passed, 4 skipped (unrelated), no regressions.
- 1-iter training smoke: ``train_single_agent.py --num-iterations 1 --rollout-steps 256`` produced ``metrics.json`` / ``config.json`` / ``policies/controller.pt`` with mean per-step team reward = -78.9 (between random floor -96 and specialist -22, as expected for fresh init).
- Analyzer smoke: ``analyze_291.py`` correctly blocks verdict without K=200 (``gate_failed``) and emits H0/H1 verdict with ``--allow-phase1-only``.
- Sweep itself NOT run (per user constraints; CPU-bound, run on ``COMPUTE_HOST_PRIMARY`` per CLAUDE.md).