### PR TITLE
fix(p3): extend LOLA CellConfig mutex to post-#312 knobs

### DIFF
--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -720,6 +720,40 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
                 "shared loss, while LOLA's opponent-shaping term assumes "
                 "independent inner gradient steps per agent. Pick one."
             )
+        # Issue #313: four additional CellConfig knobs landed on main after
+        # PR #303 (LOLA) was authored. The if-cfg.lola_dice trainer switch
+        # at ``train.py:787`` constructs ``LolaTrainer`` with only LOLA-
+        # specific kwargs, so each of these is silently dropped on the
+        # floor unless we surface the conflict here.
+        if cfg.coma:
+            raise ValueError(
+                "cfg.lola_dice=True is incompatible with cfg.coma=True. "
+                "COMA installs a CentralizedQCritic and replaces the per-agent "
+                "advantage with a counterfactual Q-value, conflicting with LOLA's "
+                "independent per-agent inner gradient step. Pick one."
+            )
+        if cfg.advantage_estimator != "gae":
+            raise ValueError(
+                f"cfg.lola_dice=True is incompatible with "
+                f"cfg.advantage_estimator={cfg.advantage_estimator!r}. LOLA-DiCE "
+                "uses its own opponent-shaping surrogate; substituting the "
+                "advantage estimator would conflate two unrelated experiments. "
+                "Pick one."
+            )
+        if cfg.influence_coef > 0:
+            raise ValueError(
+                "cfg.lola_dice=True is incompatible with cfg.influence_coef > 0. "
+                "Social-influence intrinsic reward couples agents through a "
+                "counterfactual KL bonus, while LOLA assumes independent "
+                "inner-step opponents. Pick one."
+            )
+        if cfg.macro_actions:
+            raise ValueError(
+                "cfg.lola_dice=True is incompatible with cfg.macro_actions=True. "
+                "The LOLA-DiCE x MacroActionEnv interaction is untested; the DiCE "
+                "magic-box surrogate's behavior under temporally-extended actions "
+                "has not been validated. Pick one."
+            )
 
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/training/test_lola_trainer.py
+++ b/tests/training/test_lola_trainer.py
@@ -162,6 +162,118 @@ class TestMutualExclusion:
                 cfg, output_dir=__import__("pathlib").Path("/tmp/should-not-create")
             )
 
+    # ------------------------------------------------------------------
+    # Issue #313: post-#312 CellConfig knobs (COMA / HCA / influence /
+    # macro-actions) must also raise when combined with lola_dice=True.
+    # The existing if-cfg.lola_dice trainer switch silently dropped these
+    # flags before this guard was extended.
+    # ------------------------------------------------------------------
+
+    def test_cellconfig_guard_lola_plus_coma(self):
+        from experiments.p3_specialization.train import CellConfig, train_one_cell
+
+        cfg = CellConfig(
+            scenario=SCENARIO,
+            lambda_red=0.0,
+            seed=0,
+            num_iterations=1,
+            rollout_steps=SMOKE_ROLLOUT,
+            num_agents=NUM_AGENTS,
+            lola_dice=True,
+            coma=True,
+        )
+        with pytest.raises(ValueError, match="coma"):
+            train_one_cell(
+                cfg, output_dir=__import__("pathlib").Path("/tmp/should-not-create")
+            )
+
+    def test_cellconfig_guard_lola_plus_hca(self):
+        from experiments.p3_specialization.train import CellConfig, train_one_cell
+
+        cfg = CellConfig(
+            scenario=SCENARIO,
+            lambda_red=0.0,
+            seed=0,
+            num_iterations=1,
+            rollout_steps=SMOKE_ROLLOUT,
+            num_agents=NUM_AGENTS,
+            lola_dice=True,
+            advantage_estimator="hca",
+        )
+        with pytest.raises(ValueError, match="advantage_estimator"):
+            train_one_cell(
+                cfg, output_dir=__import__("pathlib").Path("/tmp/should-not-create")
+            )
+
+    def test_cellconfig_guard_lola_plus_influence(self):
+        from experiments.p3_specialization.train import CellConfig, train_one_cell
+
+        cfg = CellConfig(
+            scenario=SCENARIO,
+            lambda_red=0.0,
+            seed=0,
+            num_iterations=1,
+            rollout_steps=SMOKE_ROLLOUT,
+            num_agents=NUM_AGENTS,
+            lola_dice=True,
+            influence_coef=0.1,
+        )
+        with pytest.raises(ValueError, match="influence_coef"):
+            train_one_cell(
+                cfg, output_dir=__import__("pathlib").Path("/tmp/should-not-create")
+            )
+
+    def test_cellconfig_guard_lola_plus_macro_actions(self):
+        from experiments.p3_specialization.train import CellConfig, train_one_cell
+
+        cfg = CellConfig(
+            scenario=SCENARIO,
+            lambda_red=0.0,
+            seed=0,
+            num_iterations=1,
+            rollout_steps=SMOKE_ROLLOUT,
+            num_agents=NUM_AGENTS,
+            lola_dice=True,
+            macro_actions=True,
+        )
+        with pytest.raises(ValueError, match="macro_actions"):
+            train_one_cell(
+                cfg, output_dir=__import__("pathlib").Path("/tmp/should-not-create")
+            )
+
+    def test_cellconfig_lola_alone_passes(self, tmp_path, monkeypatch):
+        """Sanity: ``lola_dice=True`` with all other knobs at default must
+        clear the mutex block. We monkeypatch the LolaTrainer so the test
+        verifies validation only — not a full rollout."""
+        from experiments.p3_specialization import train as train_mod
+        from experiments.p3_specialization.train import CellConfig, train_one_cell
+
+        constructed = {"hit": False}
+
+        class _StubTrainer:
+            def __init__(self, **kwargs):
+                constructed["hit"] = True
+                raise RuntimeError("short-circuit: mutex check passed")
+
+        monkeypatch.setattr(train_mod, "LolaTrainer", _StubTrainer)
+
+        cfg = CellConfig(
+            scenario=SCENARIO,
+            lambda_red=0.0,
+            seed=0,
+            num_iterations=1,
+            rollout_steps=SMOKE_ROLLOUT,
+            num_agents=NUM_AGENTS,
+            lola_dice=True,
+        )
+        # The mutex block must not raise. The stubbed trainer raises a
+        # distinct RuntimeError to confirm we reached construction.
+        with pytest.raises(RuntimeError, match="short-circuit"):
+            train_one_cell(cfg, output_dir=tmp_path / "lola-alone")
+        assert constructed["hit"], (
+            "Mutex block short-circuited; LOLA-alone happy path is broken."
+        )
+
 
 # ----------------------------------------------------------------------
 # Bucket-brigade smoke test


