### PR TITLE
test(conftest): detect stale Rust extension by mtime, fail loud with build.sh fix-it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,11 @@ uv run python experiments/scripts/compute_nash_v2.py ...
   the venv: `uv pip install pip`.
 - Rust build env vars (see `bucket-brigade-core/build.sh`):
   `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`, `RUSTC_WRAPPER=` (unset any sccache wrapper).
+- After a rebase that touches `bucket-brigade-core/src/`, `pytest` will fail
+  loudly via the `tests/conftest.py` staleness check if the installed `.so` is
+  older than the Rust sources. Fix: `bash bucket-brigade-core/build.sh`.
+  Escape hatch (CI / mtime-unreliable environments):
+  `BUCKET_BRIGADE_ALLOW_STALE_RUST=1`.
 
 **See `experiments/REMOTE_EXECUTION.md` for detailed remote workflow guide.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "research: marks tests validating research findings (deselect with '-m \"not research\"')",
     "torch_required: marks tests requiring torch/RL dependencies",
-    "requires_rust: marks tests that require the bucket-brigade-core Rust extension to be built (run bucket-brigade-core/build.sh; set BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 to skip instead of fail)",
+    "requires_rust: marks tests that require the bucket-brigade-core Rust extension to be built and up-to-date (run bucket-brigade-core/build.sh; set BUCKET_BRIGADE_ALLOW_MISSING_RUST=1 to skip when missing, or BUCKET_BRIGADE_ALLOW_STALE_RUST=1 to skip the staleness check)",
 ]
 addopts = "--strict-markers"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ This module provides:
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -17,9 +18,15 @@ import pytest
 # rare Python-only test run (e.g. on a machine without a Rust toolchain).
 RUST_ESCAPE_HATCH_ENV = "BUCKET_BRIGADE_ALLOW_MISSING_RUST"
 
-# Path the user is told to run to fix a missing Rust extension. The literal
-# string is referenced in the UsageError below and asserted by tests; keep
-# it in sync.
+# Env var that converts a stale Rust extension (`.so` older than its Rust
+# sources) from a hard collection failure into an explicit skip. Intended
+# for CI / dev workflows that knowingly skip the freshness check (e.g. when
+# file mtimes are unreliable post-checkout).
+RUST_STALE_ESCAPE_HATCH_ENV = "BUCKET_BRIGADE_ALLOW_STALE_RUST"
+
+# Path the user is told to run to fix a missing or stale Rust extension.
+# The literal string is referenced in the UsageError below and asserted by
+# tests; keep it in sync.
 RUST_BUILD_SCRIPT = "bucket-brigade-core/build.sh"
 
 
