### PR TITLE
refactor(baselines): single-source SCENARIO_RANDOM_BASELINES dict

### DIFF
--- a/bucket_brigade/baselines/__init__.py
+++ b/bucket_brigade/baselines/__init__.py
@@ -13,6 +13,11 @@ Currently exports:
   houses it owns. See :mod:`bucket_brigade.baselines.specialist`.
 - :data:`MINSPEC_RANDOM`, :data:`MINSPEC_SPECIALIST` -- canonical per-step team
   reward references for the ``minimal_specialization`` scenario (see below).
+- :data:`SCENARIO_RANDOM_BASELINES` -- canonical per-step uniform-random team
+  reward references across all 14 named scenarios + ``positional_default``,
+  mirroring the value column of
+  ``experiments/p3_specialization/diagnostics/random_baseline.py``'s
+  ``SCENARIO_CITED_VALUES`` for non-torch consumers (issue #323).
 """
 
 from bucket_brigade.baselines.specialist import (
@@ -59,10 +64,54 @@ from bucket_brigade.baselines.specialist import (
 MINSPEC_RANDOM: float = -87.72
 MINSPEC_SPECIALIST: float = -22.07
 
+# ---------------------------------------------------------------------------
+# Canonical per-step uniform-random team-reward references (all scenarios)
+# ---------------------------------------------------------------------------
+#
+# Value-only mirror of
+# ``experiments/p3_specialization/diagnostics/random_baseline.py``'s
+# ``SCENARIO_CITED_VALUES[scenario]["random"]`` column. The full table in
+# ``random_baseline.py`` also carries measurement metadata
+# (``mlp_iter0``, ``note``); this mirror lifts only the per-step random
+# baselines so non-torch consumers (e.g. ``experiments/scripts/
+# compute_nash_trained.py``) can ``from bucket_brigade.baselines import
+# SCENARIO_RANDOM_BASELINES`` without dragging in the training stack
+# (``random_baseline.py`` transitively imports ``JointPPOTrainer`` ->
+# ``torch``). See issue #323 / single-source-of-truth rationale.
+#
+# Derivation provenance: post-#236 (signal-as-first-class-action)
+# re-derivation from issue #237 on ``COMPUTE_HOST_PRIMARY`` at commit
+# ``dffe1060``: n=1000 episodes per scenario (200 episodes × 5 seeds
+# 42..46), ``MultiDiscrete([10, 2, 2])`` uniform sampling. Logs committed
+# under ``experiments/p3_specialization/diagnostics/results/
+# issue237_postmerge/``. The ``minimal_specialization`` value here is the
+# same canonical -87.72 published in ``MINSPEC_RANDOM`` above.
+#
+# Drift guard: ``tests/test_baselines_constants.py`` asserts that every
+# entry here matches ``SCENARIO_CITED_VALUES[scenario]["random"]`` so the
+# two cannot silently diverge.
+SCENARIO_RANDOM_BASELINES: dict[str, float] = {
+    "default": 251.23,
+    "easy": 355.07,
+    "hard": 124.66,
+    "trivial_cooperation": 399.99,
+    "early_containment": 297.24,
+    "greedy_neighbor": 292.78,
+    "sparse_heroics": 246.06,
+    "rest_trap": 302.87,
+    "chain_reaction": 227.39,
+    "deceptive_calm": 78.55,
+    "overcrowding": 120.24,
+    "mixed_motivation": 224.06,
+    "minimal_specialization": -87.72,
+    "positional_default": 250.73,
+}
+
 __all__ = [
     "SpecialistPolicy",
     "specialist_action",
     "specialist_action_joint",
     "MINSPEC_RANDOM",
     "MINSPEC_SPECIALIST",
+    "SCENARIO_RANDOM_BASELINES",
 ]

--- a/experiments/p3_specialization/diagnostics/random_baseline.py
+++ b/experiments/p3_specialization/diagnostics/random_baseline.py
@@ -92,6 +92,12 @@ DEFAULT_SCENARIO_NAME = "default"
 # All 14 named scenarios from ``bucket-brigade-core/src/scenarios.rs`` are
 # present post-#237; the verdict comparison should never be suppressed for a
 # named scenario.
+#
+# Cross-reference (issue #323): a value-only mirror of the ``random`` column
+# below lives in :data:`bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES`
+# for non-torch consumers (this module transitively imports torch via the
+# training package). ``tests/test_baselines_constants.py`` asserts the two
+# stay in sync.
 SCENARIO_CITED_VALUES: dict[str, dict[str, float | str | None]] = {
     "default": {
         "random": 251.23,

--- a/experiments/scripts/compute_nash_trained.py
+++ b/experiments/scripts/compute_nash_trained.py
@@ -64,6 +64,7 @@ from bucket_brigade.agents import (  # noqa: E402
     TrainedPolicyArchetype,
 )
 from bucket_brigade.agents.archetypes import ARCHETYPES  # noqa: E402
+from bucket_brigade.baselines import SCENARIO_RANDOM_BASELINES  # noqa: E402
 from bucket_brigade.envs import BucketBrigadeEnv, get_scenario_by_name  # noqa: E402
 from bucket_brigade.equilibrium.nash_solver import (  # noqa: E402
     compute_support,
@@ -297,27 +298,17 @@ def screen_trained_checkpoints(
 
 
 # ---------------------------------------------------------------------------
-# Reward-baseline lookup (subset of the SCENARIO_CITED_VALUES table; kept
-# inline so this module has no dependency on experiments/p3_specialization
-# diagnostics).
+# Reward-baseline lookup
 # ---------------------------------------------------------------------------
+#
+# Sourced from :data:`bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES`,
+# which is the canonical value-only mirror of
+# ``experiments/p3_specialization/diagnostics/random_baseline.py``'s
+# ``SCENARIO_CITED_VALUES``. Imported via ``bucket_brigade.baselines`` to
+# avoid pulling in the torch-based training stack that
+# ``random_baseline.py`` depends on (issue #323).
 
-RANDOM_BASELINES: Dict[str, float] = {
-    "default": 251.23,
-    "easy": 355.07,
-    "hard": 124.66,
-    "trivial_cooperation": 399.99,
-    "early_containment": 297.24,
-    "greedy_neighbor": 292.78,
-    "sparse_heroics": 246.06,
-    "rest_trap": 302.87,
-    "chain_reaction": 227.39,
-    "deceptive_calm": 78.55,
-    "overcrowding": 120.24,
-    "mixed_motivation": 224.06,
-    "minimal_specialization": -87.72,
-    "positional_default": 250.73,
-}
+RANDOM_BASELINES: Dict[str, float] = SCENARIO_RANDOM_BASELINES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_baselines_constants.py
+++ b/tests/test_baselines_constants.py
@@ -1,5 +1,5 @@
 """Anti-regression guard for the canonical minimal_specialization baselines
-(issue #293).
+(issue #293) and the scenario-wide random-baselines mirror (issue #323).
 
 This test pins the per-step team-reward references published by
 :mod:`bucket_brigade.baselines` to the canonical post-#246 derivation
@@ -14,6 +14,12 @@ documented in that module's docstring:
   reward on the same scenario. Re-derived post-#236 under issue #238 /
   PR #243; specialist policies signal honestly so the value is unchanged
   from pre-#236 at the precision of the n=50 sampler.
+
+* ``SCENARIO_RANDOM_BASELINES`` — value-only mirror of the ``random``
+  column of ``random_baseline.SCENARIO_CITED_VALUES`` (issue #323). The
+  drift guard asserts every key/value pair matches the diagnostics table
+  so non-torch consumers (e.g. ``compute_nash_trained.py``) get the same
+  numbers as the authoritative measurement record.
 
 Before issue #293 the codebase had three coexisting MINSPEC_RANDOM values
 spread across analyzers: ``-96.07`` (pre-#246 2-dim sampler bug),
@@ -32,7 +38,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from bucket_brigade.baselines import MINSPEC_RANDOM, MINSPEC_SPECIALIST
+from bucket_brigade.baselines import (
+    MINSPEC_RANDOM,
+    MINSPEC_SPECIALIST,
+    SCENARIO_RANDOM_BASELINES,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _RANDOM_BASELINE = (
@@ -89,4 +99,51 @@ def test_minspec_random_matches_measurement_table() -> None:
         f"['random'] = {table_value!r} disagrees with "
         f"bucket_brigade.baselines.MINSPEC_RANDOM = {MINSPEC_RANDOM!r}. "
         "Issue #293 requires these to stay aligned."
+    )
+
+
+def _parse_scenario_cited_values_random_column() -> dict[str, float]:
+    """Extract ``scenario -> random`` pairs from ``random_baseline.py`` via grep.
+
+    We avoid importing ``random_baseline`` because it transitively pulls in
+    torch (see module docstring). This mirrors the approach in
+    ``test_minspec_random_matches_measurement_table``.
+    """
+    src = _RANDOM_BASELINE.read_text()
+    # Match each `"scenario": { ... "random": <float>, ...` entry.
+    pattern = re.compile(
+        r'"(?P<name>[a-z_][a-z0-9_]*)"\s*:\s*\{[^}]*?"random"\s*:\s*(?P<value>-?\d+\.\d+)',
+        re.DOTALL,
+    )
+    return {m.group("name"): float(m.group("value")) for m in pattern.finditer(src)}
+
+
+def test_scenario_random_baselines_matches_measurement_table() -> None:
+    """``SCENARIO_RANDOM_BASELINES`` must equal the diagnostics ``random`` column.
+
+    Issue #323: ``bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES`` is a
+    value-only mirror of
+    ``random_baseline.SCENARIO_CITED_VALUES[<scenario>]["random"]``. The two
+    must agree exactly on every scenario the mirror exposes.
+    """
+    table = _parse_scenario_cited_values_random_column()
+    assert table, (
+        "Could not parse any scenario entries from random_baseline.py — "
+        "has the SCENARIO_CITED_VALUES layout changed?"
+    )
+    missing = sorted(set(SCENARIO_RANDOM_BASELINES) - set(table))
+    assert not missing, (
+        f"SCENARIO_RANDOM_BASELINES references scenarios absent from "
+        f"random_baseline.SCENARIO_CITED_VALUES: {missing}"
+    )
+    mismatches = {
+        name: (SCENARIO_RANDOM_BASELINES[name], table[name])
+        for name in SCENARIO_RANDOM_BASELINES
+        if SCENARIO_RANDOM_BASELINES[name] != table[name]
+    }
+    assert not mismatches, (
+        "SCENARIO_RANDOM_BASELINES disagrees with "
+        "random_baseline.SCENARIO_CITED_VALUES on these scenarios "
+        f"(mirror, source): {mismatches}. Issue #323 requires these to stay "
+        "aligned — update both tables together when re-deriving baselines."
     )


### PR DESCRIPTION
## Summary
Lift the per-scenario uniform-random per-step team-reward values into `bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES` so non-torch consumers can import them without dragging in the training stack. Replace the inlined dict in `experiments/scripts/compute_nash_trained.py` with an import.

## Changes
- `bucket_brigade/baselines/__init__.py`: add `SCENARIO_RANDOM_BASELINES` (14 scenarios + `positional_default`) with provenance docstring matching the existing `MINSPEC_RANDOM` style. No torch import introduced (verified by `import sys; "torch" in sys.modules` -> `False`).
- `experiments/scripts/compute_nash_trained.py`: remove inlined `RANDOM_BASELINES` dict; alias it to the imported `SCENARIO_RANDOM_BASELINES`. All call sites unchanged.
- `experiments/p3_specialization/diagnostics/random_baseline.py`: keep `SCENARIO_CITED_VALUES` as the authoritative table (it carries `mlp_iter0` + `note` metadata); add a cross-reference comment pointing to the mirror.
- `tests/test_baselines_constants.py`: add `test_scenario_random_baselines_matches_measurement_table` drift guard. Uses the same grep-based parsing trick as the existing `MINSPEC_RANDOM` table check (PR #296) to avoid importing the torch-tainted `random_baseline.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SCENARIO_RANDOM_BASELINES` in `bucket_brigade.baselines` with same keys/values as `SCENARIO_CITED_VALUES`'s `random` column | done | New drift-guard test passes; all 14 scenarios + `positional_default` present |
| `compute_nash_trained.py` no longer inlines the dict | done | `grep` shows only the new import line + alias; no literal dict |
| `random_baseline.py` `SCENARIO_CITED_VALUES` preserved (carries `mlp_iter0`/`note` metadata) | done | Only comment added, table untouched |
| No torch import introduced | done | `python -c "import bucket_brigade.baselines; import sys; assert 'torch' not in sys.modules"` succeeds |
| Drift guard test added (mirrors #296 pattern) | done | `test_scenario_random_baselines_matches_measurement_table` passes |

## Test Plan
- `uv run pytest tests/test_baselines_constants.py -v` — 4/4 pass (3 existing + 1 new).
- `tests/test_nash_trained_ppo.py` skipped locally (torch unavailable); regression coverage of the import path is provided by the new drift-guard test plus the `compute_nash_trained.py` syntax check.
- `ruff format` + `ruff check --fix` clean on all 4 modified files.

Closes #323