### PR TITLE
docs: correct TransformerPolicyNetwork param-count docstring

### DIFF
--- a/bucket_brigade/training/networks.py
+++ b/bucket_brigade/training/networks.py
@@ -707,7 +707,10 @@ class TransformerPolicyNetwork(nn.Module):
 
     This network uses self-attention to process house observations, allowing
     the agent to reason about spatial relationships and coordination needs.
-    Designed for ~200-500K parameters to better utilize GPU resources.
+    At the documented defaults (d_model=256, nhead=4, num_layers=3,
+    dim_feedforward=512, obs_dim=42) this network has roughly 1.7M parameters,
+    dominated by the transformer encoder stack. The breakdown is approximately:
+    embeddings ~5K + transformer ~1.58M + action/value heads ~100K = ~1.69M.
 
     Architecture:
         - Input embedding: Linear projection of flattened observation
@@ -735,9 +738,9 @@ class TransformerPolicyNetwork(nn.Module):
         ...     d_model=256,
         ...     num_layers=3
         ... )
-        >>> # Approximately 350K parameters
+        >>> # Approximately 1.69M parameters at the documented defaults
         >>> sum(p.numel() for p in policy.parameters())
-        ~350000
+        1686797
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Fix incorrect parameter-count claims in the `TransformerPolicyNetwork` docstring. The class header claimed "~200-500K parameters" and the example asserted "~350000", but the documented defaults (`d_model=256, nhead=4, num_layers=3, dim_feedforward=512`, post-#204 `obs_dim=42`) actually produce **1,686,797** parameters — roughly an order of magnitude off.

## Changes

- `bucket_brigade/training/networks.py:710` — Replace "~200-500K parameters" with an accurate ~1.7M description plus a 1-line component breakdown (embeddings ~5K + transformer ~1.58M + heads ~100K = ~1.69M).
- `bucket_brigade/training/networks.py:738-740` — Update the doctest example's expected return value from `~350000` to `1686797`.
- No default values or runtime behavior changed. All three callers (`bc_fit_only.py`, `bc_init.py`, `experiments/marl/train_gpu.py`) explicitly pass these hyperparameters, so the defaults are documentation-only anyway.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Docstring "~200-500K" replaced with accurate range | yes | New text states ~1.7M with component breakdown |
| Example "~350000" updated to match reality | yes | Now `1686797` (measured) |
| Existing 7 transformer tests still pass | yes | `pytest tests/test_bc_fit_transformer.py` → 7 passed |
| No runtime/behavior changes | yes | Only docstring lines modified (`git diff --stat`: 6 inserts, 3 deletes) |

## Test Plan

- Verified actual param count with `sum(p.numel() for p in TransformerPolicyNetwork(obs_dim=42, action_dims=[10,2], num_houses=10, d_model=256, nhead=4, num_layers=3, dim_feedforward=512).parameters())` → 1,686,797.
- Ran `pytest tests/test_bc_fit_transformer.py` → all 7 tests pass (the param-count assertion uses a `[300K, 3M]` envelope that already accommodates the true value).
- `ruff format` + `ruff check`: clean.

Closes #324