### PR TITLE
diag(p3): live observation audit during JointPPOTrainer rollouts

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -57,6 +57,7 @@ from bucket_brigade.training.networks import (
     compute_hca_advantages,
 )
 from bucket_brigade.training.normalizers import RunningMeanStd
+from bucket_brigade.training.obs_audit import ObsAuditor
 
 
 __all__ = ["JointPPOTrainer", "RolloutBuffer", "flatten_dict_obs"]
@@ -297,9 +298,18 @@ class JointPPOTrainer:
         hindsight_ratio_clip: float = 10.0,
         influence_coef: float = 0.0,
         influence_mc_samples: int = 4,
+        obs_auditor: Optional[ObsAuditor] = None,
     ):
         self.env_fn = env_fn
         self.env = env_fn()
+        # Issue #274: optional live observation auditor. ``None`` (default)
+        # makes the rollout path bit-for-bit identical to legacy behavior.
+        # When set, the auditor records per-(step, agent) snapshots of the
+        # exact tensor fed to the policy, the env-side dict that produced
+        # it, the raw (pre-sanitization) action, and the sanitized action
+        # the env applied (read back from ``env.last_actions``). See
+        # ``bucket_brigade/training/obs_audit.py`` for the spec.
+        self.obs_auditor = obs_auditor
         self.num_agents = num_agents
         self.obs_dim = obs_dim
         self.action_dims = action_dims
@@ -542,6 +552,66 @@ class JointPPOTrainer:
         obs = self.env.reset(seed=seed)
         # ``_last_obs`` is now ``[N, obs_dim]`` — one row per agent.
         self._last_obs = self._flatten_per_agent(obs)
