### PR TITLE
chore: fix main CI lint + bandit failures

### DIFF
--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -557,9 +557,7 @@ class HindsightNetwork(nn.Module):
         return torch.stack(log_probs, dim=1).sum(dim=1)
 
 
-def encode_return_bucket(
-    returns: torch.Tensor, num_buckets: int = 8
-) -> torch.Tensor:
+def encode_return_bucket(returns: torch.Tensor, num_buckets: int = 8) -> torch.Tensor:
     """Quantize per-step Monte-Carlo returns into a one-hot bucket encoding.
 
     Used as the future-statistic ``X_t`` consumed by :class:`HindsightNetwork`
@@ -578,8 +576,7 @@ def encode_return_bucket(
     """
     if returns.dim() != 1:
         raise ValueError(
-            f"encode_return_bucket expects 1D returns, got shape "
-            f"{tuple(returns.shape)}"
+            f"encode_return_bucket expects 1D returns, got shape {tuple(returns.shape)}"
         )
     T = returns.shape[0]
     # Use quantile boundaries for an empirically-balanced bucket assignment.
@@ -594,9 +591,7 @@ def encode_return_bucket(
         return torch.zeros((T, num_buckets), dtype=torch.float32, device=returns.device)
     edges = torch.tensor(
         [
-            sorted_returns[
-                min(int((k + 1) * T / num_buckets), T - 1)
-            ].item()
+            sorted_returns[min(int((k + 1) * T / num_buckets), T - 1)].item()
             for k in range(num_buckets - 1)
         ],
         device=returns.device,
@@ -604,9 +599,7 @@ def encode_return_bucket(
     # bucketize: bucket index = number of edges strictly less than returns
     bucket_idx = torch.bucketize(returns, edges)
     bucket_idx = torch.clamp(bucket_idx, 0, num_buckets - 1)
-    one_hot = torch.zeros(
-        (T, num_buckets), dtype=torch.float32, device=returns.device
-    )
+    one_hot = torch.zeros((T, num_buckets), dtype=torch.float32, device=returns.device)
     one_hot.scatter_(1, bucket_idx.unsqueeze(1), 1.0)
     return one_hot
 
@@ -669,7 +662,6 @@ def compute_hca_advantages(
               hindsight-net fit), ``ratio_mean`` (mean unclipped ratio).
     """
     device = observations.device
-    T = len(rewards)
 
     # Monte-Carlo return-to-go Z_t.
     Z_list = compute_returns_to_go(rewards, dones, gamma=gamma)

--- a/experiments/p3_specialization/analyze_280.py
+++ b/experiments/p3_specialization/analyze_280.py
@@ -158,7 +158,9 @@ def classify_verdict(rows: List[Dict]) -> Tuple[str, str]:
         acc_sorted[i + 1] >= acc_sorted[i] - 0.01 for i in range(len(acc_sorted) - 1)
     )
     if monotone and max_acc >= HOUSE_ON_WORK_SUCCESS:
-        winning_hs = next(h for h, a in zip(hs_sorted, acc_sorted) if a >= HOUSE_ON_WORK_SUCCESS)
+        winning_hs = next(
+            h for h, a in zip(hs_sorted, acc_sorted) if a >= HOUSE_ON_WORK_SUCCESS
+        )
         return "capacity_bound", (
             f"Monotone improvement with hidden_size; plateau >= "
             f"{HOUSE_ON_WORK_SUCCESS} reached at hidden_size={winning_hs} "
@@ -201,9 +203,7 @@ def render_markdown(rows: List[Dict], verdict: str, reasoning: str) -> str:
     ]
     for r in sorted(rows, key=lambda x: x["hidden_size"]):
         if r.get("n_seeds", 0) == 0:
-            lines.append(
-                f"| {r['hidden_size']} | - | 0 | - | - | - | - |"
-            )
+            lines.append(f"| {r['hidden_size']} | - | 0 | - | - | - | - |")
             continue
         lines.append(
             f"| {r['hidden_size']} | {r.get('n_params', '-')} | "

--- a/experiments/p3_specialization/analyze_289.py
+++ b/experiments/p3_specialization/analyze_289.py
@@ -182,9 +182,7 @@ def main() -> None:
     p.add_argument(
         "--output-dir",
         type=Path,
-        default=Path(
-            "experiments/p3_specialization/diagnostics/results/issue289_hca"
-        ),
+        default=Path("experiments/p3_specialization/diagnostics/results/issue289_hca"),
     )
     args = p.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -200,9 +198,7 @@ def main() -> None:
             payload = json.loads(args.high_lambda_result.read_text())
             high_lambda_gc = float(
                 payload.get("trailing5_gap_closed_mean")
-                or payload.get("high_lambda_arm", {}).get(
-                    "trailing5_gap_closed_mean"
-                )
+                or payload.get("high_lambda_arm", {}).get("trailing5_gap_closed_mean")
             )
         except (ValueError, TypeError, KeyError):
             high_lambda_gc = None

--- a/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.md
+++ b/experiments/p3_specialization/diagnostics/results/issue261_calibration/summary.md
@@ -1,6 +1,6 @@
 # Issue #261/#262 — Action-shaping calibration sweep
 
-Scenario: ``minimal_specialization``  
+Scenario: ``minimal_specialization``
 References (per-step mean team reward): random=-87.72, specialist=-22.07 (denominator=+65.65).
 
 ## Per-cell results
@@ -33,4 +33,3 @@ Best cell:
 - n_seeds = ``3``
 
 _No over-shaping flagged at the 100× threshold._
-

--- a/experiments/p3_specialization/run_issue288_pbt.py
+++ b/experiments/p3_specialization/run_issue288_pbt.py
@@ -48,7 +48,7 @@ import argparse
 import json
 import math
 import random
-import subprocess
+import subprocess  # nosec B404 (orchestrator spawns train.py with fixed argv)
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -148,7 +148,7 @@ def _run_lineage_cell(
 
     log_path = output_dir / "train.log"
     with log_path.open("w") as logf:
-        proc = subprocess.run(cmd, stdout=logf, stderr=subprocess.STDOUT)
+        proc = subprocess.run(cmd, stdout=logf, stderr=subprocess.STDOUT)  # nosec B603 (cmd is list, no shell)
     return proc.returncode
 
 
@@ -315,7 +315,7 @@ def run_pbt(
     seed_root = output_root / f"seed_{pbt_seed}"
     seed_root.mkdir(parents=True, exist_ok=True)
 
-    rng = random.Random(pbt_seed)
+    rng = random.Random(pbt_seed)  # nosec B311 (PBT mutation seeding, not cryptographic)
 
     # Distinct per-lineage PPO seeds. Using ``pbt_seed * 1000 + i`` keeps the
     # numbering human-readable in the per-cell config.json.

--- a/scripts/analyze_nash_equilibrium.py
+++ b/scripts/analyze_nash_equilibrium.py
@@ -33,14 +33,20 @@ def print_header(text: str):
 def print_scenario_info(scenario):
     """Print detailed scenario information."""
     print("Scenario Parameters:")
-    print(f"  Fire Dynamics:")
-    print(f"    beta (spread probability):     {scenario.prob_fire_spreads_to_neighbor:.2f}")
-    print(f"    kappa (extinguish efficiency): {scenario.prob_solo_agent_extinguishes_fire:.2f}")
-    print(f"  Reward Structure:")
-    print(f"    A (reward per saved house):    {scenario.team_reward_house_survives:.2f}")
+    print("  Fire Dynamics:")
+    print(
+        f"    beta (spread probability):     {scenario.prob_fire_spreads_to_neighbor:.2f}"
+    )
+    print(
+        f"    kappa (extinguish efficiency): {scenario.prob_solo_agent_extinguishes_fire:.2f}"
+    )
+    print("  Reward Structure:")
+    print(
+        f"    A (reward per saved house):    {scenario.team_reward_house_survives:.2f}"
+    )
     print(f"    L (penalty per ruined house):  {scenario.team_penalty_house_burns:.2f}")
     print(f"    c (cost per worker per night): {scenario.cost_to_work_one_night:.2f}")
-    print(f"  Initial Conditions:")
+    print("  Initial Conditions:")
     print(f"    p_spark (spontaneous ignition): {scenario.prob_house_catches_fire:.2f}")
     print(f"    N_min (minimum nights):         {scenario.min_nights}")
     print(f"    num_agents:                     {scenario.num_agents}")
@@ -104,7 +110,7 @@ def print_strategy_details(strategy: np.ndarray, label: str = "Strategy"):
 
     print(f"\n{label}:")
     print(f"  Classification: {classification}")
-    print(f"  Parameters:")
+    print("  Parameters:")
     for param_name, value in analysis.items():
         bar_length = int(value * 20)
         bar = "█" * bar_length + "░" * (20 - bar_length)
@@ -238,7 +244,7 @@ def main():
     for idx, (strategy_idx, probability) in enumerate(sorted_strategies):
         strategy = equilibrium.strategy_pool[strategy_idx]
         print(f"\nStrategy {idx + 1}: Probability = {probability:.3f}")
-        print_strategy_details(strategy, label=f"  Details")
+        print_strategy_details(strategy, label="  Details")
         compare_to_archetypes(strategy)
 
     # Game-theoretic interpretation

--- a/scripts/analyze_summaries.py
+++ b/scripts/analyze_summaries.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import json
 import typer
 import pandas as pd
-import numpy as np
 from typing import List, Optional
 
 # Add the bucket_brigade package to the path

--- a/scripts/build_research_content.py
+++ b/scripts/build_research_content.py
@@ -50,18 +50,20 @@ class ResearchContentBuilder:
                     if ":" in line:
                         key, value = line.split(":", 1)
                         key = key.strip()
-                        value = value.strip().strip('"\'')
+                        value = value.strip().strip("\"'")
 
                         # Parse arrays
                         if value.startswith("[") and value.endswith("]"):
                             # Simple array parsing
                             items = value[1:-1].split(",")
-                            frontmatter[key] = [item.strip().strip('"\'') for item in items]
+                            frontmatter[key] = [
+                                item.strip().strip("\"'") for item in items
+                            ]
                         else:
                             frontmatter[key] = value
 
                 # Body starts after closing ---
-                body = "\n".join(lines[end_idx + 1:])
+                body = "\n".join(lines[end_idx + 1 :])
                 return frontmatter, body
 
         # Fall back to old format if no YAML frontmatter
@@ -284,7 +286,7 @@ class ResearchContentBuilder:
 
         output_file = self.output_dir / "content_index.json"
         output_file.write_text(json.dumps(index, indent=2))
-        print(f"\nGenerated: content_index.json")
+        print("\nGenerated: content_index.json")
         print(f"  - {len(index['notebook']['entries'])} notebook entries")
         print(f"  - {len(index['library']['documents'])} library documents")
         print(f"  - {len(index['tags'])} unique tags")

--- a/scripts/compare_teams.py
+++ b/scripts/compare_teams.py
@@ -23,7 +23,6 @@ from bucket_brigade.envs import BucketBrigadeEnv
 from bucket_brigade.agents import HeuristicAgent
 from bucket_brigade.envs import (
     Scenario,
-    random_scenario,
     trivial_cooperation_scenario,
     early_containment_scenario,
     greedy_neighbor_scenario,
@@ -244,19 +243,19 @@ def display_comparison_table(
 
         t_stat, p_value = scipy_stats.ttest_ind(rewards1, rewards2)
 
-        console.print(f"\n📊 Statistical Significance Test (t-test):")
+        console.print("\n📊 Statistical Significance Test (t-test):")
         console.print(f"   t-statistic: {t_stat:.4f}")
         console.print(f"   p-value: {p_value:.4f}")
 
         if p_value < 0.05:
             winner = teams[0] if np.mean(rewards1) > np.mean(rewards2) else teams[1]
             console.print(
-                f"   ✅ [bold green]Significant difference detected (p < 0.05)[/bold green]"
+                "   ✅ [bold green]Significant difference detected (p < 0.05)[/bold green]"
             )
             console.print(f"   🏆 [bold]{winner}[/bold] performs significantly better")
         else:
             console.print(
-                f"   ⚠️  [yellow]No significant difference (p >= 0.05)[/yellow]"
+                "   ⚠️  [yellow]No significant difference (p >= 0.05)[/yellow]"
             )
 
 
@@ -313,7 +312,7 @@ def compare(
     # Ensure all teams have same size
     team_sizes = [len(team) for team in teams]
     if len(set(team_sizes)) > 1:
-        console.print(f"[red]Error: All teams must have the same size[/red]", err=True)
+        console.print("[red]Error: All teams must have the same size[/red]", err=True)
         console.print(f"Team sizes: {team_sizes}", err=True)
         raise typer.Exit(1)
 
@@ -330,7 +329,7 @@ def compare(
             raise typer.Exit(1)
 
     # Display header
-    console.print(f"\n🎮 [bold]Team Comparison[/bold]")
+    console.print("\n🎮 [bold]Team Comparison[/bold]")
     console.print(f"📋 Scenario types: {', '.join(scenario_types)}")
     console.print(f"🎲 Games per team: {count}")
     console.print(f"👥 Teams to compare: {len(teams)}\n")

--- a/scripts/evaluate_simple.py
+++ b/scripts/evaluate_simple.py
@@ -117,7 +117,7 @@ def main():
     policy.load_state_dict(checkpoint["policy_state_dict"])
     policy.eval()
 
-    print(f"✅ Model loaded successfully")
+    print("✅ Model loaded successfully")
     print(f"   Observation dim: {obs_dim}")
     print(f"   Action dims: {action_dims}")
     print(f"   Hidden size: {hidden_size}")
@@ -125,7 +125,7 @@ def main():
     # Create environment with scenario
     from bucket_brigade.envs import get_scenario_by_name
 
-    print(f"\n🎮 Creating environment")
+    print("\n🎮 Creating environment")
     print(f"   Scenario: {args.scenario}")
     print(f"   Number of opponents: {args.num_opponents}")
 
@@ -141,7 +141,7 @@ def main():
     # Print statistics
     mean_reward = np.mean(episode_rewards)
     std_reward = np.std(episode_rewards)
-    print(f"\n📊 Evaluation Results:")
+    print("\n📊 Evaluation Results:")
     print(f"   Mean Reward: {mean_reward:.2f} ± {std_reward:.2f}")
     print(f"   Min Reward: {np.min(episode_rewards):.2f}")
     print(f"   Max Reward: {np.max(episode_rewards):.2f}")
@@ -157,7 +157,7 @@ def main():
             log_evaluation_result,
         )
 
-        print(f"\n🗄️  Logging evaluation results to database...")
+        print("\n🗄️  Logging evaluation results to database...")
         experiment_session = init_experiments_db(args.experiments_db)
 
         # Find the experiment run by model path

--- a/scripts/evolve_agents.py
+++ b/scripts/evolve_agents.py
@@ -16,7 +16,6 @@ import json
 import time
 from typing import Optional
 
-import numpy as np
 
 from bucket_brigade.evolution import (
     EvolutionConfig,
@@ -24,7 +23,6 @@ from bucket_brigade.evolution import (
     Individual,
     Population,
 )
-from bucket_brigade.envs import default_scenario, greedy_neighbor_scenario
 
 
 def progress_callback(generation: int, population: Population) -> None:
@@ -367,10 +365,10 @@ def main():
     save_results(result, args.output, config)
 
     print("\nTo use the best agent:")
-    print(f"  from bucket_brigade.agents.heuristic_agent import HeuristicAgent")
+    print("  from bucket_brigade.agents.heuristic_agent import HeuristicAgent")
     print(f"  params = {result.best_individual.genome.tolist()}")
     print(
-        f"  agent = HeuristicAgent(params=np.array(params), agent_id=0, name='Evolved Champion')"
+        "  agent = HeuristicAgent(params=np.array(params), agent_id=0, name='Evolved Champion')"
     )
 
 

--- a/scripts/evolve_remote.py
+++ b/scripts/evolve_remote.py
@@ -25,7 +25,6 @@ import time
 from datetime import datetime
 from typing import Optional
 
-import numpy as np
 
 from bucket_brigade.evolution import (
     EvolutionConfig,
@@ -36,16 +35,13 @@ from bucket_brigade.evolution import (
 
 # Try to import Rust evaluator, fall back to Python if unavailable
 try:
-    from bucket_brigade.evolution.fitness_rust import RustFitnessEvaluator
+    from bucket_brigade.evolution.fitness_rust import RustFitnessEvaluator  # noqa: F401
 
     RUST_AVAILABLE = True
 except (ImportError, ModuleNotFoundError) as e:
     print(f"⚠️  Rust evaluator not available ({e}), using Python implementation")
-    from bucket_brigade.evolution.fitness import FitnessEvaluator
 
     RUST_AVAILABLE = False
-
-from bucket_brigade.envs import default_scenario
 
 
 class RemoteEvolutionRunner:
@@ -181,7 +177,7 @@ class RemoteEvolutionRunner:
                 f"✅ Using Rust fitness evaluator with {self.num_workers} workers"
             )
         else:
-            self._log(f"⚠️  Using Python fitness evaluator (slower, no parallel)")
+            self._log("⚠️  Using Python fitness evaluator (slower, no parallel)")
 
         self._log("Starting evolution...")
         self._log("")
@@ -458,7 +454,7 @@ def main():
     )
 
     # Run evolution
-    result = runner.run(seed_individuals=seed_individuals)
+    runner.run(seed_individuals=seed_individuals)
 
     print("\nEvolution complete! Check output directory for results and logs.")
 

--- a/scripts/evolve_v6.py
+++ b/scripts/evolve_v6.py
@@ -45,7 +45,9 @@ def load_evolved_agent(version: str, scenario: str) -> Optional[np.ndarray]:
     Returns:
         Agent parameters or None if not found
     """
-    agent_path = Path(f"experiments/scenarios/{scenario}/evolved_{version}/best_agent.json")
+    agent_path = Path(
+        f"experiments/scenarios/{scenario}/evolved_{version}/best_agent.json"
+    )
     if not agent_path.exists():
         return None
 
@@ -160,13 +162,15 @@ def create_tournament_fitness(
                                 action = agent.get_action(obs)
                                 actions.append(action)
 
-                            obs, rewards, terminated, truncated, info = env.step(actions)
+                            obs, rewards, terminated, truncated, info = env.step(
+                                actions
+                            )
                             total_reward += rewards[0]  # Focal agent reward
                             done = terminated or truncated
 
                         all_payoffs.append(total_reward)
 
-                    except Exception as e:
+                    except Exception:
                         # Penalize failures
                         all_payoffs.append(-200.0)
 
@@ -176,7 +180,9 @@ def create_tournament_fitness(
     return fitness_fn
 
 
-def progress_callback(generation: int, population: Population, output_dir: Path) -> None:
+def progress_callback(
+    generation: int, population: Population, output_dir: Path
+) -> None:
     """Print evolution progress and save checkpoints.
 
     Args:

--- a/scripts/evolve_v6_simple.py
+++ b/scripts/evolve_v6_simple.py
@@ -32,7 +32,9 @@ from bucket_brigade.evolution import (
 from bucket_brigade.envs import list_scenarios
 
 
-def progress_callback(generation: int, population: Population, output_dir: Path) -> None:
+def progress_callback(
+    generation: int, population: Population, output_dir: Path
+) -> None:
     """Print evolution progress and save checkpoints."""
     stats = population.get_fitness_stats()
     diversity = population.get_diversity()
@@ -62,7 +64,9 @@ def progress_callback(generation: int, population: Population, output_dir: Path)
         print(f"  → Checkpoint saved: {checkpoint_path.name}")
 
 
-def save_results(result, output_dir: Path, config: EvolutionConfig, scenario: str) -> None:
+def save_results(
+    result, output_dir: Path, config: EvolutionConfig, scenario: str
+) -> None:
     """Save evolution results."""
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/evolve_v7.py
+++ b/scripts/evolve_v7.py
@@ -31,13 +31,14 @@ from bucket_brigade.evolution import (
     Population,
 )
 from bucket_brigade.evolution.heterogeneous_evaluator import (
-    HeterogeneousEvaluator,
     create_heterogeneous_evaluator,
 )
 from bucket_brigade.envs import list_scenarios
 
 
-def progress_callback(generation: int, population: Population, output_dir: Path) -> None:
+def progress_callback(
+    generation: int, population: Population, output_dir: Path
+) -> None:
     """Print evolution progress and save checkpoints."""
     stats = population.get_fitness_stats()
     diversity = population.get_diversity()
@@ -67,7 +68,9 @@ def progress_callback(generation: int, population: Population, output_dir: Path)
         print(f"  → Checkpoint saved: {checkpoint_path.name}")
 
 
-def save_results(result, output_dir: Path, config: EvolutionConfig, scenario: str) -> None:
+def save_results(
+    result, output_dir: Path, config: EvolutionConfig, scenario: str
+) -> None:
     """Save evolution results."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -119,7 +122,7 @@ def save_results(result, output_dir: Path, config: EvolutionConfig, scenario: st
         f.write(f"Population: {config.population_size}\n")
         f.write(f"Generations: {config.num_generations}\n")
         f.write(f"Mutation Rate: {config.mutation_rate}\n")
-        f.write(f"Fitness Type: heterogeneous_tournament\n")
+        f.write("Fitness Type: heterogeneous_tournament\n")
         f.write(f"Converged At: {result.converged_at}\n\n")
         f.write("Best Individual:\n")
         f.write(f"  Fitness: {result.best_individual.fitness:.4f}\n")
@@ -243,7 +246,7 @@ def main():
     args.output.mkdir(parents=True, exist_ok=True)
 
     # Create heterogeneous evaluator
-    print(f"Creating heterogeneous evaluator...")
+    print("Creating heterogeneous evaluator...")
     print(f"  Opponent pool: {args.opponent_types}")
     evaluator = create_heterogeneous_evaluator(
         scenario_name=args.scenario,
@@ -256,6 +259,7 @@ def main():
     if args.verbose:
         print("\nTesting evaluator on random genome...")
         import numpy as np
+
         test_genome = np.random.rand(10)
         test_fitness = evaluator.evaluate(test_genome, num_games=5, verbose=True)
         print(f"Test fitness: {test_fitness:.2f}")
@@ -302,7 +306,9 @@ def main():
     print()
     start_time = time.time()
 
-    result = ga.evolve(progress_callback=lambda gen, pop: progress_callback(gen, pop, args.output))
+    result = ga.evolve(
+        progress_callback=lambda gen, pop: progress_callback(gen, pop, args.output)
+    )
 
     elapsed_time = time.time() - start_time
 
@@ -314,7 +320,7 @@ def main():
     print(f"Best Fitness: {result.best_individual.fitness:.4f}")
     print(f"Best Generation: {result.best_individual.generation}")
     print(f"Converged At: {result.converged_at}")
-    print(f"Elapsed Time: {elapsed_time:.1f}s ({elapsed_time/60:.1f}min)")
+    print(f"Elapsed Time: {elapsed_time:.1f}s ({elapsed_time / 60:.1f}min)")
     print()
 
     # Save results
@@ -326,12 +332,14 @@ def main():
     print()
     print("Next steps:")
     print("  1. Run tournament validation:")
-    print(f"     uv run python experiments/scripts/run_heterogeneous_tournament.py \\")
-    print(f"       --agents evolved_v7 evolved_v6 firefighter hero free_rider coordinator \\")
+    print("     uv run python experiments/scripts/run_heterogeneous_tournament.py \\")
+    print(
+        "       --agents evolved_v7 evolved_v6 firefighter hero free_rider coordinator \\"
+    )
     print(f"       --scenarios {args.scenario} --num-games 100")
     print()
     print("  2. Compare V7 vs V6:")
-    print(f"     Check if V7 ranks better against free_rider!")
+    print("     Check if V7 ranks better against free_rider!")
     print()
 
 

--- a/scripts/export_definitions.py
+++ b/scripts/export_definitions.py
@@ -24,14 +24,11 @@ def export_archetypes(output_path: Path):
     for name, params in ARCHETYPES.items():
         archetypes[name] = {
             "params": params.tolist(),
-            "description": f"{name.replace('_', ' ').title()} archetype"
+            "description": f"{name.replace('_', ' ').title()} archetype",
         }
 
-    with open(output_path, 'w') as f:
-        json.dump({
-            "version": "1.0",
-            "archetypes": archetypes
-        }, f, indent=2)
+    with open(output_path, "w") as f:
+        json.dump({"version": "1.0", "archetypes": archetypes}, f, indent=2)
 
     print(f"✓ Exported {len(archetypes)} archetypes to {output_path}")
 
@@ -53,14 +50,11 @@ def export_scenarios(output_path: Path):
             "N_min": int(scenario.min_nights),
             "p_spark": float(scenario.prob_house_catches_fire),
             "N_spark": int(scenario.N_spark),
-            "description": _get_scenario_description(name)
+            "description": _get_scenario_description(name),
         }
 
-    with open(output_path, 'w') as f:
-        json.dump({
-            "version": "1.0",
-            "scenarios": scenarios
-        }, f, indent=2)
+    with open(output_path, "w") as f:
+        json.dump({"version": "1.0", "scenarios": scenarios}, f, indent=2)
 
     print(f"✓ Exported {len(scenarios)} scenarios to {output_path}")
 

--- a/scripts/generate_typescript.py
+++ b/scripts/generate_typescript.py
@@ -7,7 +7,7 @@ This script reads JSON definitions and generates TypeScript modules.
 
 import json
 from pathlib import Path
-from textwrap import dedent, indent
+from textwrap import dedent
 
 
 def escape_ts_string(s: str) -> str:
@@ -128,15 +128,15 @@ def generate_archetypes(json_path: Path, output_path: Path):
         code += f"    id: '{name}',\n"
         code += f"    name: '{display_name}',\n"
         code += f"    description: '{escape_ts_string(spec['description'])}',\n"
-        code += f"    params: {{\n"
+        code += "    params: {\n"
 
         # Map parameter array to named parameters
         for i, value in enumerate(spec["params"]):
             param_name = PARAM_NAMES[i]
             code += f"      {param_name}: {value},\n"
 
-        code += f"    }},\n"
-        code += f"  }},\n"
+        code += "    },\n"
+        code += "  },\n"
 
     code += "};\n\n"
 
@@ -146,7 +146,7 @@ def generate_archetypes(json_path: Path, output_path: Path):
         code += f"  {param_name}: {{\n"
         code += f"    label: '{escape_ts_string(desc_info['label'])}',\n"
         code += f"    description: '{escape_ts_string(desc_info['description'])}',\n"
-        code += f"  }},\n"
+        code += "  },\n"
     code += "};\n\n"
 
     # Generate helper functions
@@ -236,11 +236,13 @@ def generate_scenarios(json_path: Path, output_path: Path):
         code += f"  [SCENARIO_TYPES.{constant_name}]: {{\n"
         code += f"    name: '{display_name}',\n"
         code += f"    description: '{escape_ts_string(spec.get('description', ''))}',\n"
-        code += f"    parameters: {{\n"
+        code += "    parameters: {\n"
         code += f"      prob_fire_spreads_to_neighbor: {spec['prob_fire_spreads_to_neighbor']},\n"
         code += f"      prob_solo_agent_extinguishes_fire: {spec['prob_solo_agent_extinguishes_fire']},\n"
         code += f"      prob_house_catches_fire: {spec['prob_house_catches_fire']},\n"
-        code += f"      team_reward_house_survives: {spec['team_reward_house_survives']},\n"
+        code += (
+            f"      team_reward_house_survives: {spec['team_reward_house_survives']},\n"
+        )
         code += f"      team_penalty_house_burns: {spec['team_penalty_house_burns']},\n"
         code += f"      cost_to_work_one_night: {spec['cost_to_work_one_night']},\n"
         code += f"      min_nights: {spec['min_nights']},\n"
@@ -249,8 +251,8 @@ def generate_scenarios(json_path: Path, output_path: Path):
         code += f"      penalty_own_house_burns: {spec.get('penalty_own_house_burns', 0)},\n"
         code += f"      penalty_other_house_burns: {spec.get('penalty_other_house_burns', 0)},\n"
         code += f"      num_agents: {spec.get('num_agents', 4)},\n"
-        code += f"    }},\n"
-        code += f"  }},\n"
+        code += "    },\n"
+        code += "  },\n"
 
     code += "};\n\n"
 

--- a/scripts/list_experiments.py
+++ b/scripts/list_experiments.py
@@ -12,7 +12,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import argparse
-from datetime import datetime
 from bucket_brigade.db.experiments import init_experiments_db
 from bucket_brigade.db.models import ExperimentRun, TrainingMetric, EvaluationResult
 
@@ -55,7 +54,7 @@ def show_run_details(session, run_name):
     print(f"\n🔬 Experiment Run: {run.run_name} (ID: {run.id})")
     print("=" * 80)
 
-    print(f"\n📋 Basic Info:")
+    print("\n📋 Basic Info:")
     print(f"   Scenario: {run.scenario}")
     print(f"   Model Path: {run.model_path}")
     print(f"   Started: {run.started_at.strftime('%Y-%m-%d %H:%M:%S')}")
@@ -64,15 +63,15 @@ def show_run_details(session, run_name):
         duration = (run.completed_at - run.started_at).total_seconds() / 60
         print(f"   Duration: {duration:.1f} minutes")
     else:
-        print(f"   Status: Running")
+        print("   Status: Running")
 
     if run.hyperparameters:
-        print(f"\n⚙️  Hyperparameters:")
+        print("\n⚙️  Hyperparameters:")
         for key, value in run.hyperparameters.items():
             print(f"   {key}: {value}")
 
     if run.final_stats:
-        print(f"\n📊 Final Statistics:")
+        print("\n📊 Final Statistics:")
         for key, value in run.final_stats.items():
             print(f"   {key}: {value}")
 
@@ -100,7 +99,7 @@ def show_run_details(session, run_name):
     )
 
     if evaluations:
-        print(f"\n🎯 Evaluation Results:")
+        print("\n🎯 Evaluation Results:")
         print(f"   {'Scenario':<25} {'Mean Reward':<15} {'Episodes':<10} {'Date':<20}")
         print("   " + "-" * 70)
         for eval in evaluations:

--- a/scripts/test_nash_minimal.py
+++ b/scripts/test_nash_minimal.py
@@ -110,11 +110,11 @@ print("\n" + "-" * 80)
 print("Computing Nash Equilibrium (Linear Programming)")
 print("-" * 80)
 
-from bucket_brigade.equilibrium.nash_solver import solve_symmetric_nash
+from bucket_brigade.equilibrium.nash_solver import solve_symmetric_nash  # noqa: E402
 
 distribution = solve_symmetric_nash(payoff_matrix)
 
-print(f"\nEquilibrium strategy:")
+print("\nEquilibrium strategy:")
 print(f"  Play Firefighter: {distribution[0]:.1%}")
 print(f"  Play Free Rider:  {distribution[1]:.1%}")
 

--- a/scripts/test_nash_ultra_minimal.py
+++ b/scripts/test_nash_ultra_minimal.py
@@ -4,19 +4,19 @@ Ultra-minimal test - just 2 simulations to verify correctness.
 Should complete in under 30 seconds.
 """
 
-import numpy as np
-
 print("Starting ultra-minimal Nash equilibrium test...")
 
-from bucket_brigade.envs import trivial_cooperation_scenario
-from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
-from bucket_brigade.equilibrium.payoff_evaluator import PayoffEvaluator
+from bucket_brigade.envs import trivial_cooperation_scenario  # noqa: E402
+from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS  # noqa: E402
+from bucket_brigade.equilibrium.payoff_evaluator import PayoffEvaluator  # noqa: E402
 
 print("Imports successful!")
 
 # Trivial scenario
 scenario = trivial_cooperation_scenario(num_agents=4)
-print(f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}")
+print(
+    f"Scenario: beta={scenario.prob_fire_spreads_to_neighbor}, kappa={scenario.prob_solo_agent_extinguishes_fire}"
+)
 
 # Just 2 simulations, sequential
 evaluator = PayoffEvaluator(

--- a/scripts/test_rust_fitness.py
+++ b/scripts/test_rust_fitness.py
@@ -15,7 +15,7 @@ print("=" * 80)
 
 # Create scenario
 scenario = default_scenario(num_agents=1)
-print(f"\nScenario: Default (num_agents=1)")
+print("\nScenario: Default (num_agents=1)")
 print(f"  beta:  {scenario.prob_fire_spreads_to_neighbor}")
 print(f"  kappa: {scenario.prob_solo_agent_extinguishes_fire}")
 print(f"  c (work cost): {scenario.cost_to_work_one_night}")
@@ -73,11 +73,11 @@ print("-" * 80)
 
 if firefighter_fitness > free_rider_fitness:
     advantage = firefighter_fitness - free_rider_fitness
-    print(f"\n✓ Firefighter strategy is SUPERIOR")
+    print("\n✓ Firefighter strategy is SUPERIOR")
     print(f"  Advantage: {advantage:.2f} points")
 else:
     advantage = free_rider_fitness - firefighter_fitness
-    print(f"\n✓ Free Rider strategy is SUPERIOR")
+    print("\n✓ Free Rider strategy is SUPERIOR")
     print(f"  Advantage: {advantage:.2f} points")
 
 print("\n" + "=" * 80)

--- a/scripts/test_rust_payoff.py
+++ b/scripts/test_rust_payoff.py
@@ -4,7 +4,6 @@ Test Rust-backed payoff evaluator - should be FAST!
 """
 
 import time
-import numpy as np
 from bucket_brigade.envs import greedy_neighbor_scenario
 from bucket_brigade.agents.archetypes import FIREFIGHTER_PARAMS, FREE_RIDER_PARAMS
 from bucket_brigade.equilibrium.payoff_evaluator_rust import RustPayoffEvaluator
@@ -15,10 +14,12 @@ print("=" * 80)
 
 # Greedy neighbor scenario
 scenario = greedy_neighbor_scenario(num_agents=4)
-print(f"\nScenario: Greedy Neighbor (high work cost)")
+print("\nScenario: Greedy Neighbor (high work cost)")
 print(f"  beta:  {scenario.prob_fire_spreads_to_neighbor}")
 print(f"  kappa: {scenario.prob_solo_agent_extinguishes_fire}")
-print(f"  c (work cost): {scenario.cost_to_work_one_night}  ← High cost creates free-riding incentive")
+print(
+    f"  c (work cost): {scenario.cost_to_work_one_night}  ← High cost creates free-riding incentive"
+)
 
 # Create Rust evaluator
 print("\n" + "-" * 80)
@@ -89,21 +90,21 @@ print("-" * 80)
 
 if fr_vs_ff > ff_vs_ff:
     advantage = fr_vs_ff - ff_vs_ff
-    print(f"\n✓ Free-riding is PROFITABLE when others cooperate")
+    print("\n✓ Free-riding is PROFITABLE when others cooperate")
     print(f"  Advantage: {advantage:.2f} points")
-    print(f"  → Creates incentive to free-ride")
+    print("  → Creates incentive to free-ride")
 else:
-    print(f"\n✓ Cooperation is STABLE")
-    print(f"  → Firefighter does better even when opponents cooperate")
+    print("\n✓ Cooperation is STABLE")
+    print("  → Firefighter does better even when opponents cooperate")
 
 if ff_vs_fr > fr_vs_fr:
     advantage = ff_vs_fr - fr_vs_fr
-    print(f"\n✓ Cooperation PUNISHES free-riders")
+    print("\n✓ Cooperation PUNISHES free-riders")
     print(f"  Firefighters get {advantage:.2f} more points vs free-riders")
-    print(f"  → Provides deterrent against free-riding")
+    print("  → Provides deterrent against free-riding")
 else:
-    print(f"\n✓ Free-riding is safe")
-    print(f"  → Free-riders not punished when others also free-ride")
+    print("\n✓ Free-riding is safe")
+    print("  → Free-riders not punished when others also free-ride")
 
 print("\n" + "=" * 80)
 print("SUCCESS! Rust backend is working and FAST!")

--- a/scripts/test_team.py
+++ b/scripts/test_team.py
@@ -333,7 +333,7 @@ def test(
     typer.echo("\n" + "=" * 60)
     typer.echo("📊 TOURNAMENT RESULTS")
     typer.echo("=" * 60)
-    typer.echo(f"\n🏆 Team Performance:")
+    typer.echo("\n🏆 Team Performance:")
     typer.echo(
         f"   Mean Team Reward: {stats['team_reward']['mean']:.2f} ± {stats['team_reward']['std']:.2f}"
     )
@@ -342,19 +342,19 @@ def test(
         f"   Range: [{stats['team_reward']['min']:.2f}, {stats['team_reward']['max']:.2f}]"
     )
 
-    typer.echo(f"\n🏠 Houses Saved:")
+    typer.echo("\n🏠 Houses Saved:")
     typer.echo(
         f"   Mean: {stats['houses_saved']['mean']:.2f} ± {stats['houses_saved']['std']:.2f}"
     )
     typer.echo(f"   Median: {stats['houses_saved']['median']:.2f}")
     typer.echo(f"   Success Rate (≥5): {stats['success_rate'] * 100:.1f}%")
 
-    typer.echo(f"\n⏱️  Game Length:")
+    typer.echo("\n⏱️  Game Length:")
     typer.echo(
         f"   Mean Nights: {stats['nights_played']['mean']:.1f} ± {stats['nights_played']['std']:.1f}"
     )
 
-    typer.echo(f"\n👥 Agent Contributions (by mean reward):")
+    typer.echo("\n👥 Agent Contributions (by mean reward):")
     for i, contrib in enumerate(results["agent_contributions"], 1):
         typer.echo(
             f"   {i}. {contrib['archetype']:12s} ({contrib['agent_id']}): "

--- a/scripts/train_curriculum.py
+++ b/scripts/train_curriculum.py
@@ -13,18 +13,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import argparse
-import time
 from collections import deque
 
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.optim as optim
-from torch.utils.tensorboard import SummaryWriter
 
-from bucket_brigade.envs import get_scenario_by_name
-from bucket_brigade.envs.puffer_env import PufferBucketBrigade
-from bucket_brigade.training import CurriculumTrainer, PolicyNetwork
+from bucket_brigade.training import CurriculumTrainer
 
 
 def compute_gae(rewards, values, dones, gamma=0.99, gae_lambda=0.95):

--- a/scripts/train_multi_gpu.py
+++ b/scripts/train_multi_gpu.py
@@ -161,7 +161,7 @@ def main():
     action_dims = vecenv.single_action_space.nvec.tolist()
 
     if is_master:
-        print(f"🧠 Creating policy network")
+        print("🧠 Creating policy network")
         print(f"   Observation dim: {obs_dim}")
         print(f"   Action dims: {action_dims}")
 
@@ -173,7 +173,7 @@ def main():
     if dist_info["distributed"]:
         policy = DDP(policy, device_ids=[dist_info["local_rank"]])
         if is_master:
-            print(f"✅ Policy wrapped with DistributedDataParallel")
+            print("✅ Policy wrapped with DistributedDataParallel")
 
     optimizer = torch.optim.Adam(policy.parameters(), lr=args.lr)
 

--- a/scripts/train_puffer_gpu.py
+++ b/scripts/train_puffer_gpu.py
@@ -35,7 +35,9 @@ def make_env_func(scenario=None, num_opponents=3, **kwargs):
         scenario_obj = get_scenario_by_name(scenario, num_agents=num_opponents + 1)
 
     # PufferBucketBrigade is now a native PufferEnv, no wrapping needed
-    env = PufferBucketBrigade(scenario=scenario_obj, num_opponents=num_opponents, **kwargs)
+    env = PufferBucketBrigade(
+        scenario=scenario_obj, num_opponents=num_opponents, **kwargs
+    )
     return env
 
 
@@ -75,7 +77,7 @@ def train_ppo_vectorized(
             f"⚠️  Warning: batch_size ({batch_size}) not divisible by minibatch_size ({minibatch_size})"
         )
 
-    print(f"🚀 Starting high-throughput vectorized training")
+    print("🚀 Starting high-throughput vectorized training")
     print(
         f"📊 Num envs: {num_envs}, Steps/env: {num_steps_per_env}, Batch: {batch_size:,}"
     )
@@ -106,12 +108,18 @@ def train_ppo_vectorized(
     next_done = torch.zeros(num_envs).to(device)
 
     num_updates = num_steps // batch_size
-    print(f"✅ Environments initialized, starting training loop ({num_updates} updates)...", flush=True)
+    print(
+        f"✅ Environments initialized, starting training loop ({num_updates} updates)...",
+        flush=True,
+    )
 
     for update in range(1, num_updates + 1):
         # DEBUG: Log progress every update
         if update % 10 == 0:
-            print(f"[DEBUG] Starting update {update}/{num_updates}, global_step={global_step}", flush=True)
+            print(
+                f"[DEBUG] Starting update {update}/{num_updates}, global_step={global_step}",
+                flush=True,
+            )
 
         # Collect rollout
         for step in range(num_steps_per_env):
@@ -169,7 +177,6 @@ def train_ppo_vectorized(
         b_actions = actions_buffer.reshape((-1, len(single_action_space.nvec)))
         b_advantages = advantages.reshape(-1)
         b_returns = returns.reshape(-1)
-        b_values = values_buffer.reshape(-1)
 
         # Optimizing the policy and value network using minibatches
         b_inds = np.arange(batch_size)
@@ -191,7 +198,7 @@ def train_ppo_vectorized(
 
                 with torch.no_grad():
                     # calculate approx_kl http://joschu.net/blog/kl-approx.html
-                    old_approx_kl = (-logratio).mean()
+                    _old_approx_kl = (-logratio).mean()  # noqa: F841 (kept for parity with reference PPO)
                     approx_kl = ((ratio - 1) - logratio).mean()
                     clipfracs += [
                         ((ratio - 1.0).abs() > clip_epsilon).float().mean().item()
@@ -255,7 +262,9 @@ def train_ppo_vectorized(
         # Use floor division to detect when we cross a checkpoint boundary
         checkpoint_interval = 500000
         current_checkpoint = global_step // checkpoint_interval
-        if current_checkpoint > 0 and not hasattr(train_ppo_vectorized, f'_checkpoint_{current_checkpoint}_saved'):
+        if current_checkpoint > 0 and not hasattr(
+            train_ppo_vectorized, f"_checkpoint_{current_checkpoint}_saved"
+        ):
             checkpoint_step = current_checkpoint * checkpoint_interval
             checkpoint_path = f"{writer.log_dir}/checkpoint_{checkpoint_step}.pt"
             torch.save(
@@ -268,8 +277,13 @@ def train_ppo_vectorized(
                 checkpoint_path,
             )
             # Mark this checkpoint as saved to avoid duplicates
-            setattr(train_ppo_vectorized, f'_checkpoint_{current_checkpoint}_saved', True)
-            print(f"💾 Checkpoint saved: {checkpoint_path} (at step {global_step})", flush=True)
+            setattr(
+                train_ppo_vectorized, f"_checkpoint_{current_checkpoint}_saved", True
+            )
+            print(
+                f"💾 Checkpoint saved: {checkpoint_path} (at step {global_step})",
+                flush=True,
+            )
 
     print(
         f"\n{'=' * 60}\n"
@@ -411,7 +425,7 @@ def main():
     obs_dim = vecenv.single_observation_space.shape[0]
     action_dims = vecenv.single_action_space.nvec.tolist()
 
-    print(f"🧠 Creating policy network", flush=True)
+    print("🧠 Creating policy network", flush=True)
     print(f"   Observation dim: {obs_dim}")
     print(f"   Action dims: {action_dims}")
 

--- a/scripts/train_simple.py
+++ b/scripts/train_simple.py
@@ -312,21 +312,21 @@ def main():
         return
 
     # Set seeds
-    print(f"🔍 DEBUG: Setting random seeds", flush=True)
+    print("🔍 DEBUG: Setting random seeds", flush=True)
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
     # Create environment with scenario
-    print(f"🔍 DEBUG: Importing scenario functions", flush=True)
+    print("🔍 DEBUG: Importing scenario functions", flush=True)
     from bucket_brigade.envs import get_scenario_by_name
 
     print(f"🎮 Creating environment with scenario: {args.scenario}", flush=True)
     print(f"   Number of opponents: {args.num_opponents}")
 
     scenario = get_scenario_by_name(args.scenario, num_agents=args.num_opponents + 1)
-    print(f"🔍 DEBUG: Got scenario, creating environment...", flush=True)
+    print("🔍 DEBUG: Got scenario, creating environment...", flush=True)
     env = PufferBucketBrigade(scenario=scenario, num_opponents=args.num_opponents)
-    print(f"🔍 DEBUG: Environment created!", flush=True)
+    print("🔍 DEBUG: Environment created!", flush=True)
 
     # Create policy
     obs_dim = env.observation_space.shape[0]
@@ -342,7 +342,7 @@ def main():
             flush=True,
         )
 
-    print(f"🧠 Creating policy network", flush=True)
+    print("🧠 Creating policy network", flush=True)
     print(f"   Observation dim: {obs_dim}")
     print(f"   Action dims: {action_dims}")
 
@@ -358,7 +358,7 @@ def main():
 
     writer = SummaryWriter(f"runs/{args.run_name}")
     print(f"📊 TensorBoard logging to: runs/{args.run_name}")
-    print(f"   View with: tensorboard --logdir runs/")
+    print("   View with: tensorboard --logdir runs/")
 
     # Log hyperparameters
     writer.add_text("hyperparameters/scenario", args.scenario)
@@ -378,7 +378,7 @@ def main():
             complete_experiment_run,
         )
 
-        print(f"🗄️  Initializing experiment tracking...")
+        print("🗄️  Initializing experiment tracking...")
         experiment_session = init_experiments_db(args.experiments_db)
 
         # Create experiment run
@@ -428,7 +428,7 @@ def main():
             }
             complete_experiment_run(experiment_session, experiment_run.id, final_stats)
             experiment_session.close()
-            print(f"✅ Experiment tracking completed")
+            print("✅ Experiment tracking completed")
 
     # Save model
     Path(args.save_path).parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tune_hyperparameters.py
+++ b/scripts/tune_hyperparameters.py
@@ -309,7 +309,7 @@ def main():
         args.study_name = f"ppo_tune_{args.scenario}_{int(time.time())}"
 
     print(f"\n{'=' * 70}")
-    print(f"🔍 Hyperparameter Tuning Configuration")
+    print("🔍 Hyperparameter Tuning Configuration")
     print(f"{'=' * 70}")
     print(f"Scenario: {args.scenario}")
     print(f"Study name: {args.study_name}")
@@ -339,7 +339,7 @@ def main():
     )
 
     # Run optimization
-    print(f"🚀 Starting hyperparameter optimization...\n")
+    print("🚀 Starting hyperparameter optimization...\n")
 
     try:
         study.optimize(
@@ -353,14 +353,14 @@ def main():
 
     # Print results
     print(f"\n{'=' * 70}")
-    print(f"✅ Optimization Complete!")
+    print("✅ Optimization Complete!")
     print(f"{'=' * 70}")
     print(f"Number of finished trials: {len(study.trials)}")
-    print(f"Best trial:")
+    print("Best trial:")
 
     trial = study.best_trial
     print(f"  Value (mean reward): {trial.value:.2f}")
-    print(f"  Params:")
+    print("  Params:")
     for key, value in trial.params.items():
         print(f"    {key}: {value}")
 
@@ -418,12 +418,12 @@ def main():
 
     # Print recommended command
     print("🎯 To train with best hyperparameters, run:")
-    print(f"\nuv run python scripts/train_simple.py \\")
+    print("\nuv run python scripts/train_simple.py \\")
     print(f"  --scenario {args.scenario} \\")
     print(f"  --hidden-size {trial.params['hidden_size']} \\")
     print(f"  --lr {trial.params['learning_rate']:.2e} \\")
     print(f"  --batch-size {trial.params['batch_size']} \\")
-    print(f"  --num-steps 500000\n")
+    print("  --num-steps 500000\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_bc_fit_only_hidden_size.py
+++ b/tests/test_bc_fit_only_hidden_size.py
@@ -47,7 +47,9 @@ def test_policy_network_accepts_hidden_size(hidden_size: int) -> None:
     from the 10-way house head. Verify all three heads + value head emit
     the expected batch shapes at each capacity level.
     """
-    obs_dim = 42  # minimal_specialization flat-obs dim (4 agents x 10 houses x 4 + global)
+    obs_dim = (
+        42  # minimal_specialization flat-obs dim (4 agents x 10 houses x 4 + global)
+    )
     action_dims = [10, 2, 2]
     batch = 8
 


### PR DESCRIPTION
## Summary

`main` has been failing `lint-python` and `pre-commit` since PR #307 merged. This PR brings it back to green.

- 91 ruff auto-fixes (mostly 71x F541 "f-string without placeholders" in research scripts and analyzers)
- `ruff format` drift on 15 files
- 3 bandit warnings in PR #306's PBT orchestrator silenced with scoped `# nosec` (subprocess + random — research code, not crypto)
- A handful of unused vars / imports cleaned up (HCA's `T`, evolve_remote's `result`, train_puffer_gpu's `b_values`)
- E402 noqa for intentional post-print imports in `scripts/test_nash_*.py`

## Test plan

- [x] `uv run ruff check .` → all checks passed
- [x] `uv run ruff format --check .` → all 186 files formatted
- [x] `uv run pre-commit run --all-files` → all hooks pass
- [x] HCA tests pass (verifying `T` removal in `compute_hca_advantages`)
- [x] Local environment / joint_trainer regression: clean
- [ ] CI: verify lint-python + pre-commit go green

No behavior change. Pre-existing Rust-parity test failures locally (`tests/test_progress_shaping.py::TestProgressShapingRustParity`) are unrelated — they require the Rust extension to be rebuilt against the post-#299 schema; CI rebuilds it via wasm-pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)