### PR TITLE
exp(p3): minimal 2-agent iterated dilemma — basin-trap demo

### DIFF
--- a/experiments/p3_specialization/minimal_dilemma/__init__.py
+++ b/experiments/p3_specialization/minimal_dilemma/__init__.py
@@ -1,0 +1,22 @@
+"""Minimal 2-player iterated public-goods dilemma — toy basin-trap demo (issue #292).
+
+This sub-package implements a referee-friendly Python-only reproduction of the
+basin-trap signature observed in the bucket-brigade env (issues #270, #271).
+The demo target (post-#271 reframing): PPO from random init converges to
+mutual-defect on a 2-player iterated public-goods game where the cooperative
+equilibrium yields strictly higher reward; BC-init from `always_cooperate`
+holds the cooperative basin under PPO continuation; best-of-N random nets do
+NOT bridge to the cooperative basin under the K=20 → K=200 stability protocol
+validated in #271.
+
+Modules:
+    env: 2-player iterated public-goods env (Option A; m=1.6, 50-step episodes).
+    specialists: hand-coded `always_cooperate` and `tit_for_tat` callables.
+    train_ippo: thin wrapper invoking `JointPPOTrainer` on the dilemma env.
+    bc_init: BC pipeline adapted from `bc_init.py` for the dilemma env.
+    best_of_n: random-init best-of-N with K=20 → K=200 stability re-eval.
+    verdict: 4-gate verdict classifier (basin_trap vs anti_attractor vs null).
+
+See issue #292 (`gh issue view 292 --comments`) for full spec and `run_all.sh`
+for the orchestration entry point. Heavy runs go on `COMPUTE_HOST_PRIMARY`.
+"""