+        # Issue #274: keep a handle on the pre-flatten dict so the obs
+        # auditor can record what the flattener actually consumed. Only
+        # used when ``self.obs_auditor is not None and obs_auditor.enabled``;
+        # this assignment is a single bound reference so it is essentially
+        # free for the audit-disabled path. The dict's arrays are already
+        # copies (see ``BucketBrigadeEnv._get_observation``).
+        self._last_obs_dict = obs
+
+    # ------------------------------------------------------------------
+    # Issue #274: obs-auditor helpers
+    # ------------------------------------------------------------------
+
+    def _audit_scenario_info(self) -> Dict[str, object]:
+        """Capture scenario knobs the post-hoc analyzer needs to interpret samples.
+
+        Required fields for v1 (per the curator spec):
+
+        - ``action_validity_mode`` — gates the bit-exact ``raw == sanitized``
+          cross-check on the ``last_actions`` slice (PR #316).
+        - ``macro_actions`` — present if the env is wrapped by
+          :class:`MacroActionEnv` (PR #298). When ``True``, ``raw_action``
+          is a single option index, not ``[house, mode, signal]``.
+        - ``extinguish_mode`` — present iff the underlying scenario opts
+          into the continuous-extinguish dynamics (PR #317). Affects the
+          ``houses`` slice variance interpretation.
+        - ``num_houses`` — needed to compute the houses-slice offset.
+        - ``num_agents`` — needed to recover the identity-tail offset.
+
+        All lookups are defensive: missing knobs return ``None`` and the
+        analyzer is responsible for interpreting an absent value as
+        "scenario does not expose this knob."
+        """
+        scenario = getattr(self.env, "scenario", None)
+        info: Dict[str, object] = {
+            "num_agents": int(self.num_agents),
+            "num_houses": int(self._influence_num_houses),
+            "action_validity_mode": getattr(scenario, "action_validity_mode", None),
+            "extinguish_mode": getattr(scenario, "extinguish_mode", None),
+            # ``MacroActionEnv`` (PR #298) is the only wrapper that exposes
+            # ``num_options`` (the option-head action-dim count). Use it as
+            # a duck-typed marker so this code path doesn't import the
+            # wrapper class.
+            "macro_actions": bool(hasattr(self.env, "num_options")),
+        }
+        return info
+
+    def _safe_env_last_actions(self) -> Optional[np.ndarray]:
+        """Read ``env.last_actions`` post-step, defensively.
+
+        After ``env.step``, ``last_actions`` reflects the *sanitized*
+        action (PR #316; also true on the pre-#316 ``"always_valid"``
+        path, where sanitization is a bit-exact pass-through). For
+        wrappers without a ``last_actions`` field (e.g.
+        :class:`MacroActionEnv` at the macro level), returns ``None`` and
+        the wire-in falls back to ``raw_action`` for ``action_taken``.
+        """
+        la = getattr(self.env, "last_actions", None)
+        if la is None:
+            return None
+        return np.asarray(la)
 
     def _global_obs_from_per_agent(self, obs_per_agent: torch.Tensor) -> torch.Tensor:
         """Strip the per-agent identity one-hot tail to recover the global obs.
@@ -685,9 +755,21 @@ class JointPPOTrainer:
         rewards = np.zeros((self.num_agents, num_steps), dtype=np.float32)
         dones = np.zeros(num_steps, dtype=np.float32)
 
+        # Issue #274: cache the obs-auditor enabled-flag once per rollout so
+        # the inner loop's hot path stays a single bool check. The audit-
+        # disabled path is bit-identical to the pre-#274 code.
+        audit_enabled = self.obs_auditor is not None and self.obs_auditor.enabled
+
         for t in range(num_steps):
             obs_t = torch.from_numpy(self._last_obs).to(self.device)  # [N, obs_dim]
             joint_action, lps, vs = self._act_all(obs_t)
+
+            # Snapshot the pre-step env dict (the one that produced
+            # ``self._last_obs``) before ``env.step`` mutates it. Only
+            # taken when audit is enabled — otherwise this reference
+            # is never read.
+            pre_step_obs_dict = self._last_obs_dict if audit_enabled else None
+            pre_step_flat_obs = self._last_obs.copy() if audit_enabled else None
 
             next_obs_dict, rew, done_arr, _ = self.env.step(joint_action)
             done = bool(np.asarray(done_arr).any())
@@ -700,10 +782,42 @@ class JointPPOTrainer:
                 rewards[i, t] = rew[i]
             dones[t] = float(done)
 
+            # Issue #274: emit per-agent audit records for this step. We
+            # do this *after* the env step so ``action_taken`` (read from
+            # the env's post-step ``last_actions`` slot, which reflects
+            # the sanitized action under PR #316) is available. The
+            # ``raw_action`` is what the policy emitted (``joint_action[i]``);
+            # ``action_taken`` is what the env actually applied.
+            if audit_enabled:
+                scenario_info = self._audit_scenario_info()
+                env_last_actions = self._safe_env_last_actions()
+                for i in range(self.num_agents):
+                    raw_action = np.asarray(joint_action[i], dtype=np.int64)
+                    if env_last_actions is not None and i < len(env_last_actions):
+                        action_taken = np.asarray(env_last_actions[i], dtype=np.int64)
+                    else:
+                        # Fallback (e.g. macro-action wrapper without a
+                        # ``last_actions`` echo): treat raw == taken.
+                        action_taken = raw_action[:2].copy()
+                    self.obs_auditor.maybe_record(
+                        agent_id=i,
+                        flat_obs=pre_step_flat_obs[i],
+                        env_state=pre_step_obs_dict,
+                        raw_action=raw_action,
+                        action_taken=action_taken,
+                        reward=float(rew[i]),
+                        scenario_info=scenario_info,
+                        num_agents=self.num_agents,
+                    )
+                self.obs_auditor.advance_step()
+
             if done:
                 self._reset_env()
             else:
                 self._last_obs = self._flatten_per_agent(next_obs_dict)
+                # Issue #274: keep the env-dict handle in sync with the
+                # flat obs (see ``_reset_env`` for the rationale).
+                self._last_obs_dict = next_obs_dict
 
         return RolloutBuffer(
             observations=torch.from_numpy(observations).to(self.device),

--- a/bucket_brigade/training/obs_audit.py
+++ b/bucket_brigade/training/obs_audit.py
@@ -1,0 +1,340 @@
+"""Live observation audit for the joint multi-agent PPO trainer (issue #274).
+
+This module provides a *passive* audit harness that records per-(step, agent)
+samples of the exact tensor the policy consumed at training time, alongside:
+
+- the env-side dict that the flattener was built from,
+- the raw multi-discrete action the policy emitted,
+- the sanitized action the env actually applied (post-:func:`sanitize_actions`,
+  PR #316),
+- the per-agent instantaneous reward,
+- the per-agent identity one-hot tail recovered from ``flat_obs``,
+- scenario info needed to interpret the sample (``action_validity_mode``,
+  ``macro_actions``, ``extinguish_mode``).
+
+The auditor is **observe-only**: when wired into
+:meth:`JointPPOTrainer.collect_rollout` it must not alter PPO behavior in
+any way. The bit-identity test (``tests/test_obs_audit.py``) pins that
+property against a fixed seed.
+
+Scope (curator-set v1):
+
+- Output is JSON-Lines, one record per (step, agent). Numpy arrays are
+  serialized as lists; dtype tags accompany every array.
+- Reservoir sampling picks ``N`` records uniformly over the ``total_steps``
+  the trainer will visit during the whole run, *not* per-rollout: it would
+  bias toward the start of training otherwise. The picked global step
+  indices are computed up-front from ``(num_samples, total_steps, seed)``
+  so the audit is deterministic.
+- ``N = 0`` is a no-op (no overhead, no file written).
+- ``N >= total_steps`` records every step (uniform reservoir collapses).
+
+Out of scope for v1:
+
+- Post-hoc analysis / Markdown verdict report (follow-up issue).
+- Vectorized puffer rollout path (single-agent, different obs flow).
+- Auditing macro-action expansion inside :class:`MacroActionEnv`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = ["ObsAuditSample", "ObsAuditor"]
+
+
+def _to_listish(arr) -> List:
+    """Convert a numpy array / scalar / list into a JSON-serializable list."""
+    if isinstance(arr, np.ndarray):
+        return arr.tolist()
+    if isinstance(arr, (np.integer, np.floating)):
+        return arr.item()
+    if isinstance(arr, (list, tuple)):
+        return [_to_listish(x) for x in arr]
+    if isinstance(arr, dict):
+        return {k: _to_listish(v) for k, v in arr.items()}
+    return arr
+
+
+@dataclass
+class ObsAuditSample:
+    """One audit record: what agent ``agent_id`` saw / did at global step ``t``.
+
+    Attributes:
+        t: Global timestep (rollout step counter, not iteration). Recorded
+            as the trainer's monotonically-increasing step index.
+        agent_id: Per-agent index (0..num_agents-1).
+        flat_obs: ``[obs_dim]`` float32 — exact tensor fed to the policy.
+        env_state: Dict snapshot of the pre-flatten env observation for the
+            *same* step. Keys: ``houses``, ``signals``, ``locations``,
+            ``last_actions``, ``scenario_info`` (mirrors :class:`AgentObservation`
+            in ``bucket-brigade-core``).
+        raw_action: Length-``len(action_dims)`` int64 — the action the policy
+            emitted. For multi-discrete this is ``[house, mode, signal]``.
+            For macro-actions this is a single option index.
+        action_taken: Length-2 int64 — the action the env actually applied
+            after :func:`sanitize_actions`, read back from
+            ``env.last_actions[agent_id]`` *after* :meth:`step`. Width 2
+            (``[house, mode]``) because the env strips the signal dim from
+            ``last_actions``. For pre-#316 scenarios
+            (``action_validity_mode="always_valid"``) this is bit-equal to
+            ``raw_action[:2]``.
+        reward: Per-agent instantaneous reward at step ``t``.
+        identity_tail: Length-``num_agents`` float32 — the trailing one-hot
+            slice ``flat_obs[-num_agents:]``. Extracted for the post-hoc
+            identity check; bit-equal to a slice of ``flat_obs`` but
+            captured separately so the analyzer can verify the slice
+            convention without re-reading the full obs.
+        scenario_info: Free-form dict capturing scenario knobs the analyzer
+            needs to interpret the sample. Required keys at v1:
+            ``action_validity_mode``, ``macro_actions``, ``extinguish_mode``
+            (the latter two may be ``None`` if not applicable).
+    """
+
+    t: int
+    agent_id: int
+    flat_obs: np.ndarray
+    env_state: Dict
+    raw_action: np.ndarray
+    action_taken: np.ndarray
+    reward: float
+    identity_tail: np.ndarray
+    scenario_info: Dict = field(default_factory=dict)
+
+    def to_json_dict(self) -> Dict:
+        """Convert to a JSON-serializable dict (lists, no numpy)."""
+        return {
+            "t": int(self.t),
+            "agent_id": int(self.agent_id),
+            "flat_obs": self.flat_obs.astype(np.float32).tolist(),
+            "env_state": {k: _to_listish(v) for k, v in self.env_state.items()},
+            "raw_action": np.asarray(self.raw_action).astype(np.int64).tolist(),
+            "action_taken": np.asarray(self.action_taken).astype(np.int64).tolist(),
+            "reward": float(self.reward),
+            "identity_tail": np.asarray(self.identity_tail).astype(np.float32).tolist(),
+            "scenario_info": _to_listish(self.scenario_info),
+        }
+
+    @classmethod
+    def from_json_dict(cls, d: Dict) -> "ObsAuditSample":
+        """Inverse of :meth:`to_json_dict` --- recover a sample from JSONL."""
+        return cls(
+            t=int(d["t"]),
+            agent_id=int(d["agent_id"]),
+            flat_obs=np.asarray(d["flat_obs"], dtype=np.float32),
+            env_state={k: np.asarray(v) for k, v in d["env_state"].items()},
+            raw_action=np.asarray(d["raw_action"], dtype=np.int64),
+            action_taken=np.asarray(d["action_taken"], dtype=np.int64),
+            reward=float(d["reward"]),
+            identity_tail=np.asarray(d["identity_tail"], dtype=np.float32),
+            scenario_info=dict(d.get("scenario_info", {})),
+        )
+
+
+class ObsAuditor:
+    """Reservoir-style observation auditor.
+
+    Picks ``num_samples`` global step indices uniformly from
+    ``[0, total_steps)`` up-front (seeded for determinism), then records
+    every (agent, step) pair whose step is in the picked set.
+
+    Usage::
+
+        auditor = ObsAuditor(num_samples=500, total_steps=50_000, seed=0)
+        trainer = JointPPOTrainer(..., obs_auditor=auditor)
+        for it in range(num_iterations):
+            trainer.collect_rollout(rollout_steps)
+            trainer.update(...)
+        auditor.dump(Path("audit.jsonl"))
+
+    The trainer-side wire-in is the only mechanism that mutates state on
+    this object; the auditor is otherwise inert. ``N=0`` makes
+    :meth:`maybe_record` a fast no-op so the audit-disabled path is
+    bit-for-bit equivalent to legacy ``collect_rollout``.
+
+    Args:
+        num_samples: Number of *global timesteps* to record. Each picked
+            timestep contributes ``num_agents`` records (one per agent).
+        total_steps: Total number of training timesteps the trainer will
+            visit during the run. Used to compute the picked step set;
+            if the run exceeds this budget, the extra steps are
+            silently skipped.
+        seed: Seed for the picked-step RNG.
+    """
+
+    def __init__(
+        self,
+        num_samples: int,
+        total_steps: int,
+        seed: int = 0,
+    ):
+        if num_samples < 0:
+            raise ValueError(f"num_samples must be >= 0, got {num_samples!r}")
+        if total_steps < 0:
+            raise ValueError(f"total_steps must be >= 0, got {total_steps!r}")
+
+        self.num_samples = int(num_samples)
+        self.total_steps = int(total_steps)
+        self.seed = int(seed)
+
+        # Pre-compute the set of global step indices we will record. Picking
+        # up-front avoids per-step RNG state and makes the audit deterministic
+        # against `seed` regardless of how the trainer schedules rollouts.
+        if self.num_samples == 0 or self.total_steps == 0:
+            self._picked: set = set()
+        elif self.num_samples >= self.total_steps:
+            # Record everything.
+            self._picked = set(range(self.total_steps))
+        else:
+            rng = np.random.default_rng(self.seed)
+            picks = rng.choice(
+                self.total_steps,
+                size=self.num_samples,
+                replace=False,
+            )
+            self._picked = set(int(x) for x in picks)
+
+        self.samples: List[ObsAuditSample] = []
+        # Monotonic global step counter, advanced by the wire-in's
+        # `advance_step()` call after each env step.
+        self._global_step: int = 0
+
+    # ------------------------------------------------------------------
+    # Trainer-facing hooks
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        """``True`` if any step is scheduled to be recorded.
+
+        Allows callers to skip the work of assembling the env_state dict
+        when ``num_samples == 0`` --- this is what makes the audit-disabled
+        path bit-identical to legacy ``collect_rollout``.
+        """
+        return bool(self._picked)
+
+    def should_record(self, step: Optional[int] = None) -> bool:
+        """Whether the *current* (or specified) global step is in the picked set."""
+        s = self._global_step if step is None else int(step)
+        return s in self._picked
+
+    def advance_step(self) -> None:
+        """Advance the internal global step counter by 1.
+
+        Called by the wire-in once per env step (after all per-agent
+        records for that step have been emitted).
+        """
+        self._global_step += 1
+
+    @property
+    def global_step(self) -> int:
+        return self._global_step
+
+    def maybe_record(
+        self,
+        agent_id: int,
+        flat_obs: np.ndarray,
+        env_state: Dict,
+        raw_action: np.ndarray,
+        action_taken: np.ndarray,
+        reward: float,
+        scenario_info: Optional[Dict] = None,
+        num_agents: Optional[int] = None,
+        step: Optional[int] = None,
+    ) -> None:
+        """Record one (step, agent) sample if the current step is picked.
+
+        When :attr:`enabled` is ``False`` (``num_samples == 0``) this is
+        a true no-op --- no env_state copies, no list appends.
+
+        Args:
+            agent_id: Index of the agent that consumed ``flat_obs``.
+            flat_obs: ``[obs_dim]`` float32 — exact tensor fed to the policy.
+            env_state: Dict snapshot of the pre-flatten env observation.
+            raw_action: Raw multi-discrete action the policy emitted.
+            action_taken: Sanitized action the env applied (read from
+                ``env.last_actions[agent_id]`` after ``step()``).
+            reward: Per-agent instantaneous reward at this step.
+            scenario_info: Free-form dict for scenario knobs.
+            num_agents: Width of the identity one-hot tail. Used to extract
+                the ``identity_tail`` slice from ``flat_obs``. If ``None``,
+                no slice is recorded.
+            step: Optional explicit global step (defaults to the auditor's
+                internal counter).
+        """
+        if not self._picked:
+            return
+        s = self._global_step if step is None else int(step)
+        if s not in self._picked:
+            return
+
+        if num_agents is not None and num_agents > 0:
+            identity_tail = np.asarray(flat_obs[-num_agents:], dtype=np.float32).copy()
+        else:
+            identity_tail = np.zeros(0, dtype=np.float32)
+
+        env_state_copy = {
+            k: (np.asarray(v).copy() if isinstance(v, (np.ndarray, list, tuple)) else v)
+            for k, v in env_state.items()
+        }
+
+        self.samples.append(
+            ObsAuditSample(
+                t=s,
+                agent_id=int(agent_id),
+                flat_obs=np.asarray(flat_obs, dtype=np.float32).copy(),
+                env_state=env_state_copy,
+                raw_action=np.asarray(raw_action, dtype=np.int64).copy(),
+                action_taken=np.asarray(action_taken, dtype=np.int64).copy(),
+                reward=float(reward),
+                identity_tail=identity_tail,
+                scenario_info=dict(scenario_info or {}),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # I/O
+    # ------------------------------------------------------------------
+
+    def dump(self, path: Path) -> None:
+        """Write all collected samples to ``path`` as JSON-Lines.
+
+        One record per line. Numpy arrays are emitted as nested lists; the
+        round-trip via :meth:`ObsAuditSample.from_json_dict` is dtype-faithful.
+
+        When :attr:`enabled` is False this is a no-op --- no file is created.
+        """
+        if not self._picked:
+            return
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("w") as f:
+            for s in self.samples:
+                f.write(json.dumps(s.to_json_dict()) + "\n")
+
+    @classmethod
+    def load(cls, path: Path) -> List[ObsAuditSample]:
+        """Read back a JSONL file into a list of :class:`ObsAuditSample`."""
+        out: List[ObsAuditSample] = []
+        p = Path(path)
+        with p.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                out.append(ObsAuditSample.from_json_dict(json.loads(line)))
+        return out
+
+    # ------------------------------------------------------------------
+    # Helpers for analyzers / tests
+    # ------------------------------------------------------------------
+
+    def picked_steps(self) -> Tuple[int, ...]:
+        """Return the (sorted) tuple of global step indices that will be recorded."""
+        return tuple(sorted(self._picked))

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -53,6 +53,7 @@ from bucket_brigade.training.joint_trainer import (
     flatten_dict_obs,
 )
 from bucket_brigade.training.lola_trainer import LolaTrainer
+from bucket_brigade.training.obs_audit import ObsAuditor
 
 
 @dataclass
@@ -202,6 +203,15 @@ class CellConfig:
     lola_dice: bool = False
     lola_eta: float = 1.0
     lola_lookahead_steps: int = 1
+    # Issue #274: live observation audit. When ``audit_obs > 0``, a passive
+    # :class:`ObsAuditor` is wired into the trainer and ``audit_obs`` global
+    # timesteps are sampled uniformly across the full run; per-(step, agent)
+    # snapshots are dumped to ``audit_obs_path`` as JSON-Lines. Default
+    # ``0`` is a true no-op: the trainer's rollout path is bit-for-bit
+    # identical to the audit-disabled legacy code.
+    audit_obs: int = 0
+    audit_obs_path: Optional[str] = None
+    audit_obs_seed: int = 0
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -837,6 +847,28 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
     else:
         action_dims = cfg.action_dims
 
+    # Issue #274: build the obs auditor up-front so its total-step budget
+    # can be threaded into the trainer. ``audit_obs == 0`` (default) yields
+    # a disabled auditor whose ``maybe_record`` is a true no-op, so the
+    # legacy rollout path stays bit-identical. ``audit_obs`` is intentionally
+    # not supported on the LOLA-DiCE arm (its rollout path is in
+    # :class:`LolaTrainer`, not :class:`JointPPOTrainer`); fail loud rather
+    # than silently disable.
+    audit_total_steps = cfg.num_iterations * cfg.rollout_steps
+    obs_auditor: Optional[ObsAuditor] = None
+    if cfg.audit_obs > 0:
+        if cfg.lola_dice:
+            raise ValueError(
+                "cfg.audit_obs > 0 is not supported on the LOLA-DiCE arm. "
+                "The audit hook lives in JointPPOTrainer.collect_rollout; "
+                "extend LolaTrainer separately if needed."
+            )
+        obs_auditor = ObsAuditor(
+            num_samples=int(cfg.audit_obs),
+            total_steps=int(audit_total_steps),
+            seed=int(cfg.audit_obs_seed),
+        )
+
     if cfg.lola_dice:
         # Issue #287: LOLA-DiCE arm. The trainer mirrors JointPPOTrainer's
         # collect_rollout / update / encoder_outputs_batch surface, so the
@@ -883,6 +915,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
             influence_mc_samples=cfg.influence_mc_samples,
             device=cfg.device,
             seed=cfg.seed,
+            obs_auditor=obs_auditor,
         )
 
     # Issue #270: optionally warm-start the actor weights from a BC-pretrained
@@ -990,6 +1023,21 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
         json.dump(metrics_log, f, indent=2)
     with (output_dir / "config.json").open("w") as f:
         json.dump(asdict(cfg), f, indent=2)
+
+    # Issue #274: dump obs-audit samples to disk if the auditor was wired in.
+    # ``ObsAuditor.dump`` is itself a no-op when no samples were picked.
+    if obs_auditor is not None and obs_auditor.enabled:
+        audit_path = (
+            Path(cfg.audit_obs_path)
+            if cfg.audit_obs_path is not None
+            else output_dir / "audit_obs.jsonl"
+        )
+        obs_auditor.dump(audit_path)
+        print(
+            f"  obs-audit (#274): wrote {len(obs_auditor.samples)} samples "
+            f"({cfg.audit_obs} picked steps x {cfg.num_agents} agents) "
+            f"to {audit_path}"
+        )
 
 
 def main() -> None:
@@ -1329,6 +1377,40 @@ def main() -> None:
         ),
     )
     p.add_argument("--device", default="cpu")
+    p.add_argument(
+        "--audit-obs",
+        type=int,
+        default=0,
+        help=(
+            "Issue #274: number of global timesteps to record for the live "
+            "observation audit. Picks N steps uniformly across the planned "
+            "num_iterations * rollout_steps budget, then dumps per-(step, "
+            "agent) snapshots (obs slices, raw + sanitized action, reward, "
+            "identity-tail one-hot, scenario info) as JSON-Lines. Default "
+            "0 disables the audit (bit-for-bit identical to legacy "
+            "behavior)."
+        ),
+    )
+    p.add_argument(
+        "--audit-obs-path",
+        type=str,
+        default=None,
+        help=(
+            "Issue #274: explicit path for the obs-audit JSONL dump. "
+            "Defaults to ``<output_dir>/audit_obs.jsonl`` when "
+            "--audit-obs > 0."
+        ),
+    )
+    p.add_argument(
+        "--audit-obs-seed",
+        type=int,
+        default=0,
+        help=(
+            "Issue #274: seed for the obs-audit reservoir sampler. The "
+            "picked step set is fully determined by (audit_obs, "
+            "num_iterations * rollout_steps, audit_obs_seed)."
+        ),
+    )
     args = p.parse_args()
 
     # Issue #289: ``--use-hca`` is a convenience alias for
@@ -1372,6 +1454,9 @@ def main() -> None:
         lola_eta=args.lola_eta,
         lola_lookahead_steps=args.lola_lookahead_steps,
         device=args.device,
+        audit_obs=args.audit_obs,
+        audit_obs_path=args.audit_obs_path,
+        audit_obs_seed=args.audit_obs_seed,
     )
     print(
         f"== P3 cell: scenario={cfg.scenario} lambda_red={cfg.lambda_red} "

--- a/scripts/train_puffer_gpu.py
+++ b/scripts/train_puffer_gpu.py
@@ -359,6 +359,38 @@ def main():
         choices=["serial", "multiprocessing"],
         help="Vectorization backend (serial for debugging, multiprocessing for performance)",
     )
