### PR TITLE
chore: Cloudflare Pages deployment config

### DIFF
--- a/docs/CLOUDFLARE_PAGES_SETUP.md
+++ b/docs/CLOUDFLARE_PAGES_SETUP.md
@@ -1,0 +1,60 @@
+# Cloudflare Pages Deployment
+
+This site is built for Cloudflare Pages. GH Pages remains the fallback / canonical mirror at `https://rjwalters.github.io/bucket-brigade/`.
+
+## Target topology
+
+- **Canonical URL**: `https://bucket-brigade.rjwalters.info/` (CF Pages, custom subdomain)
+- **Legacy URL**: `https://rjwalters.info/bucket-brigade/` (forwards to the canonical URL via `_redirects` in the `rjwalters.info` project)
+
+## One-time CF dashboard setup
+
+1. **Create the Pages project**
+   - CF dashboard → Pages → Create a project → Connect to Git
+   - Pick the `rjwalters/bucket-brigade` repo, production branch `main`
+
+2. **Build configuration**
+   - **Build command**: `bash scripts/cf-pages-build.sh`
+   - **Build output directory**: `web/dist`
+   - **Root directory**: *(repo root, leave blank)*
+   - **Environment variables** (Production, Preview):
+     - `VITE_BASE_PATH` = `/`
+     - `NODE_VERSION` = `20`
+     - `PYTHON_VERSION` = `3.12`
+     - `RUST_VERSION` = `stable` *(optional)*
+
+3. **Custom domain**
+   - Pages project → Custom domains → Set up custom domain → `bucket-brigade.rjwalters.info`
+   - CF auto-creates the CNAME record on the `rjwalters.info` zone
+
+4. **Legacy path redirect**
+   - In the `rjwalters.info` Pages project, add to its `_redirects` file:
+     ```
+     /bucket-brigade/*  https://bucket-brigade.rjwalters.info/:splat  301
+     ```
+   - Commit and redeploy that project.
+
+## Build environment notes
+
+`scripts/cf-pages-build.sh` installs Rust, `wasm-pack`, and `uv` on demand, then runs the same pipeline as the GH Actions workflow at `.github/workflows/deploy.yml`:
+
+1. `wasm-pack build --target web` inside `bucket-brigade-core/`
+2. `uv run python scripts/build_research_content.py`
+3. `pnpm install --frozen-lockfile` in `web/`
+4. `pnpm run build` in `web/` (which itself runs `generate:types` then `vite build`)
+
+CF Pages build images include Node and Python but not Rust — the script installs Rust lazily so warm builds reuse the cache.
+
+## Vite base path
+
+`web/vite.config.ts` reads `VITE_BASE_PATH` (defaults to `/bucket-brigade/` in production so the GH Pages build still works). Setting `VITE_BASE_PATH=/` in CF Pages flips it for the subdomain deploy.
+
+## Keeping GH Pages alive
+
+Until the CF site is verified, the GH Actions workflow (`.github/workflows/deploy.yml`) continues to publish to `rjwalters.github.io/bucket-brigade/`. Once CF is confirmed working, you can disable the GH Pages workflow:
+
+```bash
+gh workflow disable deploy.yml
+```
+
+…or remove the file.

