### PR TITLE
fix: anchor agents/ gitignore rule to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,8 +236,8 @@ out/
 .AppleDouble
 .LSOverride
 
-# Loom agents (generated at runtime)
-agents/
+# Community agent submissions (see .github/ISSUE_TEMPLATE/agent-submission.yml)
+/agents/
 
 # TensorBoard logs
 runs/


### PR DESCRIPTION
## Summary

The unanchored `agents/` pattern in `.gitignore` matched `bucket_brigade/agents/`, silently shadowing tracked source files (`agent_base.py`, `archetypes.py`, `heuristic_agent.py`, etc.). The rule's true purpose is to ignore the community agent-submission artifact directory at the repo root (`/agents/submitted/`, see `.github/ISSUE_TEMPLATE/agent-submission.yml`).

## Changes

- `.gitignore`: change `agents/` to `/agents/` (anchor to repo root).
- `.gitignore`: replace misleading section comment ("Loom agents (generated at runtime)") with accurate reference to the agent-submission flow.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `bucket_brigade/agents/` no longer ignored | yes | `git check-ignore bucket_brigade/agents/__init__.py` returns nothing (exit 1) |
| `/agents/submitted/` still ignored | yes | `git check-ignore agents/submitted/foo` returns the path (exit 0) |
| Section comment accurate | yes | Comment now references `.github/ISSUE_TEMPLATE/agent-submission.yml` |

## Test Plan

Verified with `git check-ignore` against both paths after the change. Diff is 2 lines.

Closes #322