+    parser.add_argument(
+        "--audit-obs",
+        type=int,
+        default=0,
+        help=(
+            "Issue #274: number of global timesteps to record for the live "
+            "observation audit. NOTE: this script trains via the "
+            "PufferLib vectorized PPO path (a single-agent PolicyNetwork "
+            "over RustPufferBucketBrigade), which is a different code path "
+            "from the JointPPOTrainer rollout that the audit instruments. "
+            "When --audit-obs > 0 here, the flag is forwarded to a "
+            "JointPPOTrainer-based audit run on the same scenario / seed "
+            "so the audit captures the multi-agent obs path that #274 "
+            "targets. The Puffer training itself proceeds unchanged."
+        ),
+    )
+    parser.add_argument(
+        "--audit-obs-path",
+        type=str,
+        default=None,
+        help=(
+            "Issue #274: explicit path for the obs-audit JSONL dump when "
+            "--audit-obs > 0. Defaults to "
+            "``runs/<run_name>/audit_obs.jsonl``."
+        ),
+    )
+    parser.add_argument(
+        "--audit-obs-seed",
+        type=int,
+        default=0,
+        help="Issue #274: seed for the obs-audit reservoir sampler.",
+    )
 
     args = parser.parse_args()
 
@@ -470,6 +502,84 @@ def main():
     )
 
     print(f"💾 Model saved to {args.save_path}")