--- a/scripts/cf-pages-build.sh
+++ b/scripts/cf-pages-build.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Cloudflare Pages build script.
+#
+# Runs the full web build pipeline inside CF Pages' Ubuntu build container:
+# install Rust + wasm-pack, build the WASM crate, install uv, regenerate
+# research content + TypeScript types, then run the Vite build.
+#
+# CF Pages dashboard config:
+#   Build command:        bash scripts/cf-pages-build.sh
+#   Build output dir:     web/dist
+#   Root directory:       (repo root)
+#   Env vars (optional):
+#     VITE_BASE_PATH      "/" for subdomain, "/bucket-brigade/" for path-based
+#     RUST_VERSION        stable (default below if unset)
+#     PYTHON_VERSION      3.12
+#     NODE_VERSION        20
+
+set -euo pipefail
+
+echo "::group::env"
+node --version || true
+pnpm --version || true
+python3 --version || true
+echo "::endgroup::"
+
+# Install Rust toolchain if not present (CF Pages images vary)
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "::group::install rust"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_VERSION:-stable}"
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+  rustup target add wasm32-unknown-unknown
+  echo "::endgroup::"
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Install wasm-pack
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "::group::install wasm-pack"
+  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  echo "::endgroup::"
+fi
+
+# Install uv (CF Pages has Python preinstalled; uv gives us a hermetic venv)
+if ! command -v uv >/dev/null 2>&1; then
+  echo "::group::install uv"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "::endgroup::"
+fi
+
+echo "::group::build wasm"
+(cd bucket-brigade-core && wasm-pack build --target web)
+echo "::endgroup::"
+
+echo "::group::research content"
+mkdir -p web/public/research
+cp -r experiments/scenarios web/public/research/
+uv run python scripts/build_research_content.py
+echo "::endgroup::"
+
+echo "::group::pnpm install"
+corepack enable || true
+corepack prepare pnpm@9.0.0 --activate || npm install -g pnpm@9.0.0
+(cd web && pnpm install --frozen-lockfile)
+echo "::endgroup::"
+
+echo "::group::vite build"
+(cd web && NODE_ENV=production pnpm run build)
+echo "::endgroup::"
+
+echo "Build complete. Output in web/dist (base path: ${VITE_BASE_PATH:-/bucket-brigade/})"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,10 +9,17 @@ const hasWasm = existsSync(wasmPkgPath)
 
 console.log(`🦀 Rust WASM package: ${hasWasm ? '✅ Available' : '⚠️  Not found - using JS fallback'}`)
 
+// Base path resolution:
+//   - VITE_BASE_PATH overrides everything (set in CI for CF Pages, GH Pages, etc.)
+//   - Production default is /bucket-brigade/ (matches the GH Pages URL path)
+//   - Dev uses /
+const basePath =
+  process.env.VITE_BASE_PATH ??
+  (process.env.NODE_ENV === 'production' ? '/bucket-brigade/' : '/')
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  // Use /bucket-brigade/ for GitHub Pages, / for local dev
-  base: process.env.NODE_ENV === 'production' ? '/bucket-brigade/' : '/',
+  base: basePath,
   plugins: [react()],
   server: {
     port: 3000,


### PR DESCRIPTION
## Summary

Migrating bucket-brigade.rjwalters.info from GitHub Pages to Cloudflare Pages so the custom-domain routing on rjwalters.info works again after the rjwalters.info site moved to Cloudflare.

## Changes

- **`scripts/cf-pages-build.sh`** — single-script build pipeline (Rust + WASM + uv-driven research/TS content + Vite) that CF Pages can call directly. Installs Rust and wasm-pack on demand since CF Pages base images don't ship them.
- **`web/vite.config.ts`** — read `VITE_BASE_PATH` env var so the same build serves both the new subdomain (base `/`) and the old `/bucket-brigade/` path while GH Pages remains as fallback.
- **`docs/CLOUDFLARE_PAGES_SETUP.md`** — one-time dashboard setup: build command, env vars, custom domain `bucket-brigade.rjwalters.info`, and the `_redirects` entry to add in the `rjwalters.info` project for the old `/bucket-brigade/*` URL.

## Target topology

- Canonical: `https://bucket-brigade.rjwalters.info/` (CF Pages, custom subdomain)
- Legacy: `https://rjwalters.info/bucket-brigade/*` → 301 redirect to canonical (via `_redirects` in the `rjwalters.info` project)

## Test plan

- [ ] Create the CF Pages project per `docs/CLOUDFLARE_PAGES_SETUP.md`
- [ ] Verify a build runs end-to-end on CF (Rust/WASM/Python/Node all install correctly)
- [ ] Verify `https://bucket-brigade.rjwalters.info/` loads with WASM working
- [ ] Add the `_redirects` rule to the `rjwalters.info` project and verify `https://rjwalters.info/bucket-brigade/` 301s correctly
- [ ] Disable `.github/workflows/deploy.yml` once CF site is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)