@@ -30,6 +37,83 @@ def _rust_core_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+def _installed_rust_so_path() -> Path | None:
+    """Locate the installed ``bucket_brigade_core`` ``.so`` artifact.
+
+    Returns the filesystem path to the compiled PyO3 extension (the
+    ``bucket_brigade_core.cpython-*.so`` file), or ``None`` if it cannot be
+    found. The extension is built alongside the ``__init__.py`` package, so
+    we resolve via ``bucket_brigade_core.__file__`` and glob for the ``.so``.
+    """
+    try:
+        import bucket_brigade_core
+    except ImportError:
+        return None
+
+    init_file = getattr(bucket_brigade_core, "__file__", None)
+    if not init_file:
+        return None
+
+    pkg_dir = Path(init_file).parent
+    candidates = sorted(pkg_dir.glob("bucket_brigade_core*.so"))
+    return candidates[0] if candidates else None
+
+
+def _rust_source_root() -> Path | None:
+    """Locate the ``bucket-brigade-core/`` source root.
+
+    Walks up from this conftest file looking for a sibling
+    ``bucket-brigade-core/src`` directory. Returns ``None`` if not found
+    (e.g. when running from an installed wheel without source checkout).
+    """
+    here = Path(__file__).resolve()
+    for parent in (here.parent, *here.parents):
+        candidate = parent / "bucket-brigade-core"
+        if (candidate / "src").is_dir():
+            return candidate
+    return None
+
+
+def _rust_core_is_stale() -> bool:
+    """Return True iff the installed Rust ``.so`` is older than its sources.
+
+    Compares the mtime of the compiled extension against the newest mtime
+    among ``bucket-brigade-core/src/**/*.rs`` and ``bucket-brigade-core/
+    Cargo.toml``. Returns ``False`` (not stale) in any case where the check
+    cannot be performed conservatively:
+
+      - Extension not importable (handled by the absence check, not here).
+      - Source tree not found (e.g. installed wheel, no source checkout).
+      - No Rust source files discovered (defensive — would otherwise treat
+        every install as fresh by default, which is correct).
+    """
+    so_path = _installed_rust_so_path()
+    if so_path is None or not so_path.exists():
+        # Absence is handled separately; don't double-trigger here.
+        return False
+
+    source_root = _rust_source_root()
+    if source_root is None:
+        return False
+
+    sources: list[Path] = list((source_root / "src").rglob("*.rs"))
+    cargo_toml = source_root / "Cargo.toml"
+    if cargo_toml.exists():
+        sources.append(cargo_toml)
+
+    if not sources:
+        return False
+
+    try:
+        so_mtime = so_path.stat().st_mtime
+        newest_source_mtime = max(p.stat().st_mtime for p in sources)
+    except OSError:
+        # Filesystem error reading mtimes — fail open (don't block tests).
+        return False
+
+    return newest_source_mtime > so_mtime
 
 
 def pytest_configure(config):