+
+    # Issue #274: live observation audit. The Puffer-vectorized training
+    # path above does *not* use ``JointPPOTrainer.collect_rollout`` (the
+    # only rollout path the audit instruments), so we run a small,
+    # auditor-attached training pass on the same scenario / seed to
+    # capture the multi-agent obs flow that #274 targets. This pass
+    # writes a JSONL dump but does NOT replace the saved model from the
+    # Puffer path above. ``--audit-obs == 0`` (default) skips this
+    # entirely.
+    if args.audit_obs > 0:
+        from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+        from bucket_brigade.envs import get_scenario_by_name
+        from bucket_brigade.training.joint_trainer import (
+            JointPPOTrainer,
+            flatten_dict_obs,
+        )
+        from bucket_brigade.training.obs_audit import ObsAuditor
+
+        num_agents = args.num_opponents + 1
+        scenario_obj = get_scenario_by_name(args.scenario, num_agents=num_agents)
+
+        def _audit_env_fn():
+            return BucketBrigadeEnv(scenario=scenario_obj)
+
+        probe = _audit_env_fn()
+        probe_obs = probe.reset(seed=args.seed)
+        obs_dim = flatten_dict_obs(probe_obs, agent_id=0, num_agents=num_agents).shape[
+            0
+        ]
+        num_houses = probe.num_houses
+        action_dims = [num_houses, 2, 2]
+
+        # Small audit budget — one rollout that covers the requested
+        # number of picked steps. Use a single rollout of length
+        # >= audit_obs * 2 so the reservoir can find non-overlapping picks.
+        audit_total_steps = max(args.audit_obs * 4, 256)
+        audit_rollout_steps = min(audit_total_steps, 2048)
+        audit_iters = max(1, audit_total_steps // audit_rollout_steps)
+        actual_total = audit_iters * audit_rollout_steps
+
+        auditor = ObsAuditor(
+            num_samples=int(args.audit_obs),
+            total_steps=int(actual_total),
+            seed=int(args.audit_obs_seed),
+        )
+
+        audit_trainer = JointPPOTrainer(
+            env_fn=_audit_env_fn,
+            num_agents=num_agents,
+            obs_dim=obs_dim,
+            action_dims=action_dims,
+            hidden_size=args.hidden_size,
+            lr=args.lr,
+            ppo_epochs=1,
+            minibatch_size=64,
+            device="cpu",  # audit is small; force CPU for portability
+            seed=args.seed,
+            obs_auditor=auditor,
+        )
+
+        print(
+            f"[#274] obs-audit pass: scenario={args.scenario} seed={args.seed} "
+            f"total_steps={actual_total} audit_obs={args.audit_obs}"
+        )
+        for _it in range(audit_iters):
+            rollout = audit_trainer.collect_rollout(audit_rollout_steps)
+            # Only do an update if the rollout was big enough — this is an
+            # audit, not a training pass. Skipping update keeps wall-clock
+            # tiny.
+            del rollout
+
+        audit_path = (
+            Path(args.audit_obs_path)
+            if args.audit_obs_path is not None
+            else Path(f"runs/{args.run_name}/audit_obs.jsonl")
+        )
+        auditor.dump(audit_path)
+        print(f"[#274] obs-audit: wrote {len(auditor.samples)} samples to {audit_path}")
 
 
 if __name__ == "__main__":

--- a/tests/training/test_obs_audit.py
+++ b/tests/training/test_obs_audit.py
@@ -1,0 +1,401 @@
+"""Tests for the live observation auditor (issue #274).
+
+Coverage:
+
+- Round-trip: ``ObsAuditSample`` -> JSONL -> ``ObsAuditSample``.
+- Bit-identity: training-with-auditor produces identical rollout metrics
+  to training-without-auditor when the same seed is fixed.
+- Identity-tail extraction: the auditor's ``identity_tail`` slice is the
+  trailing ``num_agents`` floats of ``flat_obs`` and equals the one-hot
+  for ``agent_id``.
+- Action sanitization parity: when ``action_validity_mode == "adjacent_only"``
+  the auditor captures both ``raw_action`` and ``action_taken``; an
+  out-of-reach raw target is rewritten by the env's ``_sanitize_actions``,
+  and the auditor's two action slots reflect the divergence.
+- Edge cases: ``N=0`` is a no-op (no file, no overhead); ``N >= total_steps``
+  records every step.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import get_scenario_by_name
+from bucket_brigade.training.joint_trainer import (
+    JointPPOTrainer,
+    flatten_dict_obs,
+)
+from bucket_brigade.training.obs_audit import ObsAuditor, ObsAuditSample
+
+
+NUM_AGENTS = 4
+ROLLOUT_STEPS = 32
+ACTION_DIMS = [10, 2, 2]
+
+
+def _env_fn():
+    return BucketBrigadeEnv(num_agents=NUM_AGENTS)
+
+
+def _adjacent_env_fn():
+    """Env-fn variant with the post-#316 adjacent-only action validity mode."""
+    scenario = get_scenario_by_name("default", num_agents=NUM_AGENTS)
+    scenario.action_validity_mode = "adjacent_only"
+    return BucketBrigadeEnv(scenario=scenario)
+
+
+def _make_trainer(obs_auditor=None, seed=0, env_fn_to_use=_env_fn) -> JointPPOTrainer:
+    env = env_fn_to_use()
+    obs = env.reset(seed=seed)
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+    return JointPPOTrainer(
+        env_fn=env_fn_to_use,
+        num_agents=NUM_AGENTS,
+        obs_dim=obs_dim,
+        action_dims=ACTION_DIMS,
+        hidden_size=16,
+        minibatch_size=32,
+        ppo_epochs=2,
+        seed=seed,
+        obs_auditor=obs_auditor,
+    )
+
+
+# ----------------------------------------------------------------------
+# 1. ObsAuditSample serialization round-trip
+# ----------------------------------------------------------------------
+
+
+class TestSerializationRoundTrip:
+    def test_to_from_json_dict_preserves_arrays(self):
+        flat_obs = np.array([0.5, -1.0, 2.0, 0.0], dtype=np.float32)
+        identity_tail = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
+        sample = ObsAuditSample(
+            t=7,
+            agent_id=1,
+            flat_obs=flat_obs,
+            env_state={
+                "houses": np.array([0, 1, 2, 0]),
+                "signals": np.array([1, 0]),
+            },
+            raw_action=np.array([3, 1, 1], dtype=np.int64),
+            action_taken=np.array([3, 1], dtype=np.int64),
+            reward=0.25,
+            identity_tail=identity_tail,
+            scenario_info={"action_validity_mode": "always_valid"},
+        )
+        d = sample.to_json_dict()
+        # Must be JSON-serializable (no numpy scalars).
+        s = json.dumps(d)
+        d2 = json.loads(s)
+        restored = ObsAuditSample.from_json_dict(d2)
+        np.testing.assert_array_equal(restored.flat_obs, flat_obs)
+        np.testing.assert_array_equal(
+            restored.raw_action, np.array([3, 1, 1], dtype=np.int64)
+        )
+        np.testing.assert_array_equal(
+            restored.action_taken, np.array([3, 1], dtype=np.int64)
+        )
+        np.testing.assert_array_equal(restored.identity_tail, identity_tail)
+        assert restored.t == 7
+        assert restored.agent_id == 1
+        assert restored.reward == pytest.approx(0.25)
+        assert restored.scenario_info["action_validity_mode"] == "always_valid"
+
+    def test_dump_and_load_jsonl(self, tmp_path: Path):
+        auditor = ObsAuditor(num_samples=5, total_steps=20, seed=0)
+        # Manually inject samples (simulate what the wire-in would do).
+        for t in auditor.picked_steps():
+            for i in range(NUM_AGENTS):
+                auditor._global_step = t  # noqa: SLF001 — direct manipulation OK in test
+                auditor.maybe_record(
+                    agent_id=i,
+                    flat_obs=np.full(8, float(t), dtype=np.float32),
+                    env_state={"houses": np.array([0, 1, 2])},
+                    raw_action=np.array([i, 0, 1], dtype=np.int64),
+                    action_taken=np.array([i, 0], dtype=np.int64),
+                    reward=float(t * 0.1),
+                    num_agents=NUM_AGENTS,
+                )
+        out = tmp_path / "audit.jsonl"
+        auditor.dump(out)
+        assert out.exists()
+        loaded = ObsAuditor.load(out)
+        assert len(loaded) == len(auditor.samples)
+        for src, dst in zip(auditor.samples, loaded):
+            assert src.t == dst.t
+            assert src.agent_id == dst.agent_id
+            np.testing.assert_array_equal(src.flat_obs, dst.flat_obs)
+
+
+# ----------------------------------------------------------------------
+# 2. Bit-identity: audit is observe-only
+# ----------------------------------------------------------------------
+
+
+class TestBitIdentity:
+    """The audit-disabled path must be bit-for-bit equivalent to the
+    audit-enabled path on metrics that PPO actually consumes."""
+
+    def test_rollout_metrics_unchanged_by_auditor(self):
+        # Two identically-seeded trainers, one with an auditor wired in.
+        torch.manual_seed(0)
+        np.random.seed(0)
+        t1 = _make_trainer(obs_auditor=None, seed=42)
+        roll_a = t1.collect_rollout(ROLLOUT_STEPS)
+
+        torch.manual_seed(0)
+        np.random.seed(0)
+        auditor = ObsAuditor(num_samples=10, total_steps=ROLLOUT_STEPS, seed=0)
+        t2 = _make_trainer(obs_auditor=auditor, seed=42)
+        roll_b = t2.collect_rollout(ROLLOUT_STEPS)
+
+        # All quantities that the trainer consumes must match bit-for-bit.
+        np.testing.assert_array_equal(
+            roll_a.observations.cpu().numpy(),
+            roll_b.observations.cpu().numpy(),
+        )
+        for i in range(NUM_AGENTS):
+            np.testing.assert_array_equal(
+                roll_a.actions[i].cpu().numpy(),
+                roll_b.actions[i].cpu().numpy(),
+            )
+            np.testing.assert_array_equal(
+                roll_a.rewards[i].cpu().numpy(),
+                roll_b.rewards[i].cpu().numpy(),
+            )
+            np.testing.assert_allclose(
+                roll_a.log_probs[i].cpu().numpy(),
+                roll_b.log_probs[i].cpu().numpy(),
+                rtol=0.0,
+                atol=0.0,
+            )
+
+        # But the auditor should have recorded samples.
+        assert len(auditor.samples) > 0
+        assert len(auditor.samples) == len(auditor.picked_steps()) * NUM_AGENTS
+
+    def test_disabled_auditor_is_no_op(self, tmp_path: Path):
+        auditor = ObsAuditor(num_samples=0, total_steps=100, seed=0)
+        assert auditor.enabled is False
+        assert auditor.picked_steps() == ()
+        # maybe_record must not append even when called.
+        auditor.maybe_record(
+            agent_id=0,
+            flat_obs=np.zeros(8, dtype=np.float32),
+            env_state={"houses": np.array([0])},
+            raw_action=np.array([0, 0, 0], dtype=np.int64),
+            action_taken=np.array([0, 0], dtype=np.int64),
+            reward=0.0,
+            num_agents=4,
+        )
+        assert auditor.samples == []
+        # dump() must NOT create a file when audit is disabled.
+        out = tmp_path / "should_not_exist.jsonl"
+        auditor.dump(out)
+        assert not out.exists()
+
+
+# ----------------------------------------------------------------------
+# 3. Identity-tail extraction
+# ----------------------------------------------------------------------
+
+
+class TestIdentityTailExtraction:
+    def test_handcrafted_flat_obs(self):
+        """Build a flat_obs by hand and verify the trailing N floats are
+        the agent's one-hot."""
+        obs_dim = 12
+        num_agents = 4
+        for agent_id in range(num_agents):
+            flat = np.zeros(obs_dim, dtype=np.float32)
+            # Populate the non-identity prefix with arbitrary values.
+            flat[: obs_dim - num_agents] = np.arange(
+                obs_dim - num_agents, dtype=np.float32
+            )
+            # Set the one-hot identity tail.
+            flat[obs_dim - num_agents + agent_id] = 1.0
+
+            auditor = ObsAuditor(num_samples=1, total_steps=1, seed=0)
+            auditor.maybe_record(
+                agent_id=agent_id,
+                flat_obs=flat,
+                env_state={"houses": np.array([0])},
+                raw_action=np.array([0, 0, 0], dtype=np.int64),
+                action_taken=np.array([0, 0], dtype=np.int64),
+                reward=0.0,
+                num_agents=num_agents,
+            )
+            assert len(auditor.samples) == 1
+            sample = auditor.samples[0]
+            # The identity_tail must be the last N elements of flat_obs.
+            np.testing.assert_array_equal(sample.identity_tail, flat[-num_agents:])
+            # And the argmax must equal agent_id.
+            assert int(np.argmax(sample.identity_tail)) == agent_id
+            # And the slice must be a valid one-hot.
+            assert sample.identity_tail.sum() == pytest.approx(1.0)
+            assert (sample.identity_tail >= 0).all()
+
+    def test_extracted_from_real_rollout(self):
+        """End-to-end: every audit sample's identity_tail matches its agent_id."""
+        auditor = ObsAuditor(
+            num_samples=ROLLOUT_STEPS, total_steps=ROLLOUT_STEPS, seed=0
+        )
+        trainer = _make_trainer(obs_auditor=auditor, seed=42)
+        trainer.collect_rollout(ROLLOUT_STEPS)
+        assert len(auditor.samples) == ROLLOUT_STEPS * NUM_AGENTS
+        for sample in auditor.samples:
+            assert sample.identity_tail.shape == (NUM_AGENTS,)
+            # The agent's one-hot must be correct.
+            assert int(np.argmax(sample.identity_tail)) == sample.agent_id
+            assert sample.identity_tail[sample.agent_id] == pytest.approx(1.0)
+            # The rest must be zero.
+            other = np.delete(sample.identity_tail, sample.agent_id)
+            assert (other == 0).all()
+
+
+# ----------------------------------------------------------------------
+# 4. Action sanitization parity (PR #316)
+# ----------------------------------------------------------------------
+
+
+class TestActionSanitizationParity:
+    def test_always_valid_mode_raw_equals_taken_house(self):
+        """With ``action_validity_mode == "always_valid"`` (the default), the
+        sanitized house index equals the raw house index."""
+        auditor = ObsAuditor(
+            num_samples=ROLLOUT_STEPS, total_steps=ROLLOUT_STEPS, seed=0
+        )
+        trainer = _make_trainer(obs_auditor=auditor, seed=42)
+        trainer.collect_rollout(ROLLOUT_STEPS)
+        assert len(auditor.samples) > 0
+        for sample in auditor.samples:
+            # raw_action is [house, mode, signal]; action_taken is [house, mode].
+            assert sample.raw_action[0] == sample.action_taken[0]
+            assert sample.raw_action[1] == sample.action_taken[1]
+            # Scenario info must mark the mode as always_valid (or None for
+            # scenarios that pre-date #316).
+            avm = sample.scenario_info.get("action_validity_mode")
+            assert avm in (None, "always_valid")
+
+    def test_adjacent_only_mode_records_raw_and_sanitized(self):
+        """With ``action_validity_mode == "adjacent_only"``, an out-of-reach
+        raw target must be rewritten by the env's ``_sanitize_actions``.
+
+        We can't easily force a specific raw action through the trainer's
+        policy network in a unit test, but we can run a rollout in
+        ``adjacent_only`` mode and verify that:
+
+        - The auditor records the mode in scenario_info.
+        - At least *some* sample shows ``raw_action[0] != action_taken[0]``
+          (or, if the policy happens to always pick in-range, that the
+          sanitization-divergence count matches the env's own behavior).
+        """
+        auditor = ObsAuditor(
+            num_samples=ROLLOUT_STEPS, total_steps=ROLLOUT_STEPS, seed=0
+        )
+        trainer = _make_trainer(
+            obs_auditor=auditor, seed=42, env_fn_to_use=_adjacent_env_fn
+        )
+        trainer.collect_rollout(ROLLOUT_STEPS)
+        assert len(auditor.samples) > 0
+        # The scenario info must mark the mode.
+        for sample in auditor.samples:
+            assert sample.scenario_info.get("action_validity_mode") == "adjacent_only"
+        # The audit captures both raw and sanitized fields; verify they have
+        # the right shapes regardless of whether divergence occurred.
+        for sample in auditor.samples:
+            assert sample.raw_action.shape == (3,)
+            assert sample.action_taken.shape == (2,)
+        # We expect *some* divergence over a 32-step rollout with random init.
+        # The env's home positions are spread around the ring, so the random
+        # policy will almost always emit an out-of-reach target sometimes.
+        divergences = sum(
+            1
+            for sample in auditor.samples
+            if sample.raw_action[0] != sample.action_taken[0]
+        )
+        # This is statistical, so allow a wide margin. With 4 agents on 10
+        # houses where each agent can only reach 3 (home + 2 adjacent), a
+        # uniform policy diverges ~70% of the time.
+        assert divergences > 0, (
+            "Expected at least one raw != sanitized action over the "
+            "rollout, got 0. Either the policy happened to always pick "
+            "in-range or the wire-in failed to capture raw_action."
+        )
+
+    def test_manually_compute_sanitization(self):
+        """Direct env-level sanity check: feed an out-of-reach action to the
+        env in ``adjacent_only`` mode and verify ``last_actions`` reflects
+        the rewrite, while a hand-built audit sample captures both."""
+        env = _adjacent_env_fn()
+        env.reset(seed=0)
+        # Pick agent 0's home and a guaranteed-out-of-reach target.
+        home = int(env.agent_home_positions[0])
+        far = (home + 5) % env.num_houses  # ring distance ~5, > 1
+
+        # Build a raw action that targets ``far`` for agent 0, home for others.
+        raw_actions = np.zeros((NUM_AGENTS, 3), dtype=np.int64)
+        for i in range(NUM_AGENTS):
+            raw_actions[i, 0] = int(env.agent_home_positions[i])
+        raw_actions[0, 0] = far
+
+        env.step(raw_actions)
+        # After step, env.last_actions[0, 0] must be home (sanitized).
+        assert int(env.last_actions[0, 0]) == home
+        # Build a sample matching what the wire-in would record.
+        auditor = ObsAuditor(num_samples=1, total_steps=1, seed=0)
+        auditor.maybe_record(
+            agent_id=0,
+            flat_obs=np.zeros(20, dtype=np.float32),
+            env_state={"houses": env.houses.copy()},
+            raw_action=raw_actions[0],
+            action_taken=np.asarray(env.last_actions[0], dtype=np.int64),
+            reward=0.0,
+            scenario_info={"action_validity_mode": "adjacent_only"},
+            num_agents=NUM_AGENTS,
+        )
+        s = auditor.samples[0]
+        assert int(s.raw_action[0]) == far
+        assert int(s.action_taken[0]) == home
+        assert s.raw_action[0] != s.action_taken[0]
+
+
+# ----------------------------------------------------------------------
+# 5. Edge cases
+# ----------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_num_samples_zero_is_no_op(self):
+        auditor = ObsAuditor(num_samples=0, total_steps=100, seed=0)
+        trainer = _make_trainer(obs_auditor=auditor, seed=42)
+        trainer.collect_rollout(ROLLOUT_STEPS)
+        assert auditor.samples == []
+        assert auditor.enabled is False
+
+    def test_num_samples_exceeds_total_steps_records_all(self):
+        auditor = ObsAuditor(num_samples=1000, total_steps=10, seed=0)
+        # When N >= total_steps, every step is picked.
+        assert len(auditor.picked_steps()) == 10
+        assert set(auditor.picked_steps()) == set(range(10))
+
+    def test_picked_steps_are_deterministic_for_seed(self):
+        a = ObsAuditor(num_samples=20, total_steps=1000, seed=42).picked_steps()
+        b = ObsAuditor(num_samples=20, total_steps=1000, seed=42).picked_steps()
+        c = ObsAuditor(num_samples=20, total_steps=1000, seed=43).picked_steps()
+        assert a == b
+        assert a != c
+        assert len(a) == 20
+
+    def test_negative_args_rejected(self):
+        with pytest.raises(ValueError):
+            ObsAuditor(num_samples=-1, total_steps=10, seed=0)
+        with pytest.raises(ValueError):
+            ObsAuditor(num_samples=1, total_steps=-1, seed=0)


### PR DESCRIPTION
## Summary
Adds a passive observation auditor that captures per-(step, agent) snapshots during `JointPPOTrainer.collect_rollout` — exact policy input, env-side dict, raw + sanitized action, reward, identity-tail one-hot, scenario info — so #272's INDUCTIVE_BIAS_GAP and PR #316's sanitization path can be cross-checked against what the policy actually consumes at training time.

## Changes
- **New** `bucket_brigade/training/obs_audit.py` — `ObsAuditSample` dataclass + `ObsAuditor` (deterministic reservoir sampler, JSONL dump/load).
- **Wire-in** `bucket_brigade/training/joint_trainer.py` — optional `obs_auditor` kwarg; records after each `env.step` so `action_taken` reflects sanitized `env.last_actions` (post-#316). Includes `_audit_scenario_info()` capturing `action_validity_mode`, `macro_actions`, `extinguish_mode`, `num_houses`, `num_agents`.
- **CLI** `experiments/p3_specialization/train.py` + `scripts/train_puffer_gpu.py` — `--audit-obs N`, `--audit-obs-path`, `--audit-obs-seed`. Default `0` is a true no-op.
- **Tests** `tests/training/test_obs_audit.py` — 13 tests covering round-trip, bit-identity, identity-tail extraction (handcrafted + end-to-end), action-sanitization parity (`always_valid` + `adjacent_only`), and edge cases.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|-----------|--------|--------------|
| `ObsAuditSample` with raw + sanitized fields | done | `to_json_dict`/`from_json_dict` round-trip tested. |
| CLI flag on both training entry points | done | `--audit-obs` on `experiments/p3_specialization/train.py` and `scripts/train_puffer_gpu.py`. |
| JSONL output per (step, agent) | done | One record per (step, agent) with all required fields (verified by smoke). |
| Audit does NOT change training behavior | done | `TestBitIdentity.test_rollout_metrics_unchanged_by_auditor` pins observations/actions/rewards/log_probs bit-identical against fixed seed. |
| Round-trip test | done | `TestSerializationRoundTrip`. |
| Identity-tail extraction test | done | `TestIdentityTailExtraction` (handcrafted obs + end-to-end). |
| Action sanitization parity test | done | `TestActionSanitizationParity` — verifies divergence in `adjacent_only` mode and equality in `always_valid` mode; one direct env-level test forces an out-of-reach raw target and confirms `raw_action[0] != action_taken[0]`. |
| N=0 no-op | done | `TestEdgeCases.test_num_samples_zero_is_no_op` + `test_disabled_auditor_is_no_op` (no file created). |
| obs_dim computed dynamically | done | Trainer probes from `flatten_dict_obs(probe_obs, agent_id=0, num_agents=N).shape[0]`; smoke confirmed 42 for 4-agent minspec. |

## Test Plan
- [x] `pytest tests/training/test_obs_audit.py` — 13/13 pass
- [x] `pytest tests/test_joint_trainer.py` — 58/58 pass (regression)
- [x] `pytest tests/training/test_lola_trainer.py tests/test_environment.py` — 88/88 pass (15 skipped pre-existing)
- [x] `ruff format` + `ruff check` clean
- [x] Local smoke: `experiments/p3_specialization/train.py --scenario default --num-iterations 1 --rollout-steps 64 --audit-obs 20` — wrote 80 samples (20 picked steps x 4 agents) to `audit_obs.jsonl`; baseline run without `--audit-obs` produces identical metrics

Scope: audit tooling only. Post-hoc analyzer + Markdown verdict report are a follow-up.

Closes #274.