### PR TITLE
fix(nash): df-precheck before compute to fail fast on disk-full

### DIFF
--- a/experiments/scripts/_disk_precheck.py
+++ b/experiments/scripts/_disk_precheck.py
@@ -1,0 +1,94 @@
+"""
+Disk-space precheck helper for long-running experiment scripts.
+
+These scripts (e.g., ``compute_nash.py``, ``compute_nash_v2.py``) can run for
+tens of minutes performing CPU-expensive simulations, and only at the very end
+write a small JSON artifact (~1.5–2 KB) to the output directory. When the
+filesystem is full at write time, all of that compute is wasted with an
+``OSError: [Errno 28] No space left on device`` traceback.
+
+This helper provides a small startup-time check: resolve the output directory
+to its existing parent, ``os.statvfs`` the filesystem, and abort early with a
+clear error message if the free space is below a configurable threshold.
+
+The default threshold is 100 MiB — overkill for the artifact itself (KB-scale)
+but enough headroom for ``tee``-style log files and other co-located output
+that accumulates during a sweep. See issue #269.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Default minimum free space (in MiB) required to proceed. Conservative to
+# leave headroom for log files via `tee` and other co-located outputs.
+DEFAULT_MIN_FREE_MIB = 100
+
+# Conversion constant.
+BYTES_PER_MIB = 1024 * 1024
+
+
+def _resolve_existing_parent(path: Path) -> Path:
+    """Return the nearest existing ancestor of ``path``.
+
+    ``os.statvfs`` requires an existing path. Output directories are typically
+    created lazily by the calling script, so we walk up to the first existing
+    parent (which lives on the same filesystem as the eventual target).
+    """
+    candidate = path.resolve()
+    while not candidate.exists():
+        parent = candidate.parent
+        if parent == candidate:
+            # Reached the filesystem root and it does not exist (extremely
+            # unlikely on a sane system, but guard anyway).
+            return Path("/")
+        candidate = parent
+    return candidate
+
+
+def check_free_space(
+    output_dir: Path,
+    min_free_mib: int = DEFAULT_MIN_FREE_MIB,
+) -> None:
+    """Abort the process if free space on ``output_dir``'s filesystem is low.
+
+    The function uses ``os.statvfs`` against the nearest existing ancestor of
+    ``output_dir`` (so it works before the directory is created). On
+    insufficient space it writes a clear error message to stderr and calls
+    ``sys.exit(1)`` — BEFORE any compute starts in the caller.
+
+    Args:
+        output_dir: The directory where the script intends to write outputs.
+            May or may not exist yet.
+        min_free_mib: Minimum required free space, in MiB. Defaults to 100.
+
+    Exits:
+        With status 1 if free bytes are below ``min_free_mib`` MiB, or if
+        the filesystem cannot be statted for some reason.
+    """
+    output_dir = Path(output_dir)
+    target = _resolve_existing_parent(output_dir)
+
+    try:
+        stats = os.statvfs(target)
+    except OSError as exc:
+        print(
+            f"ERROR: could not stat filesystem for '{target}': {exc}. "
+            "Aborting before compute.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    free_bytes = stats.f_bavail * stats.f_frsize
+    required_bytes = min_free_mib * BYTES_PER_MIB
+
+    if free_bytes < required_bytes:
+        free_mib = free_bytes / BYTES_PER_MIB
+        print(
+            f"ERROR: only {free_mib:.1f} MiB free on '{target}'; "
+            f"need at least {min_free_mib} MiB. Aborting before compute.",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/experiments/scripts/compute_nash.py
+++ b/experiments/scripts/compute_nash.py
@@ -16,8 +16,12 @@ from typing import Optional
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+# Also expose this script's own directory so sibling helpers
+# (e.g. _disk_precheck) can be imported without needing a package.
+sys.path.insert(0, str(Path(__file__).parent))
 
 import numpy as np
+from _disk_precheck import DEFAULT_MIN_FREE_MIB, check_free_space
 from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import DoubleOracle
 from bucket_brigade.agents.archetypes import (
@@ -304,6 +308,15 @@ def main():
     parser.add_argument(
         "--output-dir", type=Path, default=None, help="Output directory"
     )
+    parser.add_argument(
+        "--min-free-mib",
+        type=int,
+        default=DEFAULT_MIN_FREE_MIB,
+        help=(
+            "Minimum free space (MiB) required on the output filesystem; "
+            "abort before compute if free space is below this threshold."
+        ),
+    )
     parser.add_argument("--quiet", action="store_true", help="Reduce output verbosity")
 
     args = parser.parse_args()
@@ -311,6 +324,9 @@ def main():
     # Default output directory
     if args.output_dir is None:
         args.output_dir = Path(f"experiments/scenarios/{args.scenario}/nash")
+
+    # Disk-space precheck: fail fast on disk-full BEFORE any compute (issue #269).
+    check_free_space(args.output_dir, min_free_mib=args.min_free_mib)
 
     compute_nash_equilibrium(
         args.scenario,

--- a/experiments/scripts/compute_nash_v2.py
+++ b/experiments/scripts/compute_nash_v2.py
@@ -20,8 +20,12 @@ from typing import Optional, List
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+# Also expose this script's own directory so sibling helpers
+# (e.g. _disk_precheck) can be imported without needing a package.
+sys.path.insert(0, str(Path(__file__).parent))
 
 import numpy as np
+from _disk_precheck import DEFAULT_MIN_FREE_MIB, check_free_space
 from bucket_brigade.envs import get_scenario_by_name
 from bucket_brigade.equilibrium import (
     DoubleOracle,
@@ -390,6 +394,15 @@ def main():
         default=None,
         help="Output directory",
     )
+    parser.add_argument(
+        "--min-free-mib",
+        type=int,
+        default=DEFAULT_MIN_FREE_MIB,
+        help=(
+            "Minimum free space (MiB) required on the output filesystem; "
+            "abort before compute if free space is below this threshold."
+        ),
+    )
     parser.add_argument("--quiet", action="store_true", help="Reduce output verbosity")
 
     args = parser.parse_args()
@@ -397,6 +410,9 @@ def main():
     # Default output directory
     if args.output_dir is None:
         args.output_dir = Path(f"experiments/nash/v2_results/{args.scenario}")
+
+    # Disk-space precheck: fail fast on disk-full BEFORE any compute (issue #269).
+    check_free_space(args.output_dir, min_free_mib=args.min_free_mib)
 
     compute_nash_v2(
         args.scenario,

--- a/tests/test_compute_nash_df_precheck.py
+++ b/tests/test_compute_nash_df_precheck.py
@@ -1,0 +1,194 @@
+"""
+Tests for the disk-space precheck helper used by Nash compute scripts.
+
+Issue #269: ``compute_nash.py`` (and ``compute_nash_v2.py``) burned ~33 min of
+simulation compute and then crashed when writing the final ``equilibrium.json``
+because the filesystem was full. These tests exercise the startup-time
+precheck that aborts BEFORE any simulation work runs.
+
+The helper module ``experiments/scripts/_disk_precheck.py`` is imported by
+path because the ``experiments/scripts`` directory is not a proper Python
+package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRECHECK_PATH = REPO_ROOT / "experiments" / "scripts" / "_disk_precheck.py"
+
+
+def _load_precheck_module():
+    """Load ``_disk_precheck.py`` as a standalone module for testing."""
+    spec = importlib.util.spec_from_file_location("_disk_precheck", PRECHECK_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not load spec for {PRECHECK_PATH}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_disk_precheck"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def precheck():
+    """Provide the loaded ``_disk_precheck`` module."""
+    return _load_precheck_module()
+
+
+# ``os.statvfs`` returns an object with f_bavail (available blocks) and
+# f_frsize (fragment size in bytes). We mock with a namedtuple that exposes
+# both attributes.
+FakeStatvfs = namedtuple("FakeStatvfs", ["f_bavail", "f_frsize"])
+
+
+def _make_statvfs(free_bytes: int) -> FakeStatvfs:
+    """Return a fake ``statvfs_result`` reporting ``free_bytes`` available."""
+    # Use 4 KiB blocks; the precheck only cares about the product.
+    frsize = 4096
+    bavail = free_bytes // frsize
+    return FakeStatvfs(f_bavail=bavail, f_frsize=frsize)
+
+
+def test_passes_when_plenty_of_space(precheck, monkeypatch, tmp_path):
+    """With 10 GiB free, the precheck should not exit."""
+    monkeypatch.setattr(
+        precheck.os,
+        "statvfs",
+        lambda _path: _make_statvfs(10 * 1024 * 1024 * 1024),  # 10 GiB
+    )
+    # Should return None and not raise SystemExit.
+    assert precheck.check_free_space(tmp_path, min_free_mib=100) is None
+
+
+def test_aborts_when_below_threshold(precheck, monkeypatch, tmp_path, capsys):
+    """With only 5 MiB free and a 100 MiB threshold, the precheck must exit 1."""
+    monkeypatch.setattr(
+        precheck.os,
+        "statvfs",
+        lambda _path: _make_statvfs(5 * 1024 * 1024),  # 5 MiB
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        precheck.check_free_space(tmp_path, min_free_mib=100)
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "ERROR" in err
+    assert "MiB free" in err
+    assert "100 MiB" in err
+    assert "Aborting before compute" in err
+
+
+def test_aborts_when_zero_free_space(precheck, monkeypatch, tmp_path, capsys):
+    """ENOSPC-equivalent: 0 bytes free should fail the precheck."""
+    monkeypatch.setattr(
+        precheck.os,
+        "statvfs",
+        lambda _path: _make_statvfs(0),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        precheck.check_free_space(tmp_path, min_free_mib=100)
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "0.0 MiB free" in err
+
+
+def test_threshold_at_exact_boundary_passes(precheck, monkeypatch, tmp_path):
+    """Free bytes exactly at the threshold should be considered sufficient."""
+    threshold_mib = 100
+    free_bytes = threshold_mib * 1024 * 1024
+    monkeypatch.setattr(
+        precheck.os,
+        "statvfs",
+        lambda _path: _make_statvfs(free_bytes),
+    )
+    # Equal-to-threshold passes (the check is strict `<`).
+    assert precheck.check_free_space(tmp_path, min_free_mib=threshold_mib) is None
+
+
+def test_resolves_nonexistent_output_dir_to_parent(
+    precheck, monkeypatch, tmp_path, capsys
+):
+    """If output-dir does not exist, the precheck statvfs's its nearest ancestor."""
+    target = tmp_path / "does" / "not" / "exist" / "yet"
+    seen_paths: list[Path] = []
+
+    def fake_statvfs(path):
+        seen_paths.append(Path(path))
+        return _make_statvfs(10 * 1024 * 1024 * 1024)  # 10 GiB
+
+    monkeypatch.setattr(precheck.os, "statvfs", fake_statvfs)
+
+    precheck.check_free_space(target, min_free_mib=100)
+
+    # Should have statvfs'd an existing ancestor (tmp_path itself or one of its
+    # ancestors), not the non-existent target path.
+    assert seen_paths, "statvfs should have been called"
+    used = seen_paths[0]
+    assert used.exists(), f"precheck must call statvfs on an existing path, got {used}"
+
+
+def test_error_message_names_the_volume(precheck, monkeypatch, tmp_path, capsys):
+    """The error message should include the resolved filesystem path."""
+    monkeypatch.setattr(
+        precheck.os,
+        "statvfs",
+        lambda _path: _make_statvfs(1024),  # 1 KiB free
+    )
+
+    with pytest.raises(SystemExit):
+        precheck.check_free_space(tmp_path, min_free_mib=100)
+
+    err = capsys.readouterr().err
+    # The resolved path is the nearest existing ancestor of tmp_path
+    # (which is tmp_path itself, since pytest created it).
+    assert str(tmp_path.resolve()) in err
+
+
+def test_statvfs_oserror_aborts(precheck, monkeypatch, tmp_path, capsys):
+    """If statvfs itself fails, abort with a clear error rather than crashing later."""
+
+    def raising_statvfs(_path):
+        raise OSError("simulated stat failure")
+
+    monkeypatch.setattr(precheck.os, "statvfs", raising_statvfs)
+
+    with pytest.raises(SystemExit) as excinfo:
+        precheck.check_free_space(tmp_path, min_free_mib=100)
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "could not stat filesystem" in err
+    assert "Aborting before compute" in err
+
+
+def test_default_threshold_is_100_mib(precheck):
+    """The conservative default threshold should be 100 MiB (per issue #269)."""
+    assert precheck.DEFAULT_MIN_FREE_MIB == 100
+
+
+def test_real_filesystem_has_free_space(precheck, tmp_path):
+    """Smoke test: a real tmp dir on a normal CI box should pass the precheck.
+
+    This guards against breakage in ``_resolve_existing_parent`` / argument
+    plumbing without mocking ``os.statvfs``. If the host running tests really
+    has less than 100 MiB free, we skip rather than fail.
+    """
+    stats = os.statvfs(tmp_path)
+    free_bytes = stats.f_bavail * stats.f_frsize
+    if free_bytes < 100 * 1024 * 1024:
+        pytest.skip("host has <100 MiB free; cannot run unmocked precheck smoke test")
+
+    # Should not raise.
+    assert precheck.check_free_space(tmp_path, min_free_mib=100) is None


### PR DESCRIPTION
## Summary
Adds an `os.statvfs`-based startup precheck to `compute_nash.py` and `compute_nash_v2.py` that aborts BEFORE any simulation work runs if free space on the `--output-dir` filesystem is below a configurable threshold (default 100 MiB). Prevents the failure mode from the overnight Nash sweep (PR #245, issue #256) where ~33 min of CPU per scenario was burned only to crash at `equilibrium.json` write time on a full disk.

## Changes
- New helper `experiments/scripts/_disk_precheck.py` exposing `check_free_space(output_dir, min_free_mib=100)` and `DEFAULT_MIN_FREE_MIB = 100`. Uses `os.statvfs` against the nearest existing ancestor of the target so it works before the output dir is created.
- `compute_nash.py`: imports the helper and calls `check_free_space` right after argument parsing, before any solver work. Adds `--min-free-mib` argument (default 100).
- `compute_nash_v2.py`: same precheck and `--min-free-mib` flag.
- New `tests/test_compute_nash_df_precheck.py` (9 tests) — monkeypatches `os.statvfs` to exercise plenty/low/zero/boundary cases, the OSError fallback path, error-message content (volume named, free vs required), non-existent output-dir resolution, default-threshold constant, and an unmocked real-FS smoke test.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `compute_nash.py` aborts before simulation work when disk too low | Yes | `check_free_space()` called immediately after `parse_args()` in `main()`, before `compute_nash_equilibrium()`; tests `test_aborts_when_below_threshold` and `test_aborts_when_zero_free_space` confirm `SystemExit(1)` |
| Threshold configurable via `--min-free-mib` (default 100) | Yes | New CLI arg with `default=DEFAULT_MIN_FREE_MIB=100`; test `test_default_threshold_is_100_mib` |
| Error message names volume + free/required bytes | Yes | Format: `ERROR: only X.X MiB free on '<path>'; need at least YYY MiB. Aborting before compute.`; verified by `test_error_message_names_the_volume` and `test_aborts_when_below_threshold` |
| Same guard added to `compute_nash_v2.py` | Yes | Identical precheck + `--min-free-mib` flag added |

## Test Plan
- `uv run pytest tests/test_compute_nash_df_precheck.py -v` -> 9 passed in 0.02s
- `uv run ruff format` + `uv run ruff check --fix` on all 4 touched files -> all clean
- End-to-end smoke: invoked `check_free_space(Path('/tmp'), min_free_mib=1)` (passes) and with `min_free_mib=1 PiB` (aborts with the expected message `ERROR: only 19569.7 MiB free on '/private/tmp'; need at least 1073741824 MiB. Aborting before compute.`)

Note: `compute_nash.py --help` cannot be exercised end-to-end in this venv because the pre-existing `bucket_brigade_core` Rust extension is not built locally (unrelated to this change — same failure occurs on `main`).

Closes #269