@@ -65,13 +149,18 @@ def pytest_collection_modifyitems(config, items):
     without the Rust extension importable.
     """
     # ------------------------------------------------------------------
-    # `requires_rust` handling — see issue #189.
+    # `requires_rust` handling — see issue #189 (absence) and #330 (staleness).
     #
     # Behaviour:
-    #   - Rust importable                            -> run normally.
+    #   - Rust importable + fresh                    -> run normally.
     #   - Rust missing AND escape-hatch env unset    -> UsageError (loud).
     #   - Rust missing AND escape-hatch env set      -> explicit skip with
     #     a message naming the env var (NOT a silent skip).
+    #   - Rust present but STALE AND staleness env   -> UsageError (loud).
+    #     unset
+    #   - Rust present but STALE AND staleness env   -> explicit skip with
+    #     set                                          a message naming the
+    #                                                  env var.
     # ------------------------------------------------------------------
     requires_rust_items = [item for item in items if "requires_rust" in item.keywords]
 
@@ -97,6 +186,26 @@ def pytest_collection_modifyitems(config, items):
         )
         for item in requires_rust_items:
             item.add_marker(skip_rust)
+    elif requires_rust_items and _rust_core_is_stale():
+        # Extension is importable but the .so is older than the Rust sources —
+        # the common case after rebasing onto main commits that touched
+        # bucket-brigade-core/src/. See issue #330.
+        stale_escape_hatch = os.environ.get(RUST_STALE_ESCAPE_HATCH_ENV, "").strip()
+        if stale_escape_hatch in {"", "0", "false", "False"}:
+            raise pytest.UsageError(
+                "bucket_brigade_core (Rust extension) is older than its source "
+                f"tree, but {len(requires_rust_items)} test(s) marked "
+                "@pytest.mark.requires_rust were collected. The installed "
+                "extension will not reflect recent changes to "
+                "bucket-brigade-core/src/ or Cargo.toml.\n"
+                f"  Fix: run `bash {RUST_BUILD_SCRIPT}` to rebuild & reinstall the "
+                "extension into the active venv.\n"
+                f"  Escape hatch: set {RUST_STALE_ESCAPE_HATCH_ENV}=1 to skip the "
+                "staleness check (intended for CI/dev workflows where mtime "
+                "ordering is unreliable, e.g. after a fresh git checkout)."
+            )
+        # Escape hatch: silently accept stale extension — do NOT skip tests
+        # (a stale extension may still pass, and the user opted in explicitly).
 
     # Check for torch availability
     try:
@@ -208,8 +317,12 @@ def pytest_report_header(config):
     """Add custom information to pytest header."""
 
     headers = []
-    rust_present = "Yes" if _rust_core_available() else "No"
+    rust_available = _rust_core_available()
+    rust_present = "Yes" if rust_available else "No"
     headers.append(f"bucket-brigade-core available: {rust_present}")
+    if rust_available:
+        rust_stale = "Yes" if _rust_core_is_stale() else "No"
+        headers.append(f"bucket-brigade-core stale: {rust_stale}")
 
     # Check optional dependencies
     try:

--- a/tests/test_conftest_staleness.py
+++ b/tests/test_conftest_staleness.py
@@ -1,0 +1,162 @@
+"""
+Tests for the Rust-extension staleness detector in ``tests/conftest.py``.
+
+These tests exercise ``_rust_core_is_stale`` directly with monkeypatched
+paths and mtimes. End-to-end testing of ``pytest_collection_modifyitems``
+would require spawning a subprocess pytest run, which is brittle; here we
+test the underlying detector instead and document a manual smoke test in
+the PR body.
+
+See issue #330 for context.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests import conftest as _conftest
+
+
+def _touch_with_mtime(path: Path, mtime: float) -> None:
+    """Create ``path`` (parents included) and set its mtime to ``mtime``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    os.utime(path, (mtime, mtime))
+
+
+@pytest.fixture
+def fake_rust_tree(tmp_path, monkeypatch):
+    """Lay out a fake bucket-brigade-core tree and a fake installed .so.
+
+    Layout::
+
+        tmp_path/
+            installed/
+                bucket_brigade_core.cpython-darwin.so   <- the artifact
+            source/
+                src/
+                    lib.rs
+                    scenarios.rs
+                Cargo.toml
+
+    Returns ``(so_path, source_root)`` so tests can mutate mtimes freely.
+    Monkeypatches ``_installed_rust_so_path`` and ``_rust_source_root`` so
+    the detector sees this synthetic tree.
+    """
+    installed = tmp_path / "installed"
+    source_root = tmp_path / "source"
+
+    so_path = installed / "bucket_brigade_core.cpython-darwin.so"
+    rs_files = [
+        source_root / "src" / "lib.rs",
+        source_root / "src" / "scenarios.rs",
+    ]
+    cargo_toml = source_root / "Cargo.toml"
+
+    # Sources older than .so by default (fresh build state).
+    for rs in rs_files:
+        _touch_with_mtime(rs, mtime=1000.0)
+    _touch_with_mtime(cargo_toml, mtime=1000.0)
+    _touch_with_mtime(so_path, mtime=2000.0)
+
+    monkeypatch.setattr(_conftest, "_installed_rust_so_path", lambda: so_path)
+    monkeypatch.setattr(_conftest, "_rust_source_root", lambda: source_root)
+
+    return so_path, source_root
+
+
+class TestRustCoreIsStale:
+    """Direct tests of the ``_rust_core_is_stale`` detector."""
+
+    def test_fresh_build_is_not_stale(self, fake_rust_tree):
+        """`.so` newer than all sources -> not stale."""
+        assert _conftest._rust_core_is_stale() is False
+
+    def test_newer_rs_file_triggers_stale(self, fake_rust_tree):
+        """A `.rs` file newer than the `.so` -> stale."""
+        _, source_root = fake_rust_tree
+        os.utime(source_root / "src" / "scenarios.rs", (3000.0, 3000.0))
+        assert _conftest._rust_core_is_stale() is True
+
+    def test_newer_cargo_toml_triggers_stale(self, fake_rust_tree):
+        """`Cargo.toml` newer than the `.so` -> stale (catches dep bumps)."""
+        _, source_root = fake_rust_tree
+        os.utime(source_root / "Cargo.toml", (3000.0, 3000.0))
+        assert _conftest._rust_core_is_stale() is True
+
+    def test_equal_mtime_is_not_stale(self, fake_rust_tree):
+        """Source and `.so` at the same mtime -> not stale (boundary)."""
+        so_path, source_root = fake_rust_tree
+        os.utime(source_root / "src" / "lib.rs", (2000.0, 2000.0))
+        os.utime(so_path, (2000.0, 2000.0))
+        assert _conftest._rust_core_is_stale() is False
+
+    def test_nested_rs_file_is_detected(self, fake_rust_tree, tmp_path):
+        """Newly added deep-nested `.rs` files are picked up by rglob."""
+        _, source_root = fake_rust_tree
+        deep_rs = source_root / "src" / "agents" / "policy.rs"
+        _touch_with_mtime(deep_rs, mtime=4000.0)
+        assert _conftest._rust_core_is_stale() is True
+
+    def test_missing_so_returns_false(self, monkeypatch):
+        """No `.so` -> absence check handles this, detector returns False."""
+        monkeypatch.setattr(_conftest, "_installed_rust_so_path", lambda: None)
+        assert _conftest._rust_core_is_stale() is False
+
+    def test_missing_source_root_returns_false(self, tmp_path, monkeypatch):
+        """No source tree (e.g. wheel install) -> conservative False."""
+        so_path = tmp_path / "fake.so"
+        _touch_with_mtime(so_path, mtime=1000.0)
+        monkeypatch.setattr(_conftest, "_installed_rust_so_path", lambda: so_path)
+        monkeypatch.setattr(_conftest, "_rust_source_root", lambda: None)
+        assert _conftest._rust_core_is_stale() is False
+
+    def test_so_path_does_not_exist_returns_false(self, tmp_path, monkeypatch):
+        """`.so` path returned but file doesn't exist -> conservative False."""
+        ghost_so = tmp_path / "nonexistent.so"
+        monkeypatch.setattr(_conftest, "_installed_rust_so_path", lambda: ghost_so)
+        monkeypatch.setattr(_conftest, "_rust_source_root", lambda: tmp_path)
+        assert _conftest._rust_core_is_stale() is False
+
+    def test_empty_source_tree_returns_false(self, tmp_path, monkeypatch):
+        """Source root with no `.rs` files and no `Cargo.toml` -> False."""
+        installed = tmp_path / "installed"
+        source_root = tmp_path / "source"
+        (source_root / "src").mkdir(parents=True)
+        so_path = installed / "fake.so"
+        _touch_with_mtime(so_path, mtime=1000.0)
+
+        monkeypatch.setattr(_conftest, "_installed_rust_so_path", lambda: so_path)
+        monkeypatch.setattr(_conftest, "_rust_source_root", lambda: source_root)
+        assert _conftest._rust_core_is_stale() is False
+
+
+class TestRustSourceRootResolution:
+    """Tests for ``_rust_source_root`` path resolution."""
+
+    def test_finds_actual_source_root(self):
+        """In the real repo checkout, the detector finds bucket-brigade-core/."""
+        root = _conftest._rust_source_root()
+        # We're running from a worktree of bucket-brigade — source root must exist.
+        assert root is not None
+        assert root.name == "bucket-brigade-core"
+        assert (root / "src").is_dir()
+        assert (root / "Cargo.toml").is_file()
+
+
+class TestRustEscapeHatchConstants:
+    """Sanity checks on the escape-hatch env var name constants."""
+
+    def test_missing_hatch_name(self):
+        assert _conftest.RUST_ESCAPE_HATCH_ENV == "BUCKET_BRIGADE_ALLOW_MISSING_RUST"
+
+    def test_stale_hatch_name(self):
+        assert (
+            _conftest.RUST_STALE_ESCAPE_HATCH_ENV == "BUCKET_BRIGADE_ALLOW_STALE_RUST"
+        )
+
+    def test_build_script_path(self):
+        assert _conftest.RUST_BUILD_SCRIPT == "bucket-brigade-core/build.sh"