### PR DESCRIPTION
## Summary

Closes #313. Extends the existing LOLA CellConfig mutex block in
`experiments/p3_specialization/train.py` to cover the four knobs that
landed on `main` after PR #303 was authored. Previously, combining
`lola_dice=True` with `coma=True`, `advantage_estimator="hca"`,
`influence_coef > 0`, or `macro_actions=True` silently took the LOLA
branch and dropped the secondary flag on the floor.

## Changes

- `experiments/p3_specialization/train.py`: inside the existing
  `if cfg.lola_dice:` block, add 4 new `ValueError` raises following the
  existing pattern ("Pick one." suffix, one-sentence why-incoherent).
- `tests/training/test_lola_trainer.py`: add 4 new
  `test_cellconfig_guard_lola_plus_*` tests plus a
  `test_cellconfig_lola_alone_passes` sanity check (stubs `LolaTrainer`
  via monkeypatch to verify the LOLA-only path clears the mutex block
  without running a full rollout).

Note on `macro_actions`: strictly speaking, `action_dims` is already
forwarded to `LolaTrainer` correctly, so this knob is not silently
dropped in the same way as the other three. However, the
LOLA-DiCE x MacroActionEnv interaction is untested and the DiCE
magic-box surrogate's behavior under temporally-extended actions has
not been validated. Raising surfaces the constraint explicitly per
curator guidance.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| LOLA + COMA raises | yes | `test_cellconfig_guard_lola_plus_coma` passes |
| LOLA + non-gae advantage_estimator raises | yes | `test_cellconfig_guard_lola_plus_hca` passes (also CLI smoke `--lola-dice --use-hca`) |
| LOLA + influence_coef>0 raises | yes | `test_cellconfig_guard_lola_plus_influence` passes |
| LOLA + macro_actions raises | yes | `test_cellconfig_guard_lola_plus_macro_actions` passes |
| Existing LOLA+centralized_critic guard still works | yes | `test_cellconfig_guard_lola_plus_centralized_critic` passes |
| Existing LOLA+lambda_red>0 guard still works | yes | `test_cellconfig_guard_lola_plus_lambda_red` passes |
| LOLA-alone happy path still trains | yes | `test_cellconfig_lola_alone_passes` + CLI smoke (`--lola-dice` alone successfully ran iter 0) |
| Error messages name flag, explain why, end "Pick one." | yes | All 4 new messages follow the existing pattern |

## Test Plan

- `uv run python -m pytest tests/training/test_lola_trainer.py::TestMutualExclusion -v`
  -> 10/10 pass (5 existing + 5 new).
- CLI: `python -m experiments.p3_specialization.train --lola-dice --use-hca ...`
  raises `ValueError` matching `advantage_estimator='hca'`.
- CLI: `python -m experiments.p3_specialization.train --lola-dice ...`
  alone clears mutex, prints `iter 0` and proceeds.
- `ruff format` + `ruff check` clean.

Closes #313