### PR TITLE
fix(agents): refuse 2-head PPO checkpoints by default, opt-in via --allow-legacy-2head

### DIFF
--- a/bucket_brigade/agents/trained_policy_archetype.py
+++ b/bucket_brigade/agents/trained_policy_archetype.py
@@ -21,8 +21,10 @@ The wrapper is deliberately minimal:
   diagnostic rollouts.
 * Honest signal — the network outputs a third action head (signal) when
   ``action_dims = [10, 2, 2]``; we pass it through. For two-head legacy
-  checkpoints we synthesize ``signal := mode`` (honest), matching the
-  pre-#235 BucketBrigade contract.
+  checkpoints (pre-#236) loading is **refused by default**: synthesizing
+  ``signal := mode`` would fabricate an output the original policy never
+  produced. Pass ``allow_legacy_2head=True`` to opt in to the synthesis
+  (with a runtime warning). See issue #325 for the audit trail.
 
 The wrapper does *not* try to fit a 10-d θ vector to clone a network — see
 the Curator notes on issue #275: that approach (Option A) is lossy because
@@ -33,6 +35,7 @@ the heuristic family is low-capacity. The mixed payoff evaluator in
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -76,6 +79,15 @@ class TrainedPolicyArchetype(AgentBase):
         CPU-bound (#198 small env) so GPU launch overhead dominates.
     name
         Optional human-readable name (e.g. ``"ippo_seed42_agent0"``).
+    allow_legacy_2head
+        If ``False`` (default), refuse to load checkpoints with only 2
+        action heads (legacy pre-#236 policies) by raising ``ValueError``.
+        If ``True``, accept the legacy checkpoint and synthesize the
+        missing signal channel as ``signal := mode`` at act time, emitting
+        a ``UserWarning``. See issue #325 — all 244 existing checkpoints
+        under ``experiments/p3_specialization/`` on 2026-05-18 were 2-head,
+        so this gate is the difference between an honest "no signal" verdict
+        and a silently-fabricated one.
     """
 
     def __init__(
@@ -89,12 +101,14 @@ class TrainedPolicyArchetype(AgentBase):
         deterministic: bool = True,
         device: str = "cpu",
         name: Optional[str] = None,
+        allow_legacy_2head: bool = False,
     ) -> None:
         super().__init__(agent_id, name or f"trained-{Path(state_dict_path).stem}")
         self.state_dict_path = Path(state_dict_path)
         self.num_agents = int(num_agents)
         self.deterministic = bool(deterministic)
         self.device = torch.device(device)
+        self.allow_legacy_2head = bool(allow_legacy_2head)
 
         if not self.state_dict_path.exists():
             raise FileNotFoundError(
@@ -129,6 +143,30 @@ class TrainedPolicyArchetype(AgentBase):
                 inferred = [10, 2, 2]
             self.action_dims = inferred
 
+        # Gate legacy 2-head (pre-#236) checkpoints (#325). The PolicyNetwork
+        # only knows about the heads it was constructed with, so a 2-head
+        # checkpoint loaded as a 2-head network produces a 2-d action. The
+        # downstream env expects 3-d (house, mode, signal); the historical
+        # behavior was to silently append ``signal := mode`` at act time,
+        # which fabricates a signal output the original policy never produced.
+        # Refuse by default; opt in to the synthesis with a warning.
+        if len(self.action_dims) == 2:
+            if not self.allow_legacy_2head:
+                raise ValueError(
+                    f"TrainedPolicyArchetype: checkpoint {self.state_dict_path} "
+                    f"has 2 action heads (legacy pre-#236). Loading would "
+                    f"silently set `signal := mode`, fabricating a signal "
+                    f"output the original policy never produced. Pass "
+                    f"`allow_legacy_2head=True` to opt in to the backfill "
+                    f"(see issue #325)."
+                )
+            warnings.warn(
+                f"Loading legacy 2-head checkpoint {self.state_dict_path}; "
+                f"signal := mode backfill active (see issue #325).",
+                UserWarning,
+                stacklevel=2,
+            )
+
         self.policy = PolicyNetwork(
             obs_dim=self.obs_dim,
             action_dims=self.action_dims,
@@ -158,6 +196,8 @@ class TrainedPolicyArchetype(AgentBase):
         out = [int(a[0].item()) for a in actions]
 
         # Backfill signal for legacy two-head checkpoints (signal := mode).
+        # Only reachable when the caller opted into ``allow_legacy_2head=True``
+        # at construction time; otherwise ``__init__`` raised (#325).
         if len(out) == 2:
             out.append(out[1])
 

--- a/experiments/scripts/compute_nash_trained.py
+++ b/experiments/scripts/compute_nash_trained.py
@@ -122,7 +122,8 @@ def _make_agent(spec: Dict[str, Any], slot_id: int, num_agents: int) -> Any:
 
     ``spec`` shapes:
       * ``{"kind": "heuristic", "theta": np.ndarray(10,), "name": str}``
-      * ``{"kind": "trained", "path": Path, "name": str, "deterministic": bool}``
+      * ``{"kind": "trained", "path": Path, "name": str, "deterministic": bool,
+          "allow_legacy_2head": bool}``
     """
     kind = spec["kind"]
     if kind == "heuristic":
@@ -138,6 +139,7 @@ def _make_agent(spec: Dict[str, Any], slot_id: int, num_agents: int) -> Any:
             num_agents=num_agents,
             deterministic=spec.get("deterministic", True),
             name=f"{spec['name']}-{slot_id}",
+            allow_legacy_2head=spec.get("allow_legacy_2head", False),
         )
     raise ValueError(f"Unknown strategy kind: {kind!r}")
 
@@ -234,6 +236,7 @@ def screen_trained_checkpoints(
     margin: float,
     seed: int,
     verbose: bool = True,
+    allow_legacy_2head: bool = False,
 ) -> Tuple[List[Path], Dict[str, float]]:
     """Filter checkpoint dirs to those whose self-play team reward beats random.
 
@@ -258,6 +261,7 @@ def screen_trained_checkpoints(
                     num_agents=num_agents,
                     deterministic=True,
                     name=f"{ckpt_dir.parent.name}",
+                    allow_legacy_2head=allow_legacy_2head,
                 )
                 for i in range(num_agents)
             ]
@@ -412,6 +416,22 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--quiet", action="store_true", help="Suppress per-cell progress lines."
     )
+    parser.add_argument(
+        "--allow-legacy-2head",
+        action="store_true",
+        help=(
+            "Opt in to loading legacy pre-#236 PPO checkpoints that have only "
+            "2 action heads (house, mode). With this flag the missing signal "
+            "channel is synthesized as `signal := mode` at act time, and a "
+            "UserWarning is emitted per checkpoint. WITHOUT this flag, "
+            "TrainedPolicyArchetype refuses to load 2-head checkpoints because "
+            "the silent backfill would fabricate a signal output the original "
+            "policy never produced (issue #325). NOTE: as of 2026-05-18 all "
+            "244 existing checkpoints under experiments/p3_specialization/ "
+            "are 2-head, so this flag is currently required to include any "
+            "of them in the Nash pool."
+        ),
+    )
 
     args = parser.parse_args(argv)
     verbose = not args.quiet
@@ -438,6 +458,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     print(f"  filter-margin:    {args.filter_margin}")
     print(f"  seed:             {args.seed}")
     print(f"  output:           {output_dir}")
+    print(f"  allow-legacy-2head: {args.allow_legacy_2head}")
+    if args.allow_legacy_2head:
+        print(
+            "  WARNING: legacy 2-head checkpoints will be loaded with "
+            "`signal := mode` synthesis (#325)."
+        )
     print()
 
     # ---- Pool construction --------------------------------------------------
@@ -468,6 +494,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 margin=args.filter_margin,
                 seed=args.seed,
                 verbose=verbose,
+                allow_legacy_2head=args.allow_legacy_2head,
             )
             excluded = [d.parent.name for d in discovered if d not in kept]
         else:
@@ -489,6 +516,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                     "kind": "trained",
                     "name": f"ppo_{ckpt_dir.parent.name}",
                     "path": ckpt_dir / "agent_0.pt",
+                    "allow_legacy_2head": args.allow_legacy_2head,
                 }
             )
 
@@ -508,6 +536,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "random_baseline": random_baseline,
             "filter_enabled": not args.no_filter,
             "filter_margin": args.filter_margin,
+            "allow_legacy_2head": args.allow_legacy_2head,
             "dry_run": True,
         }
         out_json = output_dir / "equilibrium_partial.json"
@@ -574,6 +603,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "random_baseline": random_baseline,
         "filter_enabled": not args.no_filter,
         "filter_margin": args.filter_margin,
+        "allow_legacy_2head": args.allow_legacy_2head,
         "num_simulations": args.simulations,
         "seed": args.seed,
         "elapsed_payoff_sec": elapsed_payoff,
@@ -596,6 +626,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         f"- random baseline: {random_baseline:.2f}",
         f"- seed: {args.seed}",
         f"- simulations/cell: {args.simulations}",
+    ]
+    if args.allow_legacy_2head:
+        md_lines.append(
+            "- **legacy-2head**: ON — trained checkpoints had only 2 action "
+            "heads; signal channel synthesized as `signal := mode` (#325)."
+        )
+    md_lines += [
         "",
         "## Equilibrium support",
         "",

--- a/tests/test_nash_trained_ppo.py
+++ b/tests/test_nash_trained_ppo.py
@@ -159,6 +159,168 @@ def test_trained_policy_archetype_missing_file_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Legacy 2-head checkpoint: refuse by default, opt-in synthesis (#325)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_2head_checkpoint_refused_by_default(tmp_path):
+    """A 2-head state_dict must raise ValueError mentioning the opt-in flag."""
+    num_agents = 4
+    obs = _make_dummy_obs(num_agents=num_agents)
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=num_agents).shape[0]
+    # Save a legacy 2-head policy (no signal channel).
+    path = _save_random_policy(tmp_path, obs_dim=obs_dim, action_dims=[10, 2])
+
+    with pytest.raises(ValueError) as excinfo:
+        TrainedPolicyArchetype(
+            state_dict_path=path,
+            agent_id=0,
+            num_agents=num_agents,
+        )
+    msg = str(excinfo.value)
+    # Documented error must name the flag and reference the issue.
+    assert "allow_legacy_2head" in msg
+    assert "2 action heads" in msg
+    assert "signal" in msg
+
+
+def test_legacy_2head_checkpoint_opt_in_warns_and_synthesizes(tmp_path):
+    """With `allow_legacy_2head=True`, a 2-head checkpoint loads with a
+    UserWarning and ``act()`` returns a 3-d action where ``out[2] == out[1]``
+    (i.e. signal := mode synthesis)."""
+    num_agents = 4
+    obs = _make_dummy_obs(num_agents=num_agents)
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=num_agents).shape[0]
+    path = _save_random_policy(tmp_path, obs_dim=obs_dim, action_dims=[10, 2])
+
+    with pytest.warns(UserWarning, match="legacy 2-head"):
+        archetype = TrainedPolicyArchetype(
+            state_dict_path=path,
+            agent_id=0,
+            num_agents=num_agents,
+            allow_legacy_2head=True,
+        )
+    assert archetype.action_dims == [10, 2]
+    action = archetype.act(obs)
+    assert action.shape == (3,)
+    # Signal is synthesized to match mode.
+    assert int(action[2]) == int(action[1])
+
+
+def test_modern_3head_checkpoint_loads_without_warning_or_error(tmp_path):
+    """Modern 3-head checkpoints must load cleanly: no warning, no error,
+    and the legacy gate must not trip."""
+    num_agents = 4
+    obs = _make_dummy_obs(num_agents=num_agents)
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=num_agents).shape[0]
+    path = _save_random_policy(tmp_path, obs_dim=obs_dim, action_dims=[10, 2, 2])
+
+    # `pytest.warns` doesn't have a "no warning" assertion; use the standard
+    # `warnings.catch_warnings` recorder and assert nothing was raised.
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as recorded:
+        _warnings.simplefilter("always")
+        archetype = TrainedPolicyArchetype(
+            state_dict_path=path,
+            agent_id=0,
+            num_agents=num_agents,
+        )
+    legacy_warnings = [w for w in recorded if "legacy 2-head" in str(w.message)]
+    assert legacy_warnings == [], (
+        f"Modern 3-head checkpoint should not trigger the legacy warning; "
+        f"got {legacy_warnings}"
+    )
+    assert archetype.action_dims == [10, 2, 2]
+    # Sanity check act() produces a 3-d action (not via synthesis).
+    action = archetype.act(obs)
+    assert action.shape == (3,)
+
+
+def test_legacy_2head_cli_flag_plumbs_through(tmp_path, script_module):
+    """The CLI flag ``--allow-legacy-2head`` must reach the underlying
+    archetype constructor. Use a stub trained checkpoint and verify the
+    flag is propagated through the strategy spec into ``_make_agent``."""
+    num_agents = 4
+    obs = _make_dummy_obs(num_agents=num_agents)
+    obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=num_agents).shape[0]
+
+    # The CLI dry-run path is where pool construction happens.
+    # We verify two things:
+    #   1) Without the flag, a 2-head trained checkpoint causes
+    #      `screen_trained_checkpoints` to SKIP it (constructor raises).
+    #   2) With the flag, the constructor succeeds (warning emitted).
+    # We exercise the constructor path directly via _make_agent, which is
+    # the production code that consumes the flag from the spec.
+    path = _save_random_policy(tmp_path, obs_dim=obs_dim, action_dims=[10, 2])
+
+    # Without opt-in: _make_agent must raise.
+    spec_strict = {
+        "kind": "trained",
+        "name": "ppo_legacy",
+        "path": path,
+        "allow_legacy_2head": False,
+    }
+    with pytest.raises(ValueError, match="allow_legacy_2head"):
+        script_module._make_agent(spec_strict, slot_id=0, num_agents=num_agents)
+
+    # With opt-in: _make_agent must succeed (and warn).
+    spec_optin = {
+        "kind": "trained",
+        "name": "ppo_legacy",
+        "path": path,
+        "allow_legacy_2head": True,
+    }
+    with pytest.warns(UserWarning, match="legacy 2-head"):
+        agent = script_module._make_agent(spec_optin, slot_id=0, num_agents=num_agents)
+    assert isinstance(agent, TrainedPolicyArchetype)
+    assert agent.allow_legacy_2head is True
+
+
+def test_legacy_2head_cli_arg_smokes_through_main(tmp_path, script_module):
+    """End-to-end smoke: ``--allow-legacy-2head`` parses, defaults to False,
+    and is reflected in the dry-run equilibrium_partial.json output."""
+    import json
+
+    out = tmp_path / "nash_out"
+    # Default (no flag) -> allow_legacy_2head: False
+    rc = script_module.main(
+        [
+            "--scenario",
+            "default",
+            "--simulations",
+            "1",
+            "--output-dir",
+            str(out),
+            "--dry-run",
+            "--quiet",
+        ]
+    )
+    assert rc == 0
+    partial = json.loads((out / "default" / "equilibrium_partial.json").read_text())
+    assert partial["allow_legacy_2head"] is False
+
+    # With the flag set -> allow_legacy_2head: True
+    out2 = tmp_path / "nash_out_optin"
+    rc = script_module.main(
+        [
+            "--scenario",
+            "default",
+            "--simulations",
+            "1",
+            "--output-dir",
+            str(out2),
+            "--dry-run",
+            "--quiet",
+            "--allow-legacy-2head",
+        ]
+    )
+    assert rc == 0
+    partial2 = json.loads((out2 / "default" / "equilibrium_partial.json").read_text())
+    assert partial2["allow_legacy_2head"] is True
+
+
+# ---------------------------------------------------------------------------
 # Above-random filter logic
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`TrainedPolicyArchetype` previously synthesized the third action head as `signal := mode` whenever it encountered a 2-head (pre-#236) checkpoint, silently fabricating an output the original policy never produced. As of 2026-05-18 **all 244** PPO checkpoints under `experiments/p3_specialization/` are 2-head — the silent backfill is the dominant path, not an edge case, and PR #319's Nash-of-trained-PPO infrastructure is currently fabricating signals for every checkpoint it loads.

This PR implements Option B (refuse + opt-in) from issue #325: default behavior is to raise `ValueError` at load time, with an explicit `allow_legacy_2head=True` constructor kwarg and matching `--allow-legacy-2head` CLI flag in `compute_nash_trained.py` to enable the synthesis (with a `UserWarning`).

## Changes

- `bucket_brigade/agents/trained_policy_archetype.py`:
  - New `allow_legacy_2head: bool = False` constructor kwarg.
  - After inferring `action_dims`, if `len == 2` and not opted in, raise `ValueError` naming the flag and pointing to #325.
  - If opted in, emit `UserWarning("Loading legacy 2-head checkpoint ...; signal := mode backfill active")`.
  - Updated docstrings to reflect the gating.
- `experiments/scripts/compute_nash_trained.py`:
  - New `--allow-legacy-2head` CLI flag, default False, with help text explaining the silent-fabrication risk and the 244-vs-0 inventory state.
  - Threaded through `_make_agent` (via strategy spec) and `screen_trained_checkpoints` (new kwarg).
  - Banner printed at startup when opt-in is active; flag recorded in `equilibrium.json` / `equilibrium_partial.json` and surfaced in the markdown verdict.
- `tests/test_nash_trained_ppo.py`:
  - `test_legacy_2head_checkpoint_refused_by_default` — ValueError mentions `allow_legacy_2head`, "2 action heads", and "signal".
  - `test_legacy_2head_checkpoint_opt_in_warns_and_synthesizes` — UserWarning + 3-d action with `out[2] == out[1]`.
  - `test_modern_3head_checkpoint_loads_without_warning_or_error` — regression guard.
  - `test_legacy_2head_cli_flag_plumbs_through` — `_make_agent` propagates the flag.
  - `test_legacy_2head_cli_arg_smokes_through_main` — argparse: default False, present True; reflected in dry-run JSON.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 2-head without opt-in raises ValueError mentioning the flag | Done | `test_legacy_2head_checkpoint_refused_by_default` |
| 2-head with opt-in warns + synthesizes signal := mode | Done | `test_legacy_2head_checkpoint_opt_in_warns_and_synthesizes` |
| 3-head unchanged (no warn, no raise) | Done | `test_modern_3head_checkpoint_loads_without_warning_or_error` |
| CLI flag plumbs through end-to-end | Done | `test_legacy_2head_cli_flag_plumbs_through` + `test_legacy_2head_cli_arg_smokes_through_main` |

## Test Plan

- `uv run python -m pytest tests/test_nash_trained_ppo.py -v` — 15/15 pass.
- `ruff format` + `ruff check --fix` — clean.

CRITICAL: all 244 existing checkpoints are 2-head — Nash sweeps now require explicit `--allow-legacy-2head` opt-in or fresh 3-head checkpoints. Documents the silent-fabrication risk.

Coordinates with #323 which also touches `compute_nash_trained.py` (rebase expected if #323 merges first).

Closes #325