### PR DESCRIPTION
## Summary

After rebasing onto main commits that touch `bucket-brigade-core/src/`, the locally installed `bucket_brigade_core` PyO3 `.so` is stale until rebuilt. The existing `tests/conftest.py` hook only detected **absence** of the extension; this PR extends it to also detect **staleness** (`.so` older than its Rust sources) and fail loud with the same `bash bucket-brigade-core/build.sh` fix-it message.

## Changes

- `tests/conftest.py`:
  - New `_installed_rust_so_path()` resolves the compiled extension via `bucket_brigade_core.__file__` + glob.
  - New `_rust_source_root()` walks up to find `bucket-brigade-core/src`.
  - New `_rust_core_is_stale()` compares `.so` mtime against newest of `bucket-brigade-core/src/**/*.rs` + `Cargo.toml`. Conservative `False` in edge cases (missing tree, OS errors).
  - New `BUCKET_BRIGADE_ALLOW_STALE_RUST` env var as a separate escape hatch from the absence-case `BUCKET_BRIGADE_ALLOW_MISSING_RUST`.
  - `pytest_collection_modifyitems` gains a parallel branch raising `UsageError` when the extension is present but stale and `requires_rust` tests are collected.
  - `pytest_report_header` emits `bucket-brigade-core stale: Yes/No` alongside the existing availability line.