--- a/experiments/p3_specialization/minimal_dilemma/bc_init.py
+++ b/experiments/p3_specialization/minimal_dilemma/bc_init.py
@@ -1,0 +1,395 @@
+"""BC + eval gate for the minimal dilemma (issue #292).
+
+Adapts ``experiments/p3_specialization/bc_init.py`` (issue #270) to the
+:class:`MinimalDilemmaEnv` with the new specialists. Three phases mirror the
+bucket-brigade BC pipeline so the verdict semantics are directly comparable:
+
+1. **Demo gathering** — roll the chosen specialist (``always_cooperate``
+   or ``tit_for_tat``) on the dilemma env until we have ``--num-pairs``
+   per-agent ``(flat_obs, action)`` tuples. Observations are flattened
+   with :func:`flatten_dict_obs` including the per-agent identity one-hot
+   tail (#204) so the resulting state dicts plug into ``trainer.policies``
+   with zero shape massaging.
+
+2. **Supervised fit** — one :class:`PolicyNetwork` per agent, cross-entropy
+   on the single ``Discrete(2)`` head, Adam, ``--epochs`` (default 10).
+
+3. **Eval gate** — ``--eval-episodes`` deterministic-argmax episodes against
+   the env. Pass if action-prediction accuracy ≥ ``--min-action-accuracy``
+   AND mean per-step per-agent reward ≥ ``--min-mean-reward`` (defaults
+   reflect always_cooperate self-play: 99% accuracy, 0.5 per-step). The
+   script exits non-zero on failure so the downstream PPO continuation
+   isn't launched from a bad init.
+
+Per-agent state dicts are saved to ``<output_dir>/agent_{i}.pt``, matching
+the filename layout :func:`train_one_cell` (in ``train_ippo.py``) expects
+for ``--bc-init-checkpoint-dir``.
+
+Usage::
+
+    # always_cooperate fit (default specialist)
+    uv run python -m experiments.p3_specialization.minimal_dilemma.bc_init \\
+        --output-dir experiments/p3_specialization/minimal_dilemma/results/bc_alwaysC \\
+        --num-pairs-per-agent 5000
+
+    # tit_for_tat fit
+    uv run python -m experiments.p3_specialization.minimal_dilemma.bc_init \\
+        --specialist tit_for_tat --output-dir .../bc_tft
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+from bucket_brigade.training.joint_trainer import flatten_dict_obs
+from bucket_brigade.training.networks import PolicyNetwork
+
+from experiments.p3_specialization.minimal_dilemma.env import (
+    ACTION_COOPERATE,
+    EPISODE_LENGTH,
+    MULTIPLIER,
+    MinimalDilemmaEnv,
+    NUM_AGENTS,
+    REWARD_MUTUAL_COOPERATE,
+    REWARD_MUTUAL_DEFECT,
+)
+from experiments.p3_specialization.minimal_dilemma.specialists import (
+    always_cooperate,
+    tit_for_tat,
+)
+
+
+ACTION_DIMS: List[int] = [2]
+
+# Specialist registry: name → callable. Used by the CLI to pick a fit target.
+SPECIALISTS = {
+    "always_cooperate": always_cooperate,
+    "tit_for_tat": tit_for_tat,
+}
+
+
+def _gap_closed(mean_per_agent: float) -> float:
+    """Fraction of the defect→cooperate gap closed (mutual play self-evaluation)."""
+    span = REWARD_MUTUAL_COOPERATE - REWARD_MUTUAL_DEFECT
+    if span <= 0:
+        return float("nan")
+    return (mean_per_agent - REWARD_MUTUAL_DEFECT) / span
+
+
+def gather_demos(
+    specialist: Callable,
+    num_pairs_per_agent: int,
+    seed: int,
+    multiplier: float = MULTIPLIER,
+    episode_length: int = EPISODE_LENGTH,
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Roll the specialist until we have ``num_pairs_per_agent`` demos per agent.
+
+    Mirrors :func:`experiments.p3_specialization.bc_init.gather_demos`. Returns
+    ``(obs_per_agent, act_per_agent)`` with the same dtype and shape contract.
+    """
+    env = MinimalDilemmaEnv(multiplier=multiplier, episode_length=episode_length)
+    rng = np.random.default_rng(seed)
+
+    obs_buf: List[List[np.ndarray]] = [[] for _ in range(NUM_AGENTS)]
+    act_buf: List[List[np.ndarray]] = [[] for _ in range(NUM_AGENTS)]
+
+    # Each step contributes exactly one (obs, action) pair per agent (the
+    # specialist is deterministic). Stop when agent 0 reaches the target.
+    while len(obs_buf[0]) < num_pairs_per_agent:
+        obs = env.reset(seed=int(rng.integers(0, 2**31 - 1)))
+        while not env.done:
+            joint = specialist(obs, num_agents=NUM_AGENTS)
+            for i in range(NUM_AGENTS):
+                obs_buf[i].append(
+                    flatten_dict_obs(obs, agent_id=i, num_agents=NUM_AGENTS)
+                )
+                act_buf[i].append(joint[i])
+            obs, _, _, _ = env.step(joint)
+            if len(obs_buf[0]) >= num_pairs_per_agent:
+                break
+
+    obs_per_agent = [np.stack(buf, axis=0).astype(np.float32) for buf in obs_buf]
+    act_per_agent = [np.stack(buf, axis=0).astype(np.int64) for buf in act_buf]
+    return obs_per_agent, act_per_agent
+
+
+def bc_fit_one_agent(
+    obs: np.ndarray,
+    acts: np.ndarray,
+    obs_dim: int,
+    hidden_size: int,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    device: str,
+    seed: int,
+) -> Tuple[PolicyNetwork, List[float]]:
+    """Supervised fit of one PolicyNetwork to ``(obs, acts)``.
+
+    Mirrors :func:`experiments.p3_specialization.bc_init.bc_fit_one_agent` but
+    for the single-head dilemma action space (``ACTION_DIMS = [2]``).
+    """
+    torch.manual_seed(seed)
+    policy = PolicyNetwork(
+        obs_dim=obs_dim, action_dims=ACTION_DIMS, hidden_size=hidden_size
+    ).to(device)
+    opt = torch.optim.Adam(policy.parameters(), lr=lr)
+
+    x_t = torch.from_numpy(obs).float().to(device)
+    a_t = torch.from_numpy(acts).long().to(device)
+    ds = TensorDataset(x_t, a_t)
+    dl = DataLoader(ds, batch_size=batch_size, shuffle=True)
+
+    epoch_losses: List[float] = []
+    for _ in range(epochs):
+        batch_losses: List[float] = []
+        for x, a in dl:
+            logits, _ = policy(x)
+            # Single head — sum-of-heads collapses to one CE term.
+            loss = F.cross_entropy(logits[0], a[:, 0])
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            batch_losses.append(float(loss.item()))
+        epoch_losses.append(float(np.mean(batch_losses)))
+    return policy, epoch_losses
+
+
+def action_accuracy(
+    policy: PolicyNetwork,
+    obs: np.ndarray,
+    acts: np.ndarray,
+    device: str,
+) -> float:
+    """Action-prediction accuracy of the BC policy on held-out ``(obs, acts)``."""
+    policy.eval()
+    with torch.no_grad():
+        x = torch.from_numpy(obs).float().to(device)
+        logits, _ = policy(x)
+        pred = logits[0].argmax(dim=-1).cpu().numpy()
+    return float((pred == acts[:, 0]).mean())
+
+
+def evaluate_policies(
+    policies: List[PolicyNetwork],
+    num_episodes: int,
+    device: str,
+    multiplier: float = MULTIPLIER,
+    episode_length: int = EPISODE_LENGTH,
+    seed: int = 0,
+) -> dict:
+    """Roll the BC policies (argmax) for ``num_episodes`` episodes.
+
+    Returns mean per-step per-agent reward and gap_closed (defect → cooperate
+    self-play span).
+    """
+    env = MinimalDilemmaEnv(multiplier=multiplier, episode_length=episode_length)
+
+    for p in policies:
+        p.eval()
+
+    ep_per_step: List[float] = []
+    coop_counts: List[float] = []
+    with torch.no_grad():
+        for ep in range(num_episodes):
+            obs = env.reset(seed=seed + ep)
+            total = 0.0
+            n_steps = 0
+            n_coop = 0
+            while not env.done:
+                joint_rows: List[List[int]] = []
+                for i in range(NUM_AGENTS):
+                    x = flatten_dict_obs(obs, agent_id=i, num_agents=NUM_AGENTS)
+                    xt = torch.from_numpy(x).float().to(device).unsqueeze(0)
+                    actions, _, _ = policies[i].get_action(xt, deterministic=True)
+                    a_i = int(actions[0].item())
+                    joint_rows.append([a_i])
+                    if a_i == ACTION_COOPERATE:
+                        n_coop += 1
+                joint = np.asarray(joint_rows, dtype=np.int64)
+                obs, rewards, _, _ = env.step(joint)
+                total += float(rewards.sum())
+                n_steps += 1
+            if n_steps > 0:
+                # per-step per-agent reward = team_total / (n_steps * num_agents).
+                ep_per_step.append(total / (n_steps * NUM_AGENTS))
+                coop_counts.append(n_coop / (n_steps * NUM_AGENTS))
+
+    per_step = np.asarray(ep_per_step, dtype=np.float64)
+    return {
+        "n_episodes": int(per_step.size),
+        "mean_step_reward_per_agent": float(per_step.mean())
+        if per_step.size > 0
+        else 0.0,
+        "std_step_reward_per_agent": float(per_step.std(ddof=1))
+        if per_step.size > 1
+        else 0.0,
+        "mean_cooperation_fraction": float(np.mean(coop_counts))
+        if coop_counts
+        else 0.0,
+        "gap_closed": _gap_closed(float(per_step.mean()))
+        if per_step.size > 0
+        else float("nan"),
+        "reward_mutual_defect_ref": REWARD_MUTUAL_DEFECT,
+        "reward_mutual_cooperate_ref": REWARD_MUTUAL_COOPERATE,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--specialist",
+        choices=sorted(SPECIALISTS.keys()),
+        default="always_cooperate",
+        help="Which hand-coded specialist to clone.",
+    )
+    p.add_argument("--num-pairs-per-agent", type=int, default=5000)
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--batch-size", type=int, default=64)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--hidden-size", type=int, default=64)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--eval-episodes", type=int, default=20)
+    p.add_argument(
+        "--min-action-accuracy",
+        type=float,
+        default=0.99,
+        help="Test-set accuracy threshold for the BC fit gate (issue spec).",
+    )
+    p.add_argument(
+        "--min-mean-reward",
+        type=float,
+        default=0.5,
+        help=(
+            "Per-step per-agent reward floor for the BC eval gate. For the "
+            "always_cooperate specialist this corresponds to ≥ 0.5 (mutual-C "
+            "yields 0.6); set lower if cloning tit_for_tat with noise."
+        ),
+    )
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--device", default="cpu")
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    specialist = SPECIALISTS[args.specialist]
+
+    print(
+        f"== minimal_dilemma BC: specialist={args.specialist} "
+        f"num_pairs_per_agent={args.num_pairs_per_agent} epochs={args.epochs} "
+        f"seed={args.seed} =="
+    )
+
+    # ----- Phase 1: gather demos -----
+    print(f"[1/3] Gathering demos (target={args.num_pairs_per_agent}/agent)...")
+    obs_per_agent, act_per_agent = gather_demos(
+        specialist=specialist,
+        num_pairs_per_agent=args.num_pairs_per_agent,
+        seed=args.seed,
+    )
+    obs_dim = int(obs_per_agent[0].shape[1])
+    print(
+        f"  collected per-agent obs shape: {obs_per_agent[0].shape}, obs_dim={obs_dim}"
+    )
+
+    # ----- Phase 2: BC fit per agent (90/10 train/test split) -----
+    print(f"[2/3] Fitting {NUM_AGENTS} per-agent policies...")
+    policies: List[PolicyNetwork] = []
+    per_agent_loss_history: List[List[float]] = []
+    per_agent_test_acc: List[float] = []
+    for i in range(NUM_AGENTS):
+        n = len(obs_per_agent[i])
+        n_train = int(0.9 * n)
+        # Deterministic split (no shuffle here — the dataloader handles shuffle
+        # inside training). Holding out the *tail* of the demo stream gives a
+        # disjoint set of episode segments per agent.
+        x_train, x_test = obs_per_agent[i][:n_train], obs_per_agent[i][n_train:]
+        a_train, a_test = act_per_agent[i][:n_train], act_per_agent[i][n_train:]
+        policy, losses = bc_fit_one_agent(
+            obs=x_train,
+            acts=a_train,
+            obs_dim=obs_dim,
+            hidden_size=args.hidden_size,
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            device=args.device,
+            seed=args.seed + i,
+        )
+        policies.append(policy)
+        per_agent_loss_history.append(losses)
+        acc = action_accuracy(policy, x_test, a_test, args.device)
+        per_agent_test_acc.append(acc)
+        print(f"  agent {i}: final_loss={losses[-1]:.5f} test_accuracy={acc:.4f}")
+
+    # ----- Phase 3: save + eval gate -----
+    print(f"[3/3] Saving policies and evaluating ({args.eval_episodes} episodes)...")
+    for i, policy in enumerate(policies):
+        torch.save(policy.state_dict(), args.output_dir / f"agent_{i}.pt")
+
+    eval_stats = evaluate_policies(
+        policies=policies,
+        num_episodes=args.eval_episodes,
+        device=args.device,
+        seed=args.seed + 1000,
+    )
+
+    min_test_acc = float(min(per_agent_test_acc))
+    summary = {
+        "issue": 292,
+        "specialist": args.specialist,
+        "num_pairs_per_agent": args.num_pairs_per_agent,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "lr": args.lr,
+        "hidden_size": args.hidden_size,
+        "obs_dim": obs_dim,
+        "action_dims": ACTION_DIMS,
+        "seed": args.seed,
+        "per_agent_loss_history": per_agent_loss_history,
+        "per_agent_test_accuracy": per_agent_test_acc,
+        "min_test_accuracy": min_test_acc,
+        "eval": eval_stats,
+        "min_action_accuracy_gate": args.min_action_accuracy,
+        "min_mean_reward_gate": args.min_mean_reward,
+        "accuracy_gate_passed": bool(min_test_acc >= args.min_action_accuracy),
+        "reward_gate_passed": bool(
+            eval_stats["mean_step_reward_per_agent"] >= args.min_mean_reward
+        ),
+    }
+    summary["gate_passed"] = bool(
+        summary["accuracy_gate_passed"] and summary["reward_gate_passed"]
+    )
+
+    with (args.output_dir / "bc_summary.json").open("w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(
+        f"  eval: per_agent={eval_stats['mean_step_reward_per_agent']:.3f} "
+        f"coop_frac={eval_stats['mean_cooperation_fraction']:.3f} "
+        f"gap_closed={eval_stats['gap_closed']:.3f}"
+    )
+    print(
+        f"  gates: accuracy={summary['accuracy_gate_passed']} "
+        f"(min={min_test_acc:.4f}, threshold={args.min_action_accuracy}); "
+        f"reward={summary['reward_gate_passed']} "
+        f"(mean={eval_stats['mean_step_reward_per_agent']:.3f}, "
+        f"threshold={args.min_mean_reward})"
+    )
+
+    if not summary["gate_passed"]:
+        print("FAIL: BC eval gate failed. PPO continuation should NOT be launched.")
+        raise SystemExit(2)
+    print("OK: BC eval gates passed. Safe for PPO continuation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/minimal_dilemma/best_of_n.py
+++ b/experiments/p3_specialization/minimal_dilemma/best_of_n.py
@@ -1,0 +1,407 @@
+"""Random-init best-of-N with K=20 → K=200 stability re-eval (issue #292).
+
+Adapts ``experiments/p3_specialization/diagnostics/random_mlp_search.py``
+(issue #271) to the minimal-dilemma env. The K=20 → K=200 two-phase protocol
+is **mandatory** per the issue spec — it's the safeguard that flagged the
+false-positive anti-attractor signal in the bucket-brigade version. Failing
+to re-eval at K=200 would let a lucky 20-episode draw masquerade as a stable
+cooperative basin.
+
+Protocol:
+
+1. **Phase 1 (K=20):** sample ``--seeds`` (default 1000) random-init policy
+   bundles. For each seed evaluate ``--episodes-per-seed`` (default 20)
+   episodes on the dilemma env and record mean per-step per-agent reward.
+2. **Phase 2 (K=200):** take the top ``--top-frac`` (default 1%) of seeds
+   and re-evaluate with ``--restability-episodes`` (default 200) **disjoint**
+   episodes (different episode seeds than phase 1).
+3. **Stability gate (verdict input):** the random-init best-of-N arm is
+   "honest" only if top-1% phase-2 mean ≤ phase-1 mean + slack. The
+   verdict classifier (``verdict.py``) consumes this to flag basin-trap
+   vs anti-attractor.
+
+Per-agent init protocol: ``--protocol independent`` (default) uses
+``seed * NUM_AGENTS + i`` for agent ``i`` so each policy net is drawn from a
+distinct slice of parameter space. ``--protocol shared`` matches the BC-init
+experiment's single-seed broadcast.
+
+Episodes are short (50 steps) and policies are tiny (a 7-d input MLP), so the
+per-seed cost is microscopic and we run sequentially — no multiprocessing
+needed for the minimal env. (The bucket-brigade version forks because each
+episode is ~3-12 nights of Rust env.)
+
+Usage::
+
+    # smoke (~15 sec on laptop)
+    uv run python -m experiments.p3_specialization.minimal_dilemma.best_of_n \\
+        --seeds 50 --episodes-per-seed 5 --restability-episodes 10 \\
+        --output-dir /tmp/dilemma_bon_smoke
+
+    # full run on COMPUTE_HOST_PRIMARY (~5-15 min)
+    uv run python -m experiments.p3_specialization.minimal_dilemma.best_of_n \\
+        --seeds 1000 --episodes-per-seed 20 --restability-episodes 200 \\
+        --output-dir experiments/p3_specialization/minimal_dilemma/results/best_of_n
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import torch
+
+from bucket_brigade.training.joint_trainer import flatten_dict_obs
+from bucket_brigade.training.networks import PolicyNetwork
+
+from experiments.p3_specialization.minimal_dilemma.env import (
+    ACTION_COOPERATE,
+    EPISODE_LENGTH,
+    MULTIPLIER,
+    MinimalDilemmaEnv,
+    NUM_AGENTS,
+    REWARD_MUTUAL_COOPERATE,
+    REWARD_MUTUAL_DEFECT,
+)
+
+
+HIDDEN_SIZE = 64
+ACTION_DIMS: List[int] = [2]
+
+
+def gap_closed(per_agent_per_step: float) -> float:
+    """Fraction of the defect→cooperate self-play gap closed."""
+    span = REWARD_MUTUAL_COOPERATE - REWARD_MUTUAL_DEFECT
+    if span <= 0:
+        return float("nan")
+    return float((per_agent_per_step - REWARD_MUTUAL_DEFECT) / span)
+
+
+def _build_policies(seed: int, obs_dim: int, protocol: str) -> List[PolicyNetwork]:
+    """Instantiate one PolicyNetwork per agent under the chosen init protocol."""
+    policies: List[PolicyNetwork] = []
+    if protocol == "shared":
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        for _ in range(NUM_AGENTS):
+            policies.append(
+                PolicyNetwork(
+                    obs_dim=obs_dim,
+                    action_dims=ACTION_DIMS,
+                    hidden_size=HIDDEN_SIZE,
+                )
+            )
+    elif protocol == "independent":
+        for i in range(NUM_AGENTS):
+            agent_seed = seed * NUM_AGENTS + i
+            torch.manual_seed(agent_seed)
+            np.random.seed(agent_seed)
+            policies.append(
+                PolicyNetwork(
+                    obs_dim=obs_dim,
+                    action_dims=ACTION_DIMS,
+                    hidden_size=HIDDEN_SIZE,
+                )
+            )
+    else:
+        raise ValueError(f"Unknown protocol: {protocol!r}")
+    for p in policies:
+        p.eval()
+    return policies
+
+
+def _evaluate_seed(
+    seed: int,
+    n_episodes: int,
+    protocol: str,
+    episode_seed_base: int,
+    multiplier: float = MULTIPLIER,
+    episode_length: int = EPISODE_LENGTH,
+) -> Dict[str, object]:
+    """Evaluate one random-init policy bundle on the dilemma env.
+
+    Returns a dict with the same shape as the worker output in #271's
+    ``random_mlp_search.py`` so the verdict consumer is template-compatible.
+    """
+    env = MinimalDilemmaEnv(multiplier=multiplier, episode_length=episode_length)
+    obs_dim = flatten_dict_obs(
+        env.reset(seed=0), agent_id=0, num_agents=NUM_AGENTS
+    ).shape[0]
+    policies = _build_policies(seed, obs_dim, protocol)
+
+    per_step: List[float] = []
+    coop_fracs: List[float] = []
+    entropy_samples: List[float] = []
+
+    for ep in range(n_episodes):
+        # Disjoint episode-seed stream: keyed by (base, seed, episode index).
+        ep_seed = episode_seed_base + seed * 100_000 + ep
+        obs = env.reset(seed=ep_seed)
+        obs_rows = np.stack(
+            [
+                flatten_dict_obs(obs, agent_id=i, num_agents=NUM_AGENTS)
+                for i in range(NUM_AGENTS)
+            ],
+            axis=0,
+        )
+        total_reward = 0.0
+        n_steps = 0
+        n_coop = 0
+        first_step = True
+        while not env.done:
+            obs_t = torch.from_numpy(obs_rows)
+            joint_action = np.zeros((NUM_AGENTS, len(ACTION_DIMS)), dtype=np.int64)
+            with torch.no_grad():
+                for i, policy in enumerate(policies):
+                    a, _, ent, _ = policy.get_action_and_value(obs_t[i : i + 1])
+                    a_i = int(a[0].cpu().item())
+                    joint_action[i] = a_i
+                    if first_step:
+                        entropy_samples.append(float(ent.item()))
+                    if a_i == ACTION_COOPERATE:
+                        n_coop += 1
+            next_obs, rewards, _, _ = env.step(joint_action)
+            total_reward += float(rewards.sum())
+            n_steps += 1
+            first_step = False
+            if not env.done:
+                obs_rows = np.stack(
+                    [
+                        flatten_dict_obs(next_obs, agent_id=i, num_agents=NUM_AGENTS)
+                        for i in range(NUM_AGENTS)
+                    ],
+                    axis=0,
+                )
+        # Per-agent per-step reward = team_sum / (n_steps * num_agents).
+        per_step.append(total_reward / max(1, n_steps * NUM_AGENTS))
+        coop_fracs.append(n_coop / max(1, n_steps * NUM_AGENTS))
+
+    arr = np.asarray(per_step, dtype=np.float64)
+    return {
+        "seed": int(seed),
+        "protocol": protocol,
+        "per_episode": [float(x) for x in arr],
+        "mean_per_step": float(arr.mean()),
+        "std_per_step": float(arr.std(ddof=1)) if len(arr) > 1 else 0.0,
+        "coop_fraction_mean": float(np.mean(coop_fracs)) if coop_fracs else 0.0,
+        "entropy": float(np.mean(entropy_samples)) if entropy_samples else float("nan"),
+    }
+
+
+def _bootstrap_ci(
+    arr: np.ndarray, n_boot: int = 5000, alpha: float = 0.05, rng_seed: int = 0
+) -> Tuple[float, float]:
+    """Percentile bootstrap CI for the mean. Adapted from #271's implementation."""
+    rng = np.random.default_rng(rng_seed)
+    n = len(arr)
+    if n == 0:
+        return float("nan"), float("nan")
+    boots = np.empty(n_boot, dtype=np.float64)
+    for i in range(n_boot):
+        boots[i] = arr[rng.integers(0, n, size=n)].mean()
+    return (
+        float(np.percentile(boots, 100 * alpha / 2)),
+        float(np.percentile(boots, 100 * (1 - alpha / 2))),
+    )
+
+
+def stability_gate(
+    top_phase1: Sequence[Dict[str, object]],
+    top_phase2: Sequence[Dict[str, object]],
+    slack: float = 0.05,
+) -> Dict[str, object]:
+    """K=20 → K=200 stability gate (the #271 false-positive safeguard).
+
+    The gate **passes** (= no random-net bridge to cooperation, basin-trap
+    consistent) iff the top-1% phase-2 mean is no higher than the phase-1
+    mean plus ``slack``. A failure (phase-2 mean >> phase-1) would mean a
+    random net stably reaches cooperative reward — i.e. cooperation is
+    structurally accessible without gradient descent, falsifying basin-trap.
+
+    Args:
+        top_phase1: phase-1 results for the seeds re-evaluated in phase 2.
+        top_phase2: corresponding phase-2 results (same seeds, K=200).
+        slack: tolerance for noise (per-step reward units). Default 0.05.
+
+    Returns:
+        Dict with ``passed``, ``phase1_mean``, ``phase2_mean``,
+        ``phase2_max``, ``drift`` (phase2_mean − phase1_mean), and the
+        verdict-ready ``random_bridge_top1_mean`` (phase-2 estimate of
+        random-net best-of-N reward, used by the 4-gate verdict).
+    """
+    p1_means = np.asarray([r["mean_per_step"] for r in top_phase1], dtype=np.float64)
+    p2_means = np.asarray([r["mean_per_step"] for r in top_phase2], dtype=np.float64)
+    phase1_mean = float(p1_means.mean()) if p1_means.size else float("nan")
+    phase2_mean = float(p2_means.mean()) if p2_means.size else float("nan")
+    phase2_max = float(p2_means.max()) if p2_means.size else float("nan")
+    drift = phase2_mean - phase1_mean
+    # Drift is *negative* when phase-2 confirms phase-1 was lucky. We want
+    # ``phase2_mean <= phase1_mean + slack``: i.e. no upward drift beyond
+    # slack. The bridge fails (= basin-trap consistent) when this holds.
+    bridge_failed = bool(drift <= slack)
+    return {
+        "passed": bridge_failed,  # "passed" = random bridge did NOT happen
+        "phase1_mean": phase1_mean,
+        "phase2_mean": phase2_mean,
+        "phase2_max": phase2_max,
+        "drift": float(drift),
+        "slack": float(slack),
+        "random_bridge_top1_mean": phase2_mean,
+        "random_bridge_top1_max": phase2_max,
+        "random_bridge_top1_gap_closed": gap_closed(phase2_mean),
+    }
+
+
+def _run_protocol(
+    protocol: str,
+    seeds: Sequence[int],
+    episodes_per_seed: int,
+    restability_episodes: int,
+    top_frac: float,
+    multiplier: float,
+    episode_length: int,
+    out_dir: Path,
+) -> Dict[str, object]:
+    """Execute the full best-of-N + stability re-eval for one init protocol."""
+    print(f"\n=== Protocol: {protocol} ===")
+    print(f"Phase 1: {len(seeds)} seeds x {episodes_per_seed} episodes")
+
+    phase1_results: List[Dict[str, object]] = []
+    for idx, s in enumerate(seeds, 1):
+        phase1_results.append(
+            _evaluate_seed(
+                seed=int(s),
+                n_episodes=episodes_per_seed,
+                protocol=protocol,
+                episode_seed_base=0,
+                multiplier=multiplier,
+                episode_length=episode_length,
+            )
+        )
+        if idx % max(1, len(seeds) // 10) == 0:
+            print(f"  [{protocol}] phase-1 progress: {idx}/{len(seeds)}")
+
+    phase1_results.sort(key=lambda r: r["mean_per_step"], reverse=True)
+    means = np.asarray([r["mean_per_step"] for r in phase1_results])
+    n_top = max(1, int(round(top_frac * len(phase1_results))))
+    top = phase1_results[:n_top]
+    print(
+        f"Phase 1 complete. mean={means.mean():.3f} std={means.std():.3f}, "
+        f"top-{int(top_frac * 100)}% threshold={top[-1]['mean_per_step']:.3f}"
+    )
+
+    print(f"Phase 2: re-eval top-{n_top} seeds with {restability_episodes} episodes")
+    phase2_results: List[Dict[str, object]] = []
+    for idx, r in enumerate(top, 1):
+        phase2_results.append(
+            _evaluate_seed(
+                seed=int(r["seed"]),
+                n_episodes=restability_episodes,
+                protocol=protocol,
+                episode_seed_base=7_000_000,
+                multiplier=multiplier,
+                episode_length=episode_length,
+            )
+        )
+        if idx % max(1, len(top) // 5) == 0:
+            print(f"  [{protocol}] phase-2 progress: {idx}/{len(top)}")
+
+    # Attach bootstrap CIs.
+    for r in phase2_results:
+        arr = np.asarray(r["per_episode"], dtype=np.float64)
+        lo, hi = _bootstrap_ci(arr)
+        r["ci95_lo"] = lo
+        r["ci95_hi"] = hi
+    phase2_results.sort(key=lambda r: r["mean_per_step"], reverse=True)
+
+    gate = stability_gate(top, phase2_results)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with (out_dir / f"results_{protocol}.json").open("w") as f:
+        json.dump(
+            [
+                {
+                    "seed": r["seed"],
+                    "mean_per_step": r["mean_per_step"],
+                    "std_per_step": r["std_per_step"],
+                    "coop_fraction_mean": r["coop_fraction_mean"],
+                    "entropy": r["entropy"],
+                }
+                for r in phase1_results
+            ],
+            f,
+            indent=2,
+        )
+    with (out_dir / f"top_candidates_{protocol}.json").open("w") as f:
+        json.dump(top, f, indent=2)
+    with (out_dir / f"stability_{protocol}.json").open("w") as f:
+        json.dump(phase2_results, f, indent=2)
+
+    summary = {
+        "protocol": protocol,
+        "n_seeds": len(phase1_results),
+        "episodes_per_seed_phase1": int(episodes_per_seed),
+        "episodes_per_seed_phase2": int(restability_episodes),
+        "n_top": int(n_top),
+        "population_mean": float(means.mean()),
+        "population_std": float(means.std(ddof=1)) if len(means) > 1 else 0.0,
+        "stability_gate": gate,
+    }
+    return summary
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--seeds", type=int, default=1000)
+    p.add_argument("--episodes-per-seed", type=int, default=20)
+    p.add_argument("--restability-episodes", type=int, default=200)
+    p.add_argument("--top-frac", type=float, default=0.01)
+    p.add_argument(
+        "--protocol",
+        choices=["independent", "shared", "both"],
+        default="independent",
+        help="Per-agent init protocol; 'both' runs each in turn.",
+    )
+    p.add_argument("--multiplier", type=float, default=MULTIPLIER)
+    p.add_argument("--episode-length", type=int, default=EPISODE_LENGTH)
+    p.add_argument("--seed-offset", type=int, default=0)
+    p.add_argument("--output-dir", type=Path, required=True)
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    seeds = list(range(args.seed_offset, args.seed_offset + args.seeds))
+
+    protocols = (
+        ["independent", "shared"] if args.protocol == "both" else [args.protocol]
+    )
+
+    summaries: Dict[str, object] = {}
+    for proto in protocols:
+        summaries[proto] = _run_protocol(
+            protocol=proto,
+            seeds=seeds,
+            episodes_per_seed=args.episodes_per_seed,
+            restability_episodes=args.restability_episodes,
+            top_frac=args.top_frac,
+            multiplier=args.multiplier,
+            episode_length=args.episode_length,
+            out_dir=args.output_dir,
+        )
+
+    with (args.output_dir / "summary.json").open("w") as f:
+        json.dump(summaries, f, indent=2)
+    print(f"\nWrote {args.output_dir}/summary.json")
+    for proto, s in summaries.items():
+        g = s["stability_gate"]
+        print(
+            f"  [{proto}] stability_gate.passed={g['passed']} "
+            f"phase1_mean={g['phase1_mean']:.3f} "
+            f"phase2_mean={g['phase2_mean']:.3f} "
+            f"drift={g['drift']:+.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/minimal_dilemma/env.py
+++ b/experiments/p3_specialization/minimal_dilemma/env.py
@@ -1,0 +1,234 @@
+"""2-player iterated public-goods dilemma (issue #292, Option A).
+
+Tiny env that quacks like ``bucket_brigade.envs.BucketBrigadeEnv`` enough to
+plug into :class:`bucket_brigade.training.joint_trainer.JointPPOTrainer` with
+**zero core modifications**. The trick: we return a dict observation whose
+keys (``houses``, ``signals``, ``locations``, ``last_actions``,
+``scenario_info``) match what :func:`flatten_dict_obs` reads, but we size
+each slot so the concatenated obs is exactly the 5-dimensional vector
+specified in the issue (previous joint action one-hot ⊕ normalized step).
+
+Game (Option A — iterated 2-player public goods):
+
+- Two agents, each with action space ``Discrete(2)`` (``0=defect/keep``,
+  ``1=cooperate/contribute``).
+- Per-step per-agent reward: ``r_i = (m / 2) * (a_0 + a_1) - a_i`` with
+  multiplier ``m = 1.6``. Payoff matrix (per agent, per step):
+
+      (C, C) → (0.6, 0.6)
+      (C, D) → (-0.2, 0.8)
+      (D, C) → (0.8, -0.2)
+      (D, D) → (0.0, 0.0)
+
+  Mutual-C is socially optimal (sum 1.2 > 0); mutual-D is the dominant-strategy
+  equilibrium (each agent has a strict incentive to defect at every step).
+  Classic public-goods dilemma — see Foerster et al. 2018 (LOLA) for the same
+  family of testbeds.
+
+- Fixed 50-step episodes (no early termination). The dones flag fires
+  only at step 50, after which ``JointPPOTrainer.collect_rollout`` auto-resets.
+
+Observation (dict, agent-symmetric):
+
+    - ``houses``         : shape (0,)  — unused, kept for the flatten contract.
+    - ``signals``        : shape (0,)  — unused.
+    - ``locations``      : shape (0,)  — unused.
+    - ``last_actions``   : shape (2, 2) — one-hot of each agent's previous
+      action. On reset (step 0), both rows are zeros.
+    - ``scenario_info``  : shape (1,) — normalized step counter in [0, 1].
+
+After :func:`flatten_dict_obs` flattens ``last_actions`` and concatenates,
+the base obs vector is length 4 + 1 = 5; the per-agent identity one-hot
+(#204) brings it to 5 + 2 = 7 for actual trainer consumption. The
+"State dim = 5" in the issue spec refers to the pre-identity base vector.
+
+Step contract (mirrors ``BucketBrigadeEnv``):
+
+    obs = env.reset(seed=...)                       # dict
+    obs, rewards, done_arr, info = env.step(act)    # act: [2, 1] int64
+        rewards: np.ndarray shape (2,) float32
+        done_arr: np.ndarray shape (2,) bool — both entries identical
+        info: dict (currently empty)
+
+The "[2, 1]" action shape matches ``JointPPOTrainer.collect_rollout``'s
+``joint_action`` (one row per agent, one column per action dim).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+# Game constants. Public so analyzer/tests can pin reference values.
+MULTIPLIER: float = 1.6
+NUM_AGENTS: int = 2
+NUM_ACTIONS: int = 2
+EPISODE_LENGTH: int = 50
+
+ACTION_DEFECT: int = 0
+ACTION_COOPERATE: int = 1
+
+# Analytic per-step rewards (Option A, m=1.6). Used by tests and the analyzer.
+REWARD_MUTUAL_COOPERATE: float = 0.6
+REWARD_MUTUAL_DEFECT: float = 0.0
+REWARD_UNILATERAL_COOPERATE: float = -0.2  # agent who plays C while other plays D
+REWARD_UNILATERAL_DEFECT: float = 0.8  # agent who plays D while other plays C
+
+
+def step_reward(
+    a0: int, a1: int, multiplier: float = MULTIPLIER
+) -> Tuple[float, float]:
+    """Analytic per-step reward for joint action ``(a0, a1)``.
+
+    ``r_i = (m / 2) * (a_0 + a_1) - a_i``. Pure function; used by both the env
+    step and the unit tests to pin the payoff matrix.
+    """
+    contribution = 0.5 * multiplier * (a0 + a1)
+    return float(contribution - a0), float(contribution - a1)
+
+
+class MinimalDilemmaEnv:
+    """2-player iterated public-goods dilemma compatible with JointPPOTrainer.
+
+    The env shape contract matches BucketBrigadeEnv as consumed by
+    ``JointPPOTrainer.collect_rollout``:
+
+    - ``reset(seed=...)`` returns a dict obs.
+    - ``step(joint_action)`` takes a ``[N, A]`` int64 array (here ``[2, 1]``)
+      and returns ``(obs_dict, rewards[N], dones[N], info)``.
+    - ``self.done`` exposes the current termination flag (used by evaluators
+      that loop until done, e.g. the BC eval driver).
+
+    The env is fully deterministic given the joint action sequence — the
+    ``seed`` argument is accepted for API parity but has no effect on the
+    state transition (there is no exogenous randomness in this game). Per-
+    episode seeding still affects ``JointPPOTrainer``'s policy sampling
+    upstream of the env.
+    """
+
+    def __init__(
+        self,
+        multiplier: float = MULTIPLIER,
+        episode_length: int = EPISODE_LENGTH,
+    ) -> None:
+        if multiplier <= 1.0 or multiplier >= 2.0:
+            # The dilemma requires 1 < m < 2: mutual-C beats mutual-D
+            # (m > 1) but unilateral-D beats mutual-C for the defector
+            # (m < 2). Reject silly values defensively.
+            raise ValueError(
+                f"multiplier must be in (1, 2) for a public-goods dilemma; got {multiplier}"
+            )
+        if episode_length <= 0:
+            raise ValueError(f"episode_length must be positive; got {episode_length}")
+
+        self.multiplier = float(multiplier)
+        self.episode_length = int(episode_length)
+        self.num_agents = NUM_AGENTS
+
+        # Internal state.
+        self._step: int = 0
+        self._last_actions: np.ndarray = np.zeros(
+            (NUM_AGENTS, NUM_ACTIONS), dtype=np.float32
+        )
+        self._done: bool = False
+
+    # ------------------------------------------------------------------
+    # Env API (mirrors BucketBrigadeEnv)
+    # ------------------------------------------------------------------
+
+    def reset(self, seed: Optional[int] = None) -> Dict[str, np.ndarray]:
+        """Reset to step 0. Seed is accepted for API parity (no-op internally)."""
+        # ``seed`` is consumed for API parity with ``BucketBrigadeEnv.reset``.
+        # The env has no exogenous randomness, so the seed has no effect on
+        # state transitions. We *do* avoid asserting here so callers that
+        # pass seeds for stochastic-policy parity don't hit a surprise.
+        _ = seed
+        self._step = 0
+        self._last_actions = np.zeros((NUM_AGENTS, NUM_ACTIONS), dtype=np.float32)
+        self._done = False
+        return self._observation()
+
+    def step(
+        self, joint_action: np.ndarray
+    ) -> Tuple[Dict[str, np.ndarray], np.ndarray, np.ndarray, Dict[str, object]]:
+        """Apply joint action and advance one step.
+
+        Args:
+            joint_action: ``[2, 1]`` int64 array. ``joint_action[i, 0]`` is
+                agent i's action in {0, 1}.
+
+        Returns:
+            ``(obs_dict, rewards, dones, info)``:
+                - ``rewards``: shape (2,) float32.
+                - ``dones``: shape (2,) bool — both entries identical
+                  (shared termination); set to True on the last step.
+                - ``info``: empty dict.
+        """
+        if self._done:
+            raise RuntimeError(
+                "MinimalDilemmaEnv.step called on a terminated episode; "
+                "call reset() first"
+            )
+
+        ja = np.asarray(joint_action, dtype=np.int64)
+        if ja.shape != (NUM_AGENTS, 1):
+            raise ValueError(
+                f"joint_action must have shape ({NUM_AGENTS}, 1); got {ja.shape}"
+            )
+        a0 = int(ja[0, 0])
+        a1 = int(ja[1, 0])
+        if a0 not in (0, 1) or a1 not in (0, 1):
+            raise ValueError(f"actions must be in {{0, 1}}; got ({a0}, {a1})")
+
+        r0, r1 = step_reward(a0, a1, self.multiplier)
+        rewards = np.array([r0, r1], dtype=np.float32)
+
+        # Update transition state.
+        self._last_actions = np.zeros((NUM_AGENTS, NUM_ACTIONS), dtype=np.float32)
+        self._last_actions[0, a0] = 1.0
+        self._last_actions[1, a1] = 1.0
+
+        self._step += 1
+        if self._step >= self.episode_length:
+            self._done = True
+
+        dones = np.array([self._done, self._done], dtype=bool)
+        return self._observation(), rewards, dones, {}
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    @property
+    def done(self) -> bool:
+        """Whether the current episode has terminated. Mirrors BucketBrigadeEnv."""
+        return self._done
+
+    def _observation(self) -> Dict[str, np.ndarray]:
+        """Build the dict observation consumed by ``flatten_dict_obs``.
+
+        Layout (base vector after flatten = 5-d):
+            houses (0,) | signals (0,) | locations (0,) |
+            last_actions (2, 2) → flat 4-d | scenario_info (1,)
+
+        The per-agent identity one-hot (#204) is appended downstream by
+        ``flatten_dict_obs(obs, agent_id=i, num_agents=2)``, yielding the
+        7-d vector the policy consumes.
+        """
+        # Normalized step counter in [0, 1). Episode_length steps after reset,
+        # we report ``self._step / episode_length`` ∈ {0/L, 1/L, ..., (L-1)/L}.
+        # (At the moment of terminal observation we'd report L/L = 1.0, but the
+        # trainer doesn't query the obs after a done is registered: it auto-
+        # resets and the next reset reports 0.0 again.)
+        step_norm = np.array(
+            [self._step / float(self.episode_length)], dtype=np.float32
+        )
+        return {
+            "houses": np.zeros(0, dtype=np.float32),
+            "signals": np.zeros(0, dtype=np.float32),
+            "locations": np.zeros(0, dtype=np.float32),
+            "last_actions": self._last_actions.copy(),
+            "scenario_info": step_norm,
+        }

--- a/experiments/p3_specialization/minimal_dilemma/run_all.sh
+++ b/experiments/p3_specialization/minimal_dilemma/run_all.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Orchestration script for issue #292 — minimal-dilemma basin-trap demo.
+#
+# Heavy compute — run on COMPUTE_HOST_PRIMARY (per CLAUDE.md). The local
+# smoke version is the test_smoke.py pytest case; this script is the
+# full-protocol producer.
+#
+# Phases:
+#   1. IPPO baseline ×5 seeds (random init).         ~15 min total.
+#   2. Best-of-N random nets (K=20 → K=200, N=1000). ~10 min total.
+#   3. BC-init (always_cooperate) + PPO continuation ×3 seeds. ~10 min total.
+#   4. Verdict classifier (4-gate read).
+#
+# Total wall ~45 min on a single fast machine. Parallelize the IPPO seeds
+# externally (GNU parallel or N tmux panes) if you have cores to spare.
+#
+# Usage (from repo root):
+#   ./experiments/p3_specialization/minimal_dilemma/run_all.sh OUTDIR
+
+set -euo pipefail
+
+OUTDIR="${1:-experiments/p3_specialization/minimal_dilemma/results}"
+mkdir -p "$OUTDIR"
+
+echo "=== Phase 1: IPPO baseline (5 seeds, 100 iters each) ==="
+for seed in 0 1 2 3 4; do
+  uv run python -m experiments.p3_specialization.minimal_dilemma.train_ippo \
+    --seed "$seed" --num-iterations 100 --rollout-steps 2048 \
+    --output-dir "$OUTDIR/ippo_seed${seed}"
+done
+
+echo "=== Phase 2: Best-of-N (1000 seeds, K=20 → K=200) ==="
+uv run python -m experiments.p3_specialization.minimal_dilemma.best_of_n \
+  --seeds 1000 --episodes-per-seed 20 --restability-episodes 200 \
+  --protocol independent \
+  --output-dir "$OUTDIR/best_of_n"
+
+echo "=== Phase 3a: BC fit (always_cooperate) ==="
+uv run python -m experiments.p3_specialization.minimal_dilemma.bc_init \
+  --specialist always_cooperate \
+  --num-pairs-per-agent 5000 \
+  --output-dir "$OUTDIR/bc_alwaysC"
+
+echo "=== Phase 3b: PPO continuation from BC init (3 seeds, 100 iters) ==="
+for seed in 100 101 102; do
+  uv run python -m experiments.p3_specialization.minimal_dilemma.train_ippo \
+    --seed "$seed" --num-iterations 100 --rollout-steps 2048 \
+    --bc-init-checkpoint-dir "$OUTDIR/bc_alwaysC" \
+    --output-dir "$OUTDIR/bc_continuation_seed${seed}"
+done
+
+echo "=== Phase 4: Verdict ==="
+uv run python -m experiments.p3_specialization.minimal_dilemma.verdict \
+  --ippo-runs "$OUTDIR/ippo_seed0/metrics.json" \
+              "$OUTDIR/ippo_seed1/metrics.json" \
+              "$OUTDIR/ippo_seed2/metrics.json" \
+              "$OUTDIR/ippo_seed3/metrics.json" \
+              "$OUTDIR/ippo_seed4/metrics.json" \
+  --bc-continuation-runs "$OUTDIR/bc_continuation_seed100/metrics.json" \
+                         "$OUTDIR/bc_continuation_seed101/metrics.json" \
+                         "$OUTDIR/bc_continuation_seed102/metrics.json" \
+  --bc-summary "$OUTDIR/bc_alwaysC/bc_summary.json" \
+  --bestofn-summary "$OUTDIR/best_of_n/summary.json" \
+  --output "$OUTDIR/verdict.json"
+
+echo "All done. Verdict at $OUTDIR/verdict.json"

--- a/experiments/p3_specialization/minimal_dilemma/specialists.py
+++ b/experiments/p3_specialization/minimal_dilemma/specialists.py
@@ -1,0 +1,126 @@
+"""Hand-coded specialists for the minimal-dilemma env (issue #292).
+
+Two policies the BC pipeline can clone:
+
+- :func:`always_cooperate` — unconditional cooperation. Simplest possible
+  cooperative basin signal; if BC clones this and PPO-continuation holds,
+  that's the basin-trap verdict in the toy.
+- :func:`tit_for_tat` — cooperate on step 0, then copy opponent's previous
+  action. Matches the LOLA paper's testbed specialist.
+
+Both functions mirror the signature of
+:func:`bucket_brigade.baselines.specialist_action_joint` — they take a dict
+observation and return a ``[num_agents, action_dims_count]`` int64 array —
+so the BC pipeline (``bc_init.py``) can swap them in with zero plumbing
+changes.
+
+Self-play reference rewards (per-step, per-agent, mutual play, m=1.6):
+
+    always_cooperate vs always_cooperate → 0.6   (cooperative upper bound)
+    tit_for_tat      vs tit_for_tat      → 0.6   (both cooperate forever)
+    always_cooperate vs always_defect    → -0.2  (the cooperator's loss)
+    tit_for_tat      vs always_defect    → ~0.0  (only step 0 is C; rest D)
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import numpy as np
+
+from experiments.p3_specialization.minimal_dilemma.env import (
+    ACTION_COOPERATE,
+    ACTION_DEFECT,
+    NUM_AGENTS,
+)
+
+
+def always_cooperate(
+    obs: Mapping[str, np.ndarray], num_agents: int = NUM_AGENTS
+) -> np.ndarray:
+    """Return the all-cooperate joint action regardless of observation.
+
+    Signature mirrors :func:`bucket_brigade.baselines.specialist_action_joint`:
+    obs is the dict returned by :meth:`MinimalDilemmaEnv.reset`/``step``,
+    output is a ``[num_agents, 1]`` int64 array (one column because the env's
+    ``action_dims = [2]``).
+    """
+    if num_agents != NUM_AGENTS:
+        raise ValueError(
+            f"always_cooperate expects num_agents={NUM_AGENTS}; got {num_agents}"
+        )
+    return np.full((num_agents, 1), ACTION_COOPERATE, dtype=np.int64)
+
+
+def always_defect(
+    obs: Mapping[str, np.ndarray], num_agents: int = NUM_AGENTS
+) -> np.ndarray:
+    """Return the all-defect joint action regardless of observation.
+
+    Included as a baseline arm (mutual-defect = 0.0 per-step reward floor).
+    Same signature as :func:`always_cooperate`.
+    """
+    if num_agents != NUM_AGENTS:
+        raise ValueError(
+            f"always_defect expects num_agents={NUM_AGENTS}; got {num_agents}"
+        )
+    return np.full((num_agents, 1), ACTION_DEFECT, dtype=np.int64)
+
+
+def tit_for_tat(
+    obs: Mapping[str, np.ndarray], num_agents: int = NUM_AGENTS
+) -> np.ndarray:
+    """Cooperate on step 0; otherwise copy opponent's previous action.
+
+    Reads ``obs["last_actions"]`` (shape ``[2, 2]``, one-hot rows). On step 0
+    every row is all-zeros (no previous action), which we interpret as
+    "no signal yet → cooperate" (the canonical TFT starting move).
+
+    Returns ``[num_agents, 1]`` int64.
+    """
+    if num_agents != NUM_AGENTS:
+        raise ValueError(
+            f"tit_for_tat expects num_agents={NUM_AGENTS}; got {num_agents}"
+        )
+    last_actions = np.asarray(obs["last_actions"], dtype=np.float32)
+    if last_actions.shape != (NUM_AGENTS, 2):
+        raise ValueError(
+            f"tit_for_tat: obs['last_actions'] must have shape (2, 2); "
+            f"got {last_actions.shape}"
+        )
+
+    joint = np.empty((num_agents, 1), dtype=np.int64)
+    # On step 0 every row is all-zeros → ``argmax`` returns 0, but that's
+    # "defect". Detect the start-of-episode condition explicitly and emit
+    # cooperate instead.
+    is_reset = bool(last_actions.sum() == 0.0)
+    for i in range(num_agents):
+        opponent = 1 - i
+        if is_reset:
+            joint[i, 0] = ACTION_COOPERATE
+        else:
+            # Copy opponent's previous action. ``argmax`` over the one-hot row
+            # recovers the action index in {0=D, 1=C}.
+            joint[i, 0] = int(np.argmax(last_actions[opponent]))
+    return joint
+
+
+def always_random(
+    obs: Mapping[str, np.ndarray],
+    num_agents: int = NUM_AGENTS,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Uniform random action for each agent. Useful sanity baseline.
+
+    Per-step reward in expectation: E[r] = (m/2)*E[a_0 + a_1] - E[a_i]
+    = (m/2)*1 - 0.5 = 0.8 - 0.5 = 0.3 (Option A, m=1.6).
+
+    Not used by BC (random policies aren't worth cloning) but included for
+    the baseline table.
+    """
+    if num_agents != NUM_AGENTS:
+        raise ValueError(
+            f"always_random expects num_agents={NUM_AGENTS}; got {num_agents}"
+        )
+    gen = rng if rng is not None else np.random.default_rng()
+    return gen.integers(0, 2, size=(num_agents, 1), dtype=np.int64)

--- a/experiments/p3_specialization/minimal_dilemma/test_minimal_dilemma.py
+++ b/experiments/p3_specialization/minimal_dilemma/test_minimal_dilemma.py
@@ -1,0 +1,540 @@
+"""Tests for the minimal-dilemma toy reproduction (issue #292).
+
+Eight test classes covering the 8 testable items from the curator spec:
+
+1. Env step contract: action shape, reward sign, episode length.
+2. Env payoff matrix matches the analytic table (Option A, m=1.6).
+3. Specialist policies (always_cooperate, always_defect, tit_for_tat) are
+   correct in isolation.
+4. ``flatten_dict_obs`` integration: the env dict shape produces a 7-d
+   per-agent obs (5-d base + 2 identity-tail), as required by the curator
+   spec.
+5. 7-arm baseline harness: rolling each arm against itself reproduces the
+   expected per-step reward within reasonable variance.
+6. K=20 → K=200 stability gate logic (synthetic data; passes when phase-2
+   is stable, fails when phase-2 drifts upward).
+7. IPPO smoke run: 1-2 iters complete without exception and emit a
+   well-formed metrics.json.
+8. Determinism: two trainings with identical seed produce identical
+   final actor weights.
+
+These tests are local-only and run in <2 min. Full sweeps go on
+COMPUTE_HOST_PRIMARY per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+# Repo-root sys.path shim — pytest is invoked from inside the worktree but
+# the experiments package isn't always on sys.path by default in a uv venv.
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from bucket_brigade.training.joint_trainer import flatten_dict_obs  # noqa: E402
+
+from experiments.p3_specialization.minimal_dilemma.env import (  # noqa: E402
+    ACTION_COOPERATE,
+    ACTION_DEFECT,
+    EPISODE_LENGTH,
+    MinimalDilemmaEnv,
+    NUM_AGENTS,
+    REWARD_MUTUAL_COOPERATE,
+    REWARD_MUTUAL_DEFECT,
+    REWARD_UNILATERAL_COOPERATE,
+    REWARD_UNILATERAL_DEFECT,
+    step_reward,
+)
+from experiments.p3_specialization.minimal_dilemma.specialists import (  # noqa: E402
+    always_cooperate,
+    always_defect,
+    always_random,
+    tit_for_tat,
+)
+from experiments.p3_specialization.minimal_dilemma.best_of_n import (  # noqa: E402
+    stability_gate,
+)
+from experiments.p3_specialization.minimal_dilemma.train_ippo import (  # noqa: E402
+    TrainConfig,
+    train_one_cell,
+)
+from experiments.p3_specialization.minimal_dilemma.verdict import (  # noqa: E402
+    classify_verdict,
+    compute_verdict,
+    gate1_ippo_defects,
+    gate2_specialist_dominates,
+    gate3_bc_holds_basin,
+    gate4_bridge_fails,
+)
+
+
+# ----------------------------------------------------------------------------
+# 1) Env step contract.
+# ----------------------------------------------------------------------------
+class TestEnvStepContract:
+    def test_reset_returns_dict_with_required_keys(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        # ``flatten_dict_obs`` reads these five keys; missing any would
+        # silently break the JointPPOTrainer integration.
+        for key in ("houses", "signals", "locations", "last_actions", "scenario_info"):
+            assert key in obs, f"missing obs key: {key}"
+        assert obs["last_actions"].shape == (NUM_AGENTS, 2)
+        assert obs["scenario_info"].shape == (1,)
+        assert env.done is False
+
+    def test_step_action_shape_validation(self):
+        env = MinimalDilemmaEnv()
+        env.reset(seed=0)
+        with pytest.raises(ValueError, match="shape"):
+            env.step(np.array([[0]], dtype=np.int64))  # wrong shape
+
+    def test_step_action_value_validation(self):
+        env = MinimalDilemmaEnv()
+        env.reset(seed=0)
+        with pytest.raises(ValueError, match="actions must be"):
+            env.step(np.array([[0], [3]], dtype=np.int64))
+
+    def test_step_rewards_shape_and_dtype(self):
+        env = MinimalDilemmaEnv()
+        env.reset(seed=0)
+        joint = np.array([[1], [1]], dtype=np.int64)
+        obs, rewards, dones, info = env.step(joint)
+        assert rewards.shape == (NUM_AGENTS,)
+        assert rewards.dtype == np.float32
+        assert dones.shape == (NUM_AGENTS,)
+        assert dones.dtype == np.bool_
+        assert info == {}
+
+    def test_episode_length_exact(self):
+        """Episode must terminate at exactly step EPISODE_LENGTH (50)."""
+        env = MinimalDilemmaEnv()
+        env.reset(seed=0)
+        joint = np.array([[0], [0]], dtype=np.int64)
+        for step in range(EPISODE_LENGTH - 1):
+            _, _, dones, _ = env.step(joint)
+            assert not dones.any(), f"episode ended early at step {step}"
+        _, _, dones, _ = env.step(joint)
+        assert dones.all(), "episode did not terminate at EPISODE_LENGTH"
+        assert env.done is True
+
+    def test_step_after_done_raises(self):
+        env = MinimalDilemmaEnv(episode_length=2)
+        env.reset(seed=0)
+        joint = np.array([[0], [0]], dtype=np.int64)
+        env.step(joint)
+        env.step(joint)
+        assert env.done
+        with pytest.raises(RuntimeError, match="terminated"):
+            env.step(joint)
+
+
+# ----------------------------------------------------------------------------
+# 2) Payoff matrix matches the analytic table.
+# ----------------------------------------------------------------------------
+class TestPayoffMatrix:
+    def test_pure_function_payoff_matrix(self):
+        assert step_reward(0, 0) == pytest.approx(
+            (REWARD_MUTUAL_DEFECT, REWARD_MUTUAL_DEFECT)
+        )
+        assert step_reward(1, 1) == pytest.approx(
+            (REWARD_MUTUAL_COOPERATE, REWARD_MUTUAL_COOPERATE)
+        )
+        # (C, D) → agent 0 = cooperator (loses), agent 1 = defector (gains).
+        assert step_reward(1, 0) == pytest.approx(
+            (REWARD_UNILATERAL_COOPERATE, REWARD_UNILATERAL_DEFECT)
+        )
+        assert step_reward(0, 1) == pytest.approx(
+            (REWARD_UNILATERAL_DEFECT, REWARD_UNILATERAL_COOPERATE)
+        )
+
+    def test_dilemma_invariants(self):
+        """Public-goods dilemma requires 1 < m < 2; check each inequality."""
+        # Mutual-C strictly beats mutual-D.
+        assert REWARD_MUTUAL_COOPERATE > REWARD_MUTUAL_DEFECT
+        # Unilateral-D strictly beats mutual-C for the defector (incentive
+        # to defect at every step → dominant-strategy equilibrium).
+        assert REWARD_UNILATERAL_DEFECT > REWARD_MUTUAL_COOPERATE
+        # Mutual-D strictly beats unilateral-C for the cooperator
+        # (incentive to defect even when partner cooperates).
+        assert REWARD_MUTUAL_DEFECT > REWARD_UNILATERAL_COOPERATE
+
+    def test_total_reward_over_10_steps(self):
+        """10 steps of mutual-C → sum = 6.0; 10 steps of mutual-D → 0.0 (curator spec)."""
+        env = MinimalDilemmaEnv(episode_length=10)
+        env.reset(seed=0)
+        total_a0 = 0.0
+        total_a1 = 0.0
+        joint = np.array([[1], [1]], dtype=np.int64)
+        for _ in range(10):
+            _, rewards, _, _ = env.step(joint)
+            total_a0 += float(rewards[0])
+            total_a1 += float(rewards[1])
+        assert total_a0 == pytest.approx(6.0)
+        assert total_a1 == pytest.approx(6.0)
+
+        env = MinimalDilemmaEnv(episode_length=10)
+        env.reset(seed=0)
+        total_a0 = 0.0
+        joint = np.array([[0], [0]], dtype=np.int64)
+        for _ in range(10):
+            _, rewards, _, _ = env.step(joint)
+            total_a0 += float(rewards[0])
+        assert total_a0 == pytest.approx(0.0)
+
+
+# ----------------------------------------------------------------------------
+# 3) Specialists are correct.
+# ----------------------------------------------------------------------------
+class TestSpecialists:
+    def test_always_cooperate_emits_C_for_any_obs(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        joint = always_cooperate(obs)
+        assert joint.shape == (NUM_AGENTS, 1)
+        assert joint.dtype == np.int64
+        assert (joint == ACTION_COOPERATE).all()
+        # Mid-episode obs — also all-C.
+        for _ in range(5):
+            obs, _, _, _ = env.step(joint)
+            joint = always_cooperate(obs)
+            assert (joint == ACTION_COOPERATE).all()
+
+    def test_always_defect_emits_D_for_any_obs(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        joint = always_defect(obs)
+        assert (joint == ACTION_DEFECT).all()
+
+    def test_tit_for_tat_starts_cooperate(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        joint = tit_for_tat(obs)
+        # Step 0: no prior actions → both agents cooperate.
+        assert (joint == ACTION_COOPERATE).all()
+
+    def test_tit_for_tat_copies_opponent(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        # Step 0: TFT cooperates (smoke check; full assertion is in
+        # test_tit_for_tat_starts_cooperate above).
+        _ = tit_for_tat(obs)
+        # Inject an asymmetric move so the previous-action obs is interesting.
+        injected = np.array([[ACTION_DEFECT], [ACTION_COOPERATE]], dtype=np.int64)
+        obs, _, _, _ = env.step(injected)
+        joint1 = tit_for_tat(obs)
+        # Agent 0 should now copy opponent's previous action = ACTION_COOPERATE.
+        # Agent 1 should copy opponent's previous action = ACTION_DEFECT.
+        assert int(joint1[0, 0]) == ACTION_COOPERATE
+        assert int(joint1[1, 0]) == ACTION_DEFECT
+
+    def test_always_random_distribution(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        rng = np.random.default_rng(42)
+        joints = np.stack([always_random(obs, rng=rng) for _ in range(2000)])
+        coop_frac = float((joints == ACTION_COOPERATE).mean())
+        # Loose bounds: with 4000 samples (2 agents × 2000 steps) the
+        # cooperation rate should be near 0.5 — well inside [0.45, 0.55].
+        assert 0.45 < coop_frac < 0.55
+
+
+# ----------------------------------------------------------------------------
+# 4) flatten_dict_obs integration.
+# ----------------------------------------------------------------------------
+class TestObsFlatteningIntegration:
+    def test_obs_dim_is_7_with_identity_tail(self):
+        """5-d base (4-d last_actions + 1-d step) + 2-d identity = 7-d."""
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        flat = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS)
+        assert flat.shape == (7,)
+        assert flat.dtype == np.float32
+
+    def test_per_agent_flatten_differs_only_in_identity_tail(self):
+        env = MinimalDilemmaEnv()
+        obs = env.reset(seed=0)
+        flat0 = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS)
+        flat1 = flatten_dict_obs(obs, agent_id=1, num_agents=NUM_AGENTS)
+        # First 5 entries (the shared global obs) match exactly.
+        np.testing.assert_array_equal(flat0[:5], flat1[:5])
+        # Last 2 entries (identity one-hot) differ.
+        np.testing.assert_array_equal(flat0[5:], np.array([1.0, 0.0], dtype=np.float32))
+        np.testing.assert_array_equal(flat1[5:], np.array([0.0, 1.0], dtype=np.float32))
+
+
+# ----------------------------------------------------------------------------
+# 5) 7-arm baseline harness expected per-step rewards.
+# ----------------------------------------------------------------------------
+def _self_play_per_agent_reward(
+    arm_a, arm_b, num_episodes=10, episode_length=50, seed=0
+) -> float:
+    """Roll two policies against each other and return mean per-step per-agent reward.
+
+    Each ``arm`` is a callable ``policy(obs, num_agents=2) -> [2, 1]`` joint
+    action. We pick row 0 of arm_a's output for agent 0 and row 1 of arm_b's
+    output for agent 1 so each arm controls only its own agent.
+    """
+    env = MinimalDilemmaEnv(episode_length=episode_length)
+    totals: list[float] = []
+    rng = np.random.default_rng(seed)
+    for ep in range(num_episodes):
+        obs = env.reset(seed=int(rng.integers(0, 2**31 - 1)))
+        ep_total = 0.0
+        while not env.done:
+            ja = arm_a(obs)
+            jb = arm_b(obs)
+            joint = np.array([[int(ja[0, 0])], [int(jb[1, 0])]], dtype=np.int64)
+            obs, rewards, _, _ = env.step(joint)
+            ep_total += float(rewards.sum())
+        totals.append(ep_total / (episode_length * NUM_AGENTS))
+    return float(np.mean(totals))
+
+
+class TestSevenArmBaselines:
+    """Curator's expected per-step per-agent rewards (Option A, m=1.6).
+
+    Arm                                   | Expected
+    --------------------------------------+----------
+    Mutual defect (AllD vs AllD)          | 0.0
+    Random vs Random                      | 0.3
+    AllC vs AllC                          | 0.6
+    AllC vs AllD                          | 0.3 (= -0.2/2 + 0.8/2)
+    TFT vs TFT                            | 0.6 (mutual cooperation forever)
+    TFT vs AllD                           | very small (TFT defects step 1+)
+    AllD vs Random                        | ~0.4 (D gets 0.5*0.8=0.4)
+
+    "Random_seeded" uses a fixed RNG so the test is deterministic.
+    """
+
+    def test_alld_self_play_is_zero(self):
+        r = _self_play_per_agent_reward(always_defect, always_defect)
+        assert r == pytest.approx(0.0, abs=1e-6)
+
+    def test_allc_self_play_is_cooperative(self):
+        r = _self_play_per_agent_reward(always_cooperate, always_cooperate)
+        assert r == pytest.approx(REWARD_MUTUAL_COOPERATE, abs=1e-6)
+
+    def test_tft_self_play_is_cooperative(self):
+        r = _self_play_per_agent_reward(tit_for_tat, tit_for_tat)
+        assert r == pytest.approx(REWARD_MUTUAL_COOPERATE, abs=1e-6)
+
+    def test_allc_vs_alld_midpoint(self):
+        r = _self_play_per_agent_reward(always_cooperate, always_defect)
+        # (-0.2 + 0.8) / 2 = 0.3
+        assert r == pytest.approx(0.3, abs=1e-6)
+
+    def test_random_self_play_near_quarter_point(self):
+        # E[r] under uniform random = 0.3 (= m/4); finite-sample tolerance 0.1.
+        def rand_fn(obs, num_agents=NUM_AGENTS, _rng=np.random.default_rng(0)):
+            return always_random(obs, num_agents=num_agents, rng=_rng)
+
+        r = _self_play_per_agent_reward(rand_fn, rand_fn, num_episodes=200)
+        assert 0.20 < r < 0.40
+
+
+# ----------------------------------------------------------------------------
+# 6) K=20 → K=200 stability gate logic on synthetic data.
+# ----------------------------------------------------------------------------
+class TestStabilityGate:
+    def test_stable_top_passes_gate(self):
+        # Phase 1 and phase 2 means agree → bridge "failed" (basin-trap consistent).
+        top_phase1 = [
+            {"mean_per_step": 0.05},
+            {"mean_per_step": 0.04},
+            {"mean_per_step": 0.03},
+        ]
+        top_phase2 = [
+            {"mean_per_step": 0.05},
+            {"mean_per_step": 0.04},
+            {"mean_per_step": 0.03},
+        ]
+        gate = stability_gate(top_phase1, top_phase2, slack=0.05)
+        assert gate["passed"] is True
+        assert gate["drift"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_drifting_upward_fails_gate(self):
+        # Phase 2 mean much higher than phase 1 → bridge succeeded → fail.
+        # Use a drift larger than the slack to ensure the gate flags it.
+        top_phase1 = [
+            {"mean_per_step": 0.10},
+            {"mean_per_step": 0.05},
+        ]
+        top_phase2 = [
+            {"mean_per_step": 0.50},
+            {"mean_per_step": 0.40},
+        ]
+        gate = stability_gate(top_phase1, top_phase2, slack=0.05)
+        assert gate["passed"] is False
+        assert gate["drift"] > 0.05
+
+    def test_drifting_downward_passes_gate(self):
+        # The #271 failure mode: phase-1 looked good, phase-2 collapsed.
+        # Bridge fails (= basin-trap consistent).
+        top_phase1 = [{"mean_per_step": 0.45}]
+        top_phase2 = [{"mean_per_step": 0.05}]
+        gate = stability_gate(top_phase1, top_phase2, slack=0.05)
+        assert gate["passed"] is True
+        assert gate["drift"] < 0.0
+
+
+# ----------------------------------------------------------------------------
+# 7) IPPO smoke run.
+# ----------------------------------------------------------------------------
+class TestIPPOSmoke:
+    def test_two_iter_training_produces_metrics(self, tmp_path: Path):
+        cfg = TrainConfig(
+            seed=0,
+            num_iterations=2,
+            rollout_steps=128,
+            hidden_size=32,
+            ppo_epochs=2,
+            minibatch_size=64,
+        )
+        metrics = train_one_cell(cfg, tmp_path)
+        assert (tmp_path / "metrics.json").exists()
+        assert (tmp_path / "config.json").exists()
+        assert (tmp_path / "policies" / "agent_0.pt").exists()
+        assert (tmp_path / "policies" / "agent_1.pt").exists()
+        # Metrics list has one entry per iteration with the expected keys.
+        assert len(metrics) == 2
+        for record in metrics:
+            assert "mean_step_reward_per_agent" in record
+            assert "cooperation_fraction" in record
+            assert 0.0 <= record["cooperation_fraction"] <= 1.0
+        # JSON round-trip works.
+        with (tmp_path / "metrics.json").open() as f:
+            loaded = json.load(f)
+        assert len(loaded) == 2
+
+    def test_mappo_arm_runs(self, tmp_path: Path):
+        cfg = TrainConfig(
+            seed=0,
+            num_iterations=1,
+            rollout_steps=128,
+            hidden_size=32,
+            ppo_epochs=1,
+            minibatch_size=64,
+            centralized_critic=True,
+        )
+        train_one_cell(cfg, tmp_path)
+        assert (tmp_path / "metrics.json").exists()
+
+
+# ----------------------------------------------------------------------------
+# 8) Determinism at fixed seed.
+# ----------------------------------------------------------------------------
+class TestDeterminism:
+    def test_same_seed_same_final_policy(self, tmp_path: Path):
+        cfg_a = TrainConfig(
+            seed=7,
+            num_iterations=2,
+            rollout_steps=128,
+            hidden_size=32,
+            ppo_epochs=1,
+            minibatch_size=64,
+        )
+        cfg_b = TrainConfig(
+            seed=7,
+            num_iterations=2,
+            rollout_steps=128,
+            hidden_size=32,
+            ppo_epochs=1,
+            minibatch_size=64,
+        )
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        train_one_cell(cfg_a, dir_a)
+        train_one_cell(cfg_b, dir_b)
+        # Compare final state dicts byte-for-byte.
+        sd_a0 = torch.load(dir_a / "policies" / "agent_0.pt", weights_only=True)
+        sd_b0 = torch.load(dir_b / "policies" / "agent_0.pt", weights_only=True)
+        for k in sd_a0:
+            torch.testing.assert_close(sd_a0[k], sd_b0[k], rtol=0, atol=0)
+
+
+# ----------------------------------------------------------------------------
+# 9) Verdict classifier — full 4-gate truth table.
+# ----------------------------------------------------------------------------
+class TestVerdictClassifier:
+    """Each named verdict is reachable from a synthetic fixture set."""
+
+    def _make_ippo_summaries(self, reward: float, coop: float, n: int = 5):
+        return [
+            {"final_per_agent_reward": reward, "final_coop_fraction": coop}
+            for _ in range(n)
+        ]
+
+    def _passing_bestofn_gate(self):
+        return {
+            "passed": True,
+            "phase1_mean": 0.05,
+            "phase2_mean": 0.05,
+            "phase2_max": 0.06,
+            "drift": 0.0,
+            "slack": 0.05,
+        }
+
+    def test_basin_trap_replicated(self):
+        out = compute_verdict(
+            ippo_seed_summaries=self._make_ippo_summaries(reward=0.0, coop=0.02),
+            specialist_per_agent_reward=0.6,
+            bc_summary={"min_test_accuracy": 0.99},
+            ppo_continuation_seed_summaries=self._make_ippo_summaries(
+                reward=0.5, coop=0.95, n=3
+            ),
+            bestofn_stability_gate=self._passing_bestofn_gate(),
+        )
+        assert out["verdict"] == "basin_trap_replicated"
+
+    def test_anti_attractor_in_toy_when_bc_decays(self):
+        # Gate 3 fails (BC reward collapses to defect under PPO continuation).
+        out = compute_verdict(
+            ippo_seed_summaries=self._make_ippo_summaries(reward=0.0, coop=0.02),
+            specialist_per_agent_reward=0.6,
+            bc_summary={"min_test_accuracy": 0.99},
+            ppo_continuation_seed_summaries=self._make_ippo_summaries(
+                reward=0.0, coop=0.02, n=3
+            ),
+            bestofn_stability_gate=self._passing_bestofn_gate(),
+        )
+        assert out["verdict"] == "anti_attractor_in_toy"
+
+    def test_null_result_when_ippo_does_not_defect(self):
+        # Gate 1 fails (IPPO above defect threshold).
+        out = compute_verdict(
+            ippo_seed_summaries=self._make_ippo_summaries(reward=0.4, coop=0.7),
+            specialist_per_agent_reward=0.6,
+            bc_summary={"min_test_accuracy": 0.99},
+            ppo_continuation_seed_summaries=self._make_ippo_summaries(
+                reward=0.5, coop=0.95, n=3
+            ),
+            bestofn_stability_gate=self._passing_bestofn_gate(),
+        )
+        assert out["verdict"] == "null_result"
+
+    def test_unit_gate_helpers(self):
+        # Direct unit coverage of each gate helper.
+        g1 = gate1_ippo_defects(
+            [{"final_per_agent_reward": 0.01, "final_coop_fraction": 0.05}]
+        )
+        assert g1["passed"]
+        g2 = gate2_specialist_dominates(0.6)
+        assert g2["passed"]
+        g3 = gate3_bc_holds_basin(
+            {"min_test_accuracy": 0.99},
+            [{"final_per_agent_reward": 0.5, "final_coop_fraction": 0.95}],
+        )
+        assert g3["passed"]
+        g4 = gate4_bridge_fails(
+            {"passed": True, "phase2_mean": 0.05}, ippo_mean_reward=0.0
+        )
+        assert g4["passed"]
+        assert classify_verdict(g1, g2, g3, g4) == "basin_trap_replicated"

--- a/experiments/p3_specialization/minimal_dilemma/train_ippo.py
+++ b/experiments/p3_specialization/minimal_dilemma/train_ippo.py
@@ -1,0 +1,259 @@
+"""IPPO baseline + MAPPO arm for the minimal dilemma (issue #292).
+
+Thin driver that invokes :class:`bucket_brigade.training.joint_trainer.JointPPOTrainer`
+on :class:`MinimalDilemmaEnv` with **zero core modifications**. Two arms:
+
+- ``--centralized-critic=False`` (default) — independent-PPO. The primary
+  basin-trap claim (H1): IPPO from random init converges to mutual-defect
+  (per-step reward ≈ 0.0).
+- ``--centralized-critic=True`` — MAPPO (issue #208). The intervention-
+  sensitivity probe (H2): does centralized-critic shared baseline let PPO
+  reach the cooperative basin from random init?
+
+Outputs (under ``--output-dir``):
+
+- ``metrics.json``  — per-iteration scalars: ``iteration``,
+  ``mean_step_reward_per_agent`` (team / num_agents → directly comparable
+  to the analytic table in the issue), ``cooperation_fraction``, and the
+  full ``JointPPOTrainer.update`` stats dict.
+- ``config.json``   — exact arguments used.
+- ``policies/agent_{i}.pt`` — final per-agent state dicts (consumed by BC
+  / verdict scripts downstream).
+
+Usage::
+
+    # 5-iter smoke (~30 sec on laptop)
+    uv run python -m experiments.p3_specialization.minimal_dilemma.train_ippo \\
+        --seed 0 --num-iterations 5 --rollout-steps 256 \\
+        --output-dir /tmp/dilemma_smoke
+
+    # Full IPPO baseline (100 iters; runs on COMPUTE_HOST_PRIMARY).
+    uv run python -m experiments.p3_specialization.minimal_dilemma.train_ippo \\
+        --seed 0 --num-iterations 100 --rollout-steps 2048 \\
+        --output-dir experiments/p3_specialization/minimal_dilemma/results/ippo_seed0
+
+    # MAPPO arm (H2).
+    uv run python -m experiments.p3_specialization.minimal_dilemma.train_ippo \\
+        --seed 0 --num-iterations 100 --rollout-steps 2048 \\
+        --centralized-critic \\
+        --output-dir experiments/p3_specialization/minimal_dilemma/results/mappo_seed0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import torch
+
+from bucket_brigade.training.joint_trainer import JointPPOTrainer, flatten_dict_obs
+
+from experiments.p3_specialization.minimal_dilemma.env import (
+    ACTION_COOPERATE,
+    EPISODE_LENGTH,
+    MULTIPLIER,
+    MinimalDilemmaEnv,
+    NUM_AGENTS,
+)
+
+
+# Single Discrete(2) action head per agent — the dilemma is a one-dim choice.
+ACTION_DIMS: List[int] = [2]
+
+
+@dataclass
+class TrainConfig:
+    """Per-cell training config (mirrors ``experiments/p3_specialization/train.py``)."""
+
+    seed: int
+    num_iterations: int = 100
+    rollout_steps: int = 2048
+    hidden_size: int = 64
+    lr: float = 3e-4
+    ppo_epochs: int = 4
+    minibatch_size: int = 256
+    gamma: float = 0.99
+    gae_lambda: float = 0.95
+    entropy_coef: float = 0.01
+    value_coef: float = 0.5
+    centralized_critic: bool = False
+    multiplier: float = MULTIPLIER
+    episode_length: int = EPISODE_LENGTH
+    device: str = "cpu"
+    bc_init_checkpoint_dir: Optional[str] = None
+
+
+def make_env_fn(multiplier: float, episode_length: int):
+    """Closure factory matching the ``env_fn`` shape expected by JointPPOTrainer."""
+
+    def env_fn() -> MinimalDilemmaEnv:
+        return MinimalDilemmaEnv(multiplier=multiplier, episode_length=episode_length)
+
+    return env_fn
+
+
+def train_one_cell(cfg: TrainConfig, output_dir: Path) -> List[dict]:
+    """Run one training cell to completion. Returns the metrics log.
+
+    Mirrors :func:`experiments.p3_specialization.train.train_one_cell` but
+    stripped of the BB-specific MI / curriculum / shaping plumbing — the
+    minimal-dilemma env has none of those signals.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    env_fn = make_env_fn(cfg.multiplier, cfg.episode_length)
+
+    # Probe obs_dim from a single reset. Identity tail (#204) is appended by
+    # ``flatten_dict_obs`` when ``agent_id`` is passed. For the minimal env:
+    # base = last_actions(4) + scenario_info(1) = 5; identity tail = 2;
+    # total = 7. We let the probe compute it rather than hardcoding so a
+    # future env-shape tweak doesn't require touching this driver.
+    probe = env_fn()
+    probe_obs = probe.reset(seed=cfg.seed)
+    obs_dim = flatten_dict_obs(probe_obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+
+    trainer = JointPPOTrainer(
+        env_fn=env_fn,
+        num_agents=NUM_AGENTS,
+        obs_dim=obs_dim,
+        action_dims=ACTION_DIMS,
+        hidden_size=cfg.hidden_size,
+        lr=cfg.lr,
+        gamma=cfg.gamma,
+        gae_lambda=cfg.gae_lambda,
+        ppo_epochs=cfg.ppo_epochs,
+        minibatch_size=cfg.minibatch_size,
+        value_coef=cfg.value_coef,
+        entropy_coef=cfg.entropy_coef,
+        redundancy_coef=0.0,
+        centralized_critic=cfg.centralized_critic,
+        device=cfg.device,
+        seed=cfg.seed,
+    )
+
+    # Optional BC warm-start. Same protocol as
+    # ``experiments/p3_specialization/train.py:667`` (issue #270).
+    if cfg.bc_init_checkpoint_dir is not None:
+        bc_dir = Path(cfg.bc_init_checkpoint_dir)
+        if not bc_dir.is_dir():
+            raise FileNotFoundError(
+                f"bc_init_checkpoint_dir does not exist or is not a directory: {bc_dir}"
+            )
+        for i, policy in enumerate(trainer.policies):
+            ckpt_path = bc_dir / f"agent_{i}.pt"
+            if not ckpt_path.exists():
+                raise FileNotFoundError(
+                    f"BC checkpoint missing for agent {i}: expected {ckpt_path}"
+                )
+            sd = torch.load(ckpt_path, map_location=cfg.device, weights_only=True)
+            policy.load_state_dict(sd)
+        print(f"  BC-init: loaded {NUM_AGENTS} per-agent state dicts from {bc_dir}")
+
+    metrics_log: List[dict] = []
+    for it in range(cfg.num_iterations):
+        rollout = trainer.collect_rollout(cfg.rollout_steps)
+        stats = trainer.update(rollout)
+
+        # Per-step team reward (averaged over both agents). For the dilemma,
+        # the natural unit is per-agent (matches the analytic payoff table);
+        # we report both for ease of comparison.
+        team_sum = sum(
+            float(rollout.rewards[i].sum().item()) for i in range(NUM_AGENTS)
+        )
+        per_step_per_agent = team_sum / (cfg.rollout_steps * NUM_AGENTS)
+
+        # Cooperation fraction across the rollout (both agents pooled).
+        coop_count = 0
+        total_actions = 0
+        for i in range(NUM_AGENTS):
+            acts = rollout.actions[i][:, 0].cpu().numpy()
+            coop_count += int((acts == ACTION_COOPERATE).sum())
+            total_actions += len(acts)
+        coop_fraction = float(coop_count / max(1, total_actions))
+
+        record = {
+            "iteration": it,
+            "mean_step_reward_per_agent": per_step_per_agent,
+            "mean_step_reward_team": team_sum / cfg.rollout_steps,
+            "cooperation_fraction": coop_fraction,
+            **stats,
+        }
+        metrics_log.append(record)
+
+        if it % max(1, cfg.num_iterations // 10) == 0 or it == cfg.num_iterations - 1:
+            print(
+                f"  iter {it:4d} | per_agent {per_step_per_agent:+.3f} | "
+                f"coop_frac {coop_fraction:.3f} | "
+                f"policy_loss {stats.get('policy_loss', float('nan')):.4f}"
+            )
+
+    # Save final policies.
+    pol_dir = output_dir / "policies"
+    pol_dir.mkdir(exist_ok=True)
+    for i, policy in enumerate(trainer.policies):
+        torch.save(policy.state_dict(), pol_dir / f"agent_{i}.pt")
+
+    with (output_dir / "metrics.json").open("w") as f:
+        json.dump(metrics_log, f, indent=2)
+    with (output_dir / "config.json").open("w") as f:
+        json.dump(asdict(cfg), f, indent=2)
+
+    return metrics_log
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--seed", type=int, required=True)
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--num-iterations", type=int, default=100)
+    p.add_argument("--rollout-steps", type=int, default=2048)
+    p.add_argument("--hidden-size", type=int, default=64)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--ppo-epochs", type=int, default=4)
+    p.add_argument("--minibatch-size", type=int, default=256)
+    p.add_argument("--entropy-coef", type=float, default=0.01)
+    p.add_argument("--value-coef", type=float, default=0.5)
+    p.add_argument(
+        "--centralized-critic",
+        action="store_true",
+        help="Enable MAPPO (centralized critic) per #208 — H2 intervention arm.",
+    )
+    p.add_argument(
+        "--bc-init-checkpoint-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory with per-agent BC-pretrained state dicts (agent_{i}.pt). "
+            "Loaded into trainer.policies before the first PPO iteration."
+        ),
+    )
+    p.add_argument("--device", default="cpu")
+    args = p.parse_args()
+
+    cfg = TrainConfig(
+        seed=args.seed,
+        num_iterations=args.num_iterations,
+        rollout_steps=args.rollout_steps,
+        hidden_size=args.hidden_size,
+        lr=args.lr,
+        ppo_epochs=args.ppo_epochs,
+        minibatch_size=args.minibatch_size,
+        entropy_coef=args.entropy_coef,
+        value_coef=args.value_coef,
+        centralized_critic=args.centralized_critic,
+        bc_init_checkpoint_dir=args.bc_init_checkpoint_dir,
+        device=args.device,
+    )
+    print(
+        f"== minimal_dilemma train: seed={cfg.seed} "
+        f"centralized_critic={cfg.centralized_critic} "
+        f"bc_init={cfg.bc_init_checkpoint_dir} =="
+    )
+    train_one_cell(cfg, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/p3_specialization/minimal_dilemma/verdict.py
+++ b/experiments/p3_specialization/minimal_dilemma/verdict.py
@@ -1,0 +1,274 @@
+"""4-gate verdict classifier for the minimal dilemma (issue #292).
+
+Consumes the JSON outputs of the IPPO baseline, best-of-N, and BC-init
+arms and emits one of three verdicts:
+
+- ``basin_trap_replicated`` — all 4 gates pass; the minimal env reproduces
+  the bucket-brigade basin-trap signature.
+- ``anti_attractor_in_toy`` — gate 3 fails (BC-init decays under PPO
+  continuation); the toy env exhibits an actively misleading gradient.
+  Publishable as a falsification (re-opens the anti-attractor thesis).
+- ``null_result`` — at least one of the supporting gates (1, 2, or 4)
+  fails, leaving the basin-trap reading unresolved.
+
+The 4 gates (from the curator's success criterion):
+
+1. **IPPO converges to defection** — mean per-step per-agent reward at
+   final iter within ``[-0.05, 0.10]`` (≈ mutual-defect = 0.0) AND
+   cooperation fraction < 10%. Averaged over ``>=`` 5 seeds.
+2. **Specialist dominates** — ``always_cooperate`` self-play yields per-
+   step per-agent reward >= 0.5 (mutual-C = 0.6). This is a pure
+   analytic check — read from the env spec, not from a trained model.
+3. **BC-init holds the basin** — BC clones ``always_cooperate`` to
+   >= 95% action accuracy AND PPO continuation for 100 iters keeps
+   per-step per-agent reward >= 0.4 (i.e. does NOT decay to defect).
+4. **Best-of-N does not bridge** — random-init top-1% K=200 phase-2
+   mean stays at or below IPPO converged value + 0.10 slack. The
+   stability gate in ``best_of_n.py`` already encodes this; we
+   simply read its verdict.
+
+Failure of gate 3 specifically flips the verdict to
+``anti_attractor_in_toy``; failure of any other gate downgrades to
+``null_result``. This matches the issue's explicit falsification path:
+basin-trap and anti-attractor are mutually exclusive readings of gate 3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+# Gate thresholds. Pinned constants so the classifier is reproducible across
+# downstream analyses and tests can exercise the boundary cases.
+GATE1_REWARD_MAX: float = 0.10  # IPPO must not exceed this per-step per-agent reward
+GATE1_REWARD_MIN: float = -0.05  # nor fall below this (sanity floor)
+GATE1_COOP_FRAC_MAX: float = 0.10  # IPPO cooperation fraction ceiling
+GATE2_SPECIALIST_REWARD_MIN: float = 0.50  # always_cooperate self-play floor
+GATE3_BC_ACTION_ACC_MIN: float = 0.95  # BC action accuracy gate
+GATE3_BC_PPO_REWARD_MIN: float = 0.40  # post-PPO reward floor for "basin holds"
+GATE4_BRIDGE_SLACK: float = 0.10  # random-best-of-N must stay within slack of IPPO
+
+
+def gate1_ippo_defects(ippo_seed_summaries: List[Dict]) -> Dict[str, object]:
+    """Gate 1: IPPO converges to defection across all seeds."""
+    if not ippo_seed_summaries:
+        return {"passed": False, "reason": "no IPPO seeds provided"}
+    rewards = [s["final_per_agent_reward"] for s in ippo_seed_summaries]
+    coops = [s["final_coop_fraction"] for s in ippo_seed_summaries]
+    mean_reward = sum(rewards) / len(rewards)
+    mean_coop = sum(coops) / len(coops)
+    reward_ok = GATE1_REWARD_MIN <= mean_reward <= GATE1_REWARD_MAX
+    coop_ok = mean_coop < GATE1_COOP_FRAC_MAX
+    return {
+        "passed": bool(reward_ok and coop_ok),
+        "mean_final_per_agent_reward": mean_reward,
+        "mean_coop_fraction": mean_coop,
+        "n_seeds": len(rewards),
+        "reward_in_range": reward_ok,
+        "coop_below_threshold": coop_ok,
+        "threshold_reward_max": GATE1_REWARD_MAX,
+        "threshold_reward_min": GATE1_REWARD_MIN,
+        "threshold_coop_max": GATE1_COOP_FRAC_MAX,
+    }
+
+
+def gate2_specialist_dominates(specialist_per_agent_reward: float) -> Dict[str, object]:
+    """Gate 2: ``always_cooperate`` self-play exceeds the cooperative threshold."""
+    passed = specialist_per_agent_reward >= GATE2_SPECIALIST_REWARD_MIN
+    return {
+        "passed": bool(passed),
+        "specialist_per_agent_reward": float(specialist_per_agent_reward),
+        "threshold": GATE2_SPECIALIST_REWARD_MIN,
+    }
+
+
+def gate3_bc_holds_basin(
+    bc_summary: Dict, ppo_continuation_seed_summaries: List[Dict]
+) -> Dict[str, object]:
+    """Gate 3: BC clones the specialist AND PPO continuation keeps cooperative reward."""
+    bc_accuracy = float(bc_summary.get("min_test_accuracy", 0.0))
+    accuracy_ok = bc_accuracy >= GATE3_BC_ACTION_ACC_MIN
+    if not ppo_continuation_seed_summaries:
+        return {
+            "passed": False,
+            "reason": "no BC-init PPO continuation seeds provided",
+            "bc_action_accuracy": bc_accuracy,
+            "accuracy_ok": accuracy_ok,
+        }
+    cont_rewards = [
+        s["final_per_agent_reward"] for s in ppo_continuation_seed_summaries
+    ]
+    mean_cont_reward = sum(cont_rewards) / len(cont_rewards)
+    reward_ok = mean_cont_reward >= GATE3_BC_PPO_REWARD_MIN
+    return {
+        "passed": bool(accuracy_ok and reward_ok),
+        "bc_action_accuracy": bc_accuracy,
+        "accuracy_ok": accuracy_ok,
+        "mean_post_ppo_per_agent_reward": mean_cont_reward,
+        "reward_ok": reward_ok,
+        "n_seeds": len(cont_rewards),
+        "threshold_accuracy": GATE3_BC_ACTION_ACC_MIN,
+        "threshold_reward": GATE3_BC_PPO_REWARD_MIN,
+    }
+
+
+def gate4_bridge_fails(
+    bestofn_stability_gate: Dict, ippo_mean_reward: float
+) -> Dict[str, object]:
+    """Gate 4: random-init best-of-N (K=200 confirmed) does NOT bridge to cooperation."""
+    phase2_mean = float(bestofn_stability_gate.get("phase2_mean", float("nan")))
+    # The bridge "fails" (= basin-trap consistent) when the phase-2 confirmed
+    # random-net top-1% reward stays within ``GATE4_BRIDGE_SLACK`` of IPPO.
+    bridge_failed = phase2_mean <= ippo_mean_reward + GATE4_BRIDGE_SLACK
+    # Also require the stability gate's own check (drift <= slack) — the #271
+    # safeguard. If phase-2 reward is much higher than phase-1, even a low
+    # absolute value could indicate the K=20 ranking missed something.
+    stability_ok = bool(bestofn_stability_gate.get("passed", False))
+    return {
+        "passed": bool(bridge_failed and stability_ok),
+        "phase2_mean": phase2_mean,
+        "ippo_reference": float(ippo_mean_reward),
+        "slack": GATE4_BRIDGE_SLACK,
+        "bridge_below_ippo_plus_slack": bridge_failed,
+        "stability_gate_passed": stability_ok,
+    }
+
+
+def classify_verdict(gate1: Dict, gate2: Dict, gate3: Dict, gate4: Dict) -> str:
+    """Map the four gate verdicts to one of three named outcomes.
+
+    - All four pass → ``basin_trap_replicated`` (textbook target).
+    - Gate 3 fails specifically → ``anti_attractor_in_toy`` (BC decays;
+      this falsifies basin-trap and reopens the anti-attractor reading).
+    - Any other configuration → ``null_result``.
+    """
+    g1 = bool(gate1["passed"])
+    g2 = bool(gate2["passed"])
+    g3 = bool(gate3["passed"])
+    g4 = bool(gate4["passed"])
+    if g1 and g2 and g3 and g4:
+        return "basin_trap_replicated"
+    if g1 and g2 and (not g3) and g4:
+        return "anti_attractor_in_toy"
+    return "null_result"
+
+
+def compute_verdict(
+    ippo_seed_summaries: List[Dict],
+    specialist_per_agent_reward: float,
+    bc_summary: Dict,
+    ppo_continuation_seed_summaries: List[Dict],
+    bestofn_stability_gate: Dict,
+) -> Dict[str, object]:
+    """Top-level entry: assemble all four gates and the named verdict."""
+    g1 = gate1_ippo_defects(ippo_seed_summaries)
+    g2 = gate2_specialist_dominates(specialist_per_agent_reward)
+    g3 = gate3_bc_holds_basin(bc_summary, ppo_continuation_seed_summaries)
+    ippo_reference = g1.get("mean_final_per_agent_reward", 0.0)
+    g4 = gate4_bridge_fails(bestofn_stability_gate, float(ippo_reference))
+    verdict = classify_verdict(g1, g2, g3, g4)
+    return {
+        "issue": 292,
+        "verdict": verdict,
+        "gate1_ippo_defects": g1,
+        "gate2_specialist_dominates": g2,
+        "gate3_bc_holds_basin": g3,
+        "gate4_bridge_fails": g4,
+    }
+
+
+def _load_metrics(path: Path) -> List[Dict]:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _seed_summary_from_metrics(metrics_path: Path) -> Dict:
+    """Extract gate-relevant scalars from a single training cell's metrics.json."""
+    metrics = _load_metrics(metrics_path)
+    final = metrics[-1]
+    return {
+        "metrics_path": str(metrics_path),
+        "final_per_agent_reward": float(final["mean_step_reward_per_agent"]),
+        "final_coop_fraction": float(final["cooperation_fraction"]),
+        "iteration": int(final["iteration"]),
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--ippo-runs",
+        nargs="+",
+        required=True,
+        help="Paths to IPPO seed cell metrics.json files.",
+    )
+    p.add_argument(
+        "--bc-continuation-runs",
+        nargs="+",
+        required=True,
+        help="Paths to BC-init PPO continuation seed metrics.json files.",
+    )
+    p.add_argument(
+        "--bc-summary",
+        type=Path,
+        required=True,
+        help="Path to bc_init.py's bc_summary.json output.",
+    )
+    p.add_argument(
+        "--bestofn-summary",
+        type=Path,
+        required=True,
+        help="Path to best_of_n.py's summary.json output.",
+    )
+    p.add_argument(
+        "--bestofn-protocol",
+        default="independent",
+        help="Which init protocol's stability gate to consume (default: independent).",
+    )
+    p.add_argument(
+        "--specialist-per-agent-reward",
+        type=float,
+        default=0.6,
+        help="Analytic always_cooperate self-play per-step per-agent reward.",
+    )
+    p.add_argument("--output", type=Path, required=True)
+    args = p.parse_args()
+
+    ippo_summaries = [_seed_summary_from_metrics(Path(x)) for x in args.ippo_runs]
+    cont_summaries = [
+        _seed_summary_from_metrics(Path(x)) for x in args.bc_continuation_runs
+    ]
+    with args.bc_summary.open() as f:
+        bc_summary = json.load(f)
+    with args.bestofn_summary.open() as f:
+        bestofn = json.load(f)
+    stab = bestofn[args.bestofn_protocol]["stability_gate"]
+
+    verdict = compute_verdict(
+        ippo_seed_summaries=ippo_summaries,
+        specialist_per_agent_reward=args.specialist_per_agent_reward,
+        bc_summary=bc_summary,
+        ppo_continuation_seed_summaries=cont_summaries,
+        bestofn_stability_gate=stab,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as f:
+        json.dump(verdict, f, indent=2)
+
+    print(f"\n== Verdict: {verdict['verdict']} ==")
+    for k in (
+        "gate1_ippo_defects",
+        "gate2_specialist_dominates",
+        "gate3_bc_holds_basin",
+        "gate4_bridge_fails",
+    ):
+        print(f"  {k}: passed={verdict[k]['passed']}")
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #292. Basin-trap demo reframe (anti-attractor falsified by #271). Reuses `joint_trainer` + `bc_init` templates; **zero core mods**.

The minimal 2-player iterated public-goods env (m=1.6, 50-step episodes, Discrete(2) actions) is a Python-only referee-friendly reproduction of the bucket-brigade basin-trap signature. Per the curator's reframe (the anti-attractor reading was falsified by #271/#270), the demo target is now "PPO converges to all-defect; specialist holds the cooperative basin under BC-init + PPO continuation; random-init best-of-N does not bridge under the K=20 → K=200 stability protocol."

## Changes

- `experiments/p3_specialization/minimal_dilemma/env.py` — 2-player iterated public-goods env that quacks like `BucketBrigadeEnv` (returns the dict obs keys `flatten_dict_obs` reads), so `JointPPOTrainer` plugs in unchanged.
- `experiments/p3_specialization/minimal_dilemma/specialists.py` — `always_cooperate`, `always_defect`, `tit_for_tat`, `always_random` callables matching the `specialist_action_joint` signature.
- `experiments/p3_specialization/minimal_dilemma/train_ippo.py` — thin `JointPPOTrainer` wrapper with `--centralized-critic` (H2 MAPPO arm) and `--bc-init-checkpoint-dir` (#270 warm-start).
- `experiments/p3_specialization/minimal_dilemma/bc_init.py` — BC pipeline adapted from #270's template; dual-gate (action accuracy ≥ 99% AND mean reward ≥ 0.5).
- `experiments/p3_specialization/minimal_dilemma/best_of_n.py` — random-init best-of-N with the **mandatory** K=20 → K=200 stability re-eval (#271 false-positive safeguard).
- `experiments/p3_specialization/minimal_dilemma/verdict.py` — 4-gate classifier emitting `basin_trap_replicated` / `anti_attractor_in_toy` / `null_result`.
- `experiments/p3_specialization/minimal_dilemma/run_all.sh` — orchestration script for `COMPUTE_HOST_PRIMARY`.
- `experiments/p3_specialization/minimal_dilemma/test_minimal_dilemma.py` — 31 tests covering all 8 curator-spec test items.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New 7-file layout under `minimal_dilemma/` | ✓ | 9 files (curator's 7 + `verdict.py` + tests) |
| Env: m=1.6, 50-step episodes, Discrete(2), 5-d base obs | ✓ | `env.py` constants pinned; tests assert obs shape and episode length |
| Reuse `JointPPOTrainer` with zero core mods | ✓ | `train_ippo.py` imports unchanged trainer; MAPPO arm via existing `centralized_critic=True` (#208) |
| BC pipeline mirrors `bc_init.py` template | ✓ | Same 3-phase structure; new specialists; dual-gate |
| K=20 → K=200 two-phase protocol baked in | ✓ | `best_of_n.py` `stability_gate()` + tests covering pass/fail boundaries |
| 4-gate verdict classifier | ✓ | `verdict.py` with full truth table tests (3 named outcomes reachable) |
| 8 testable items from spec | ✓ | 31 tests across 9 classes (env contract, payoffs, specialists, obs flatten, 7-arm baselines, stability gate, IPPO smoke, MAPPO smoke, determinism, verdict) |
| Compute placement: heavy on `COMPUTE_HOST_PRIMARY` | ✓ | `run_all.sh` documents this; no heavy run executed locally |
| No modification to bucket-brigade core | ✓ | `git diff --stat origin/main` touches only `experiments/p3_specialization/minimal_dilemma/` |

## Test Plan

- All 31 pytest tests pass locally in <2 sec (`uv run python -m pytest experiments/p3_specialization/minimal_dilemma/test_minimal_dilemma.py`).
- `ruff check` and `ruff format` clean.
- End-to-end CLI smoke verified (not committed, run locally):
  - IPPO 2-iter smoke produces metrics.json and policies.
  - BC fit (200 demos × 3 epochs) reaches 100% test accuracy and 0.6 per-agent self-play reward.
  - BC-init checkpoint loads correctly into `JointPPOTrainer`.
  - Best-of-N (20 seeds × 3/5 episodes) exercises both phases and the stability gate.
  - Verdict CLI consumes all upstream JSON and emits the correct named outcome.

Heavy sweeps (5×100 IPPO seeds, 1000-seed best-of-N, 3×100 BC continuation) are scoped for `COMPUTE_HOST_PRIMARY` per `CLAUDE.md` and `run_all.sh`. No heavy compute ran locally for this PR.

Closes #292