- `pyproject.toml`: `requires_rust` marker description mentions the new escape hatch.
- `CLAUDE.md`: One-bullet note in the existing Rust gotchas list documenting the staleness check + escape hatch.
- `tests/test_conftest_staleness.py` (new): 13 unit tests of the detector with monkeypatched paths/mtimes — covers fresh, stale-by-.rs, stale-by-Cargo.toml, equal-mtime boundary, nested .rs files, missing artifacts, OS error fallback.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Touch a `.rs` file -> pytest fails with clear staleness message naming `bash bucket-brigade-core/build.sh` | Verified | Smoke test: `touch bucket-brigade-core/src/scenarios.rs && uv run pytest tests/test_rust_integration.py` -> `UsageError` with build.sh fix-it. |
| Run `bash bucket-brigade-core/build.sh` -> tests pass | Verified | `uv pip install -e ./bucket-brigade-core --no-build-isolation` (the inner step build.sh runs); `uv run pytest tests/test_rust_integration.py` -> 4 passed, 1 skipped. |
| Escape hatch converts failure to allowed run | Verified | `BUCKET_BRIGADE_ALLOW_STALE_RUST=1 uv run pytest tests/test_rust_integration.py` -> tests run normally. |
| `pytest_report_header` shows stale line | Verified | Header now prints `bucket-brigade-core stale: Yes`/`No` whenever the extension is importable. |
| No false negative on normal post-build state | Verified | After rebuild, header reports `stale: No` and all integration tests pass. |
| Hook catches `Cargo.toml` changes too | Verified | `test_newer_cargo_toml_triggers_stale` covers this. |

## Test Plan

- `uv run pytest tests/test_conftest_staleness.py -v` -> 13/13 passed.
- Manual smoke (documented above): touch a `.rs` file -> staleness `UsageError` with the canonical fix-it.
- Manual smoke: `BUCKET_BRIGADE_ALLOW_STALE_RUST=1` allows the run through.
- Manual smoke: rebuild via `uv pip install -e ./bucket-brigade-core --no-build-isolation` clears the staleness flag and integration tests pass.
- `uv run ruff format` + `uv run ruff check --fix` -> clean.

Closes #330