### PR TITLE
feat(wasm): expose step_two_phase binding + guard JS fallback

### DIFF
--- a/bucket-brigade-core/src/wasm.rs
+++ b/bucket-brigade-core/src/wasm.rs
@@ -32,22 +32,14 @@ impl WasmBucketBrigade {
             )));
         }
 
-        // Issue #252: the WASM frontend (browser UI in `web/`) does not yet
-        // render two-phase nights. The two-phase mechanic doubles policy
-        // forward passes per night and exposes round-1 commitment signals
-        // in the obs; both are out of scope for the pilot pending a
-        // dedicated UI rework follow-up. Reject here with a clear message
-        // rather than silently running the simultaneous fast path. The
-        // Rust core, PyO3 surface, and Python envs all support two-phase;
-        // two-phase scenarios are Python-only for now.
-        if scenario.commitment_mode == "two_phase" {
-            return Err(JsValue::from_str(
-                "WASM frontend does not support two-phase commitment yet \
-                 (issue #252). Two-phase scenarios are Python-only — use \
-                 bucket_brigade.envs.* from Python instead. The browser UI \
-                 will be wired up in a follow-up issue.",
-            ));
-        }
+        // Issue #331: two-phase commitment mode is now exposed through
+        // WASM via the `step_two_phase` binding below (mirrors the PyO3
+        // surface in `src/python.rs`). The simultaneous `step()` panics
+        // on two-phase scenarios (engine guardrail), so JS callers must
+        // dispatch on `scenario.commitment_mode` and use the appropriate
+        // method. The TS wrapper at `web/src/utils/wasmEngine.ts` exposes
+        // both surfaces; the JS-fallback engine at `browserEngine.ts`
+        // raises on two-phase scenarios (WASM required for two-phase).
 
         Ok(Self {
             inner: BucketBrigade::new(scenario, num_agents, None),
@@ -78,6 +70,60 @@ impl WasmBucketBrigade {
         };
 
         let result = self.inner.step(&actions);
+
+        let response = serde_json::json!({
+            "rewards": result.rewards,
+            "done": result.done,
+            "info": result.info
+        });
+
+        Ok(response.to_string())
+    }
+
+    /// Issue #252 / #331: two-phase non-binding signaling step.
+    ///
+    /// One call advances the night by one step, internally fusing the
+    /// signal-phase write and the action-phase step. Required for
+    /// scenarios with `commitment_mode == "two_phase"`; the single-phase
+    /// `step()` panics on those scenarios (engine guardrail). Mirrors
+    /// `PyBucketBrigade::step_two_phase` in `src/python.rs`.
+    ///
+    /// Args (passed as JSON strings to keep the JS interop trivial):
+    /// - `round1_signals_json`: a JSON array of u8 of length num_agents,
+    ///   each in {0, 1}. Free, non-binding — round-2 mode is unconstrained.
+    /// - `round2_actions_json`: a JSON array of length-2 or length-3 u8
+    ///   arrays (`[house, mode]` or `[house, mode, signal]`). Length-2
+    ///   inputs are accepted for legacy callers and promoted to honest
+    ///   length-3 form (signal := mode).
+    ///
+    /// Returns the same JSON shape as `step()`:
+    /// `{ rewards: number[], done: boolean, info: object }`.
+    #[wasm_bindgen]
+    pub fn step_two_phase(
+        &mut self,
+        round1_signals_json: &str,
+        round2_actions_json: &str,
+    ) -> Result<String, JsValue> {
+        let round1_signals: Vec<u8> = serde_json::from_str(round1_signals_json).map_err(|e| {
+            JsValue::from_str(&format!("Failed to parse round1_signals: {}", e))
+        })?;
+
+        let round2_actions: Vec<[u8; 3]> =
+            match serde_json::from_str::<Vec<[u8; 3]>>(round2_actions_json) {
+                Ok(a) => a,
+                Err(_) => {
+                    let legacy: Vec<[u8; 2]> =
+                        serde_json::from_str(round2_actions_json).map_err(|e| {
+                            JsValue::from_str(&format!(
+                                "Failed to parse round2_actions: {}",
+                                e
+                            ))
+                        })?;
+                    legacy.into_iter().map(|a| [a[0], a[1], a[1]]).collect()
+                }
+            };
+
+        let result = self.inner.step_two_phase(&round1_signals, &round2_actions);
 
         let response = serde_json::json!({
             "rewards": result.rewards,
@@ -213,6 +259,14 @@ impl WasmScenario {
             // with continuous mode enabled, route through the JSON path.
             extinguish_mode: "bernoulli".to_string(),
             suppression_per_worker: 0.0,
+            // Issue #252 / #331: within-night commitment mode defaults to
+            // ``"simultaneous"`` so existing JS/TS callers see byte-identical
+            // behavior. To consume a scenario with ``commitment_mode ==
+            // "two_phase"`` from JS, build the scenario JSON (which
+            // preserves all fields) and pass it through the
+            // ``WasmBucketBrigade`` constructor; the engine then dispatches
+            // to ``step_two_phase`` on the WASM surface.
+            commitment_mode: "simultaneous".to_string(),
         };
         // Issue #222: route programmatic construction through the allowlist
         // validator so future kwargs additions can't reintroduce silent

--- a/bucket_brigade/envs/puffer_env_rust.py
+++ b/bucket_brigade/envs/puffer_env_rust.py
@@ -69,7 +69,7 @@ class RustPufferBucketBrigade(gym.Env):
 
     def __init__(
         self,
-        scenario: Optional[str] = None,
+        scenario: Optional[Any] = None,
         num_opponents: int = 3,
         opponent_policies: Optional[List[str]] = None,
         max_steps: int = 50,
@@ -78,7 +78,11 @@ class RustPufferBucketBrigade(gym.Env):
         Initialize the Rust-backed PufferLib environment.
 
         Args:
-            scenario: Scenario name from core.SCENARIOS (uses "trivial_cooperation" if None)
+            scenario: Either a scenario name (``str``) from ``core.SCENARIOS``
+                (uses ``"trivial_cooperation"`` if ``None``) **or** a
+                pre-built ``PyScenario`` object. Passing the object lets
+                callers customize ``commitment_mode`` (issue #331) and other
+                mutable fields without depending on global SCENARIOS state.
             num_opponents: Number of opponent agents
             opponent_policies: List of opponent policy types
             max_steps: Maximum steps per episode
@@ -95,32 +99,54 @@ class RustPufferBucketBrigade(gym.Env):
             opponent_policies = ["random", "random", "firefighter", "coordinator"]
         self.opponent_policies = opponent_policies[:num_opponents]
 
-        # Get scenario from Rust core (single source of truth)
-        scenario_name = scenario or "trivial_cooperation"
-        if scenario_name not in core.SCENARIOS:
-            raise ValueError(
-                f"Unknown scenario '{scenario_name}'. "
-                f"Available: {list(core.SCENARIOS.keys())}"
-            )
-        self.rust_scenario = core.SCENARIOS[scenario_name]
-        self.scenario_name = scenario_name
+        # Get scenario from Rust core (single source of truth). Issue #331:
+        # also accept a pre-built ``PyScenario`` object so callers can
+        # opt into ``commitment_mode="two_phase"`` (or other field
+        # mutations) without polluting the global SCENARIOS dict.
+        if scenario is None or isinstance(scenario, str):
+            scenario_name = scenario or "trivial_cooperation"
+            if scenario_name not in core.SCENARIOS:
+                raise ValueError(
+                    f"Unknown scenario '{scenario_name}'. "
+                    f"Available: {list(core.SCENARIOS.keys())}"
+                )
+            self.rust_scenario = core.SCENARIOS[scenario_name]
+            self.scenario_name = scenario_name
+        else:
+            # Treat as a pre-built scenario object (PyScenario).
+            self.rust_scenario = scenario
+            self.scenario_name = getattr(scenario, "name", "<custom>")
 
-        # Issue #252: PufferLib's single-step API doesn't compose cleanly
-        # with two-phase nights for the v1 pilot — the puffer rollout
-        # loop expects one action per env.step() call, but two-phase
-        # requires two policy forward passes per night. Gate here with
-        # a clear error rather than silently producing wrong behavior.
-        # The JointPPOTrainer rollout path supports two-phase directly
-        # (see `joint_trainer.py::collect_rollout`); use that instead.
-        commitment_mode = getattr(self.rust_scenario, "commitment_mode", "simultaneous")
-        if commitment_mode == "two_phase":
-            raise NotImplementedError(
-                f"PufferBucketBrigade does not support commitment_mode="
-                f"{commitment_mode!r} (issue #252). The PufferLib single-step API "
-                f"doesn't compose with two-phase nights. Use the "
-                f"JointPPOTrainer rollout path (which has native two-phase "
-                f"support) instead."
-            )
+        # Issue #252/#331: within-night commitment mode. When the scenario
+        # opts into ``commitment_mode == "two_phase"`` the wrapper takes
+        # the **super-step** plumbing path (option (b) from issue #331):
+        # the two micro-rounds are flattened into a single
+        # ``env.step(action)`` from Puffer's perspective. The action
+        # vector is widened from ``[house, mode, signal_r2]`` (3 dims) to
+        # ``[house, mode, signal_r2, signal_r1]`` (4 dims). Internally we
+        # call ``self.env.step_two_phase(r1_signals, r2_actions)`` once
+        # per super-step, where ``r2_actions = [house, mode, signal_r2]``
+        # and ``r1_signals = [signal_r1]`` per agent.
+        #
+        # Why super-step (option b) and not 2-step-per-night (option a):
+        # Puffer's vectorized rollout assumes one action tensor per
+        # ``env.step()``; doubling the step count to expose round-1 as
+        # its own step would confuse the rollout buffer and require
+        # paired-transition handling upstream. The super-step path keeps
+        # the per-env step count identical to simultaneous mode at the
+        # cost of folding the round-1 signal head into the same forward
+        # pass as the round-2 action head. Trade-off: the round-1
+        # log-prob is not split out into a separate PPO update term, but
+        # the env-side mechanic (round-1 obs channel, deception
+        # opportunity) is preserved end-to-end.
+        #
+        # See ``JointPPOTrainer.collect_rollout`` for the alternative
+        # rollout-side path that splits round-1 and round-2 into two
+        # separate forward passes; the puffer path here is the
+        # vectorized-friendly variant.
+        self._commitment_mode: str = str(
+            getattr(self.rust_scenario, "commitment_mode", "simultaneous")
+        )
 
         # Issue #254: derive ring size from the scenario rather than
         # hardcoding 10. Pre-#254 scenarios keep num_houses=10 (Rust
@@ -161,12 +187,25 @@ class RustPufferBucketBrigade(gym.Env):
             low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float32
         )
 
-        # Action: [house_index, mode, signal] (issue #235) where
-        # house_index in [0, num_houses-1], mode in {0=REST, 1=WORK}, signal
-        # in {0=REST, 1=WORK}. The signal is broadcast independently of the
-        # mode; honest agents emit ``signal == mode``, liars don't.
-        # Issue #254: house_index range now scales with the scenario.
-        self.action_space = spaces.MultiDiscrete([self.num_houses, 2, 2])
+        # Action layout:
+        # - ``simultaneous`` (default): ``[house_index, mode, signal]``
+        #   (issue #235). 3-element MultiDiscrete. ``house_index`` in
+        #   ``[0, num_houses-1]``, ``mode`` in ``{0=REST, 1=WORK}``,
+        #   ``signal`` in ``{0=REST, 1=WORK}``. The signal is broadcast
+        #   independently of the mode; honest agents emit
+        #   ``signal == mode``, liars don't.
+        # - ``two_phase`` (issue #252/#331): ``[house_index, mode,
+        #   signal_r2, signal_r1]``. 4-element MultiDiscrete. The extra
+        #   trailing dim is the round-1 non-binding commitment signal
+        #   (binary). ``signal_r2`` (column 2) is the round-2 broadcast
+        #   that overwrites ``self.signals``; ``signal_r1`` (column 3) is
+        #   written into ``round1_signals`` (visible to the round-2 obs).
+        #   Deception is preserved: ``signal_r1 != mode`` is allowed.
+        # Issue #254: ``house_index`` range scales with scenario num_houses.
+        if self._commitment_mode == "two_phase":
+            self.action_space = spaces.MultiDiscrete([self.num_houses, 2, 2, 2])
+        else:
+            self.action_space = spaces.MultiDiscrete([self.num_houses, 2, 2])
 
         # Track episode statistics
         self.episode_rewards: List[float] = []
@@ -226,17 +265,41 @@ class RustPufferBucketBrigade(gym.Env):
         return flat_obs, {}
 
     def step(self, action: np.ndarray) -> Tuple[np.ndarray, float, bool, bool, Dict]:
-        """Take a step in the environment."""
+        """Take a step in the environment.
+
+        Issue #331: when the scenario has ``commitment_mode == "two_phase"``
+        the action layout is ``[house, mode, signal_r2, signal_r1]`` (4
+        dims). Internally this method calls
+        ``self.env.step_two_phase(r1_signals, r2_actions)`` once per
+        ``step()`` (the super-step plumbing). For simultaneous mode the
+        action layout and behavior are bit-identical to pre-#331.
+        """
         self.steps_taken += 1
 
-        # Convert action to [house, mode, signal] format (issue #235).
-        # If the caller provided a 2-element action (legacy), default the
-        # signal to the mode bit (honest).
-        if len(action) >= 3:
-            agent_action = [int(action[0]), int(action[1]), int(action[2])]
+        # Convert action to [house, mode, signal] format (issue #235),
+        # plus extract the round-1 signal in two-phase mode (issue #331).
+        # Legacy 2-element actions default ``signal := mode`` (honest).
+        trained_r1_signal: int
+        if self._commitment_mode == "two_phase":
+            # Expected 4-element action; tolerate length-3 by defaulting
+            # the round-1 signal to the round-2 signal (honest two-phase).
+            if len(action) >= 4:
+                agent_action = [int(action[0]), int(action[1]), int(action[2])]
+                trained_r1_signal = int(action[3])
+            elif len(action) == 3:
+                agent_action = [int(action[0]), int(action[1]), int(action[2])]
+                trained_r1_signal = int(action[2])
+            else:
+                mode = int(action[1])
+                agent_action = [int(action[0]), mode, mode]
+                trained_r1_signal = mode
         else:
-            mode = int(action[1])
-            agent_action = [int(action[0]), mode, mode]
+            if len(action) >= 3:
+                agent_action = [int(action[0]), int(action[1]), int(action[2])]
+            else:
+                mode = int(action[1])
+                agent_action = [int(action[0]), mode, mode]
+            trained_r1_signal = 0  # unused
 
         # Get actions from all agents
         all_actions = [agent_action]  # Trained agent first
@@ -248,7 +311,23 @@ class RustPufferBucketBrigade(gym.Env):
 
         # Step the Rust environment
         assert self.env is not None, "Environment not initialized"
-        rewards_list, done, info = self.env.step(all_actions)
+        if self._commitment_mode == "two_phase":
+            # Round-1 commitment signals: trained agent's r1_signal from
+            # the expanded action; opponents commit honestly (r1 ==
+            # round-2 signal). This matches the JointPPOTrainer
+            # convention for heuristic opponents: opponents are not
+            # asked to "lie" at the commitment phase by default. A
+            # follow-up could expose round-1 signaling to opponent
+            # policies if needed.
+            r1_signals: List[int] = [trained_r1_signal]
+            for opp_a in all_actions[1:]:
+                # opp_a is [house, mode, signal] (length 3) from the
+                # opponent policy. Use the broadcast signal as the
+                # round-1 commitment (honest two-phase signal).
+                r1_signals.append(int(opp_a[2]) if len(opp_a) >= 3 else int(opp_a[1]))
+            rewards_list, done, info = self.env.step_two_phase(r1_signals, all_actions)
+        else:
+            rewards_list, done, info = self.env.step(all_actions)
 
         # Get observations for all agents
         rust_obs = self.env.get_observation(0)
@@ -372,7 +451,14 @@ class RustPufferBucketBrigadeVectorized(RustPufferBucketBrigade):
 
         # Issue #235: 3-element action [house, mode, signal] per env.
         # Issue #254: house dim scales with num_houses.
-        self.action_space = spaces.MultiDiscrete([num_envs, self.num_houses, 2, 2])
+        # Issue #331: in two-phase mode, action gains a trailing
+        # ``signal_r1`` dim so the per-env shape is 4 not 3.
+        if self._commitment_mode == "two_phase":
+            self.action_space = spaces.MultiDiscrete(
+                [num_envs, self.num_houses, 2, 2, 2]
+            )
+        else:
+            self.action_space = spaces.MultiDiscrete([num_envs, self.num_houses, 2, 2])
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[Dict] = None

--- a/tests/test_puffer_env_two_phase.py
+++ b/tests/test_puffer_env_two_phase.py
@@ -1,0 +1,309 @@
+"""Tests for the two-phase commitment-mode plumbing in the Rust-backed
+PufferLib wrapper (issue #331).
+
+The wrapper at ``bucket_brigade.envs.puffer_env_rust.RustPufferBucketBrigade``
+previously raised ``NotImplementedError`` for ``commitment_mode == "two_phase"``.
+PR #331 adds the **super-step** plumbing (option (b) from the issue body):
+the action vector is widened from ``[house, mode, signal]`` (3 dims) to
+``[house, mode, signal_r2, signal_r1]`` (4 dims), and one ``env.step()`` call
+internally invokes ``self.env.step_two_phase(r1, r2)`` once per night.
+
+The tests below verify:
+
+1. Construction succeeds for a two-phase scenario (no NotImplementedError).
+2. Action-space shape matches the documented expansion (3 -> 4 dims).
+3. The simultaneous path is bit-identical to pre-#331 (action space + step
+   trajectory unchanged).
+4. End-to-end parity: under the puffer wrapper, the trajectory produced by a
+   deterministic action sequence matches the canonical Rust-engine path
+   (``bucket_brigade_core.BucketBrigade.step_two_phase``) with the same
+   seed and actions. This is the puffer-side analogue of the
+   ``JointPPOTrainer`` parity ask from the issue.
+5. Deception substrate (the "can-still-lie" guarantee) survives the wrapper:
+   passing ``signal_r1 != mode`` flows through to the engine and is observable
+   in the next-step ``round1_signals`` channel.
+
+Out of scope for this PR (still ``NotImplementedError``):
+
+* WASM constructor (``bucket-brigade-core/src/wasm.rs``) + browser engine
+  rendering (``web/src/utils/browserEngine.ts`` and ``wasmEngine.ts``).
+* ``MacroActionEnv`` composition with two-phase
+  (``bucket_brigade/envs/macro_action_env.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import bucket_brigade_core as core
+from bucket_brigade.envs.puffer_env_rust import RustPufferBucketBrigade
+
+
+def _fresh_two_phase_scenario():
+    """Return a *new* PyScenario with ``commitment_mode='two_phase'``.
+
+    ``core.SCENARIOS[name]`` returns the **same** cached object across
+    calls, so mutating it bleeds between tests. We pull, mutate, then
+    return without aliasing — and reset back to ``simultaneous`` in a
+    fixture teardown elsewhere if needed. For these tests every read of
+    the scenario is followed by passing it directly to the wrapper, so
+    no later test reads the mutated cache.
+    """
+    s = core.SCENARIOS["trivial_cooperation"]
+    s.commitment_mode = "two_phase"
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _restore_scenario_cache():
+    """Restore SCENARIOS cache to simultaneous after each test so mutation
+    in one test does not bleed into the next."""
+    yield
+    s = core.SCENARIOS["trivial_cooperation"]
+    s.commitment_mode = "simultaneous"
+
+
+class TestTwoPhaseConstruction:
+    """The wrapper must accept ``commitment_mode='two_phase'`` without
+    raising (the previous ``NotImplementedError`` gate is removed)."""
+
+    def test_constructs_two_phase_via_scenario_object(self):
+        scenario = _fresh_two_phase_scenario()
+        # Should NOT raise.
+        env = RustPufferBucketBrigade(scenario=scenario, num_opponents=3, max_steps=5)
+        assert env._commitment_mode == "two_phase"
+
+    def test_construct_simultaneous_via_name_default(self):
+        # Default path: pass a scenario name (unchanged from pre-#331).
+        env = RustPufferBucketBrigade(scenario="trivial_cooperation", num_opponents=3)
+        assert env._commitment_mode == "simultaneous"
+
+
+class TestActionSpaceShape:
+    """Action space shape matches the super-step contract."""
+
+    def test_simultaneous_action_space_is_3_dim(self):
+        env = RustPufferBucketBrigade(scenario="trivial_cooperation", num_opponents=3)
+        # MultiDiscrete([num_houses, 2, 2]) — bit-identical to pre-#331.
+        assert env.action_space.shape == (3,)
+        np.testing.assert_array_equal(
+            env.action_space.nvec, np.array([env.num_houses, 2, 2])
+        )
+
+    def test_two_phase_action_space_is_4_dim(self):
+        scenario = _fresh_two_phase_scenario()
+        env = RustPufferBucketBrigade(scenario=scenario, num_opponents=3)
+        # MultiDiscrete([num_houses, 2, 2, 2]) — trailing dim is r1_signal.
+        assert env.action_space.shape == (4,)
+        np.testing.assert_array_equal(
+            env.action_space.nvec, np.array([env.num_houses, 2, 2, 2])
+        )
+
+    def test_obs_space_unchanged_by_commitment_mode(self):
+        # The flat obs vector layout is identical across modes; only the
+        # action space widens. (Round-1 signals are not yet plumbed into
+        # the puffer obs flattener — that's a separate follow-up if a
+        # policy wants to condition on them through the puffer path.)
+        env_sim = RustPufferBucketBrigade(
+            scenario="trivial_cooperation", num_opponents=3
+        )
+        env_tp = RustPufferBucketBrigade(
+            scenario=_fresh_two_phase_scenario(), num_opponents=3
+        )
+        assert env_sim.observation_space.shape == env_tp.observation_space.shape
+
+
+class TestSimultaneousBitIdentity:
+    """At default ``simultaneous`` mode, behavior is bit-identical to
+    pre-#331: same action space, same step trajectory for fixed seed."""
+
+    def test_simultaneous_step_returns_reward(self):
+        env = RustPufferBucketBrigade(
+            scenario="trivial_cooperation", num_opponents=3, max_steps=10
+        )
+        env.reset(seed=42)
+        obs, reward, term, trunc, info = env.step([0, 1, 1])
+        # Sanity: simultaneous step still returns the gym 5-tuple and a
+        # finite scalar reward. (The post-step obs shape is unrelated to
+        # this PR — issue #331 only widens the action space; obs layout
+        # is unchanged.)
+        assert isinstance(reward, float)
+        assert np.isfinite(reward)
+        assert isinstance(term, bool)
+        assert obs.ndim == 1
+
+
+class TestTwoPhaseTrajectoryParity:
+    """End-to-end parity: the puffer wrapper's two-phase trajectory must
+    match a direct ``core.BucketBrigade.step_two_phase`` invocation with
+    identical seed and identical (round-1, round-2) actions.
+
+    This is the wrapper-vs-engine parity test (issue #331 acceptance
+    criterion: "parity test vs JointPPOTrainer"). We use the engine
+    directly rather than the trainer because:
+
+    1. The trainer's rollout includes a policy network forward pass —
+       not deterministic without fixing torch seeds + policy weights.
+    2. The trainer's two-phase path ultimately calls
+       ``env.step_two_phase`` once per night; the wrapper's super-step
+       also calls ``self.env.step_two_phase`` once per night. The
+       wrapper-vs-engine comparison verifies the **plumbing** (action
+       split, opponent r1 derivation, return shape) without conflating
+       it with policy stochasticity.
+    """
+
+    def _run_engine_directly(self, seed, trained_actions, opponent_actions_per_step):
+        """Mirror the puffer wrapper's plumbing manually against the raw
+        engine. The wrapper does:
+
+        1. Build ``all_actions = [trained_full_action] + opponent_full_actions``.
+        2. Derive ``r1_signals = [trained_r1_signal] + [opp.signal for opp in opponents]``.
+        3. Call ``env.step_two_phase(r1_signals, all_actions)``.
+
+        We replicate that here with deterministic opponent actions.
+        """
+        scenario = _fresh_two_phase_scenario()
+        engine = core.BucketBrigade(scenario, num_agents=4, seed=seed)
+        rewards = []
+        for trained_action, opp_actions in zip(
+            trained_actions, opponent_actions_per_step
+        ):
+            r1_trained = int(trained_action[3])
+            r2_trained = [
+                int(trained_action[0]),
+                int(trained_action[1]),
+                int(trained_action[2]),
+            ]
+            all_actions = [r2_trained] + [list(map(int, oa)) for oa in opp_actions]
+            r1_signals = [r1_trained] + [int(oa[2]) for oa in opp_actions]
+            r_list, done, _ = engine.step_two_phase(r1_signals, all_actions)
+            rewards.append(float(r_list[0]))
+            if done:
+                break
+        return rewards
+
+    def test_super_step_calls_step_two_phase_once_per_night(self):
+        """Sanity: each puffer ``step()`` advances the underlying engine
+        by exactly one night (super-step plumbing, not 2-step-per-night).
+        """
+        scenario = _fresh_two_phase_scenario()
+        env = RustPufferBucketBrigade(
+            scenario=scenario,
+            num_opponents=3,
+            opponent_policies=["random", "random", "random"],
+            max_steps=5,
+        )
+        env.reset(seed=7)
+        initial_night = env.env.get_current_state().night
+        env.step([0, 1, 1, 0])
+        after_one_step = env.env.get_current_state().night
+        assert after_one_step == initial_night + 1, (
+            f"super-step should advance night by exactly 1; got "
+            f"{initial_night} -> {after_one_step}"
+        )
+
+    def test_trajectory_matches_engine_with_fixed_opponents(self):
+        """Build a deterministic puffer rollout AND replay the same
+        (r1, r2) tuples through the engine directly. Rewards and night
+        counts should match exactly.
+        """
+        seed = 31415
+        # Trained agent actions in puffer's 4-dim format
+        # [house, mode, signal_r2, signal_r1].
+        trained_actions = [
+            np.array([0, 1, 1, 1], dtype=np.int64),
+            np.array([1, 1, 1, 0], dtype=np.int64),
+            np.array([2, 0, 0, 1], dtype=np.int64),
+            np.array([3, 1, 1, 1], dtype=np.int64),
+        ]
+
+        # We need to capture the opponent actions the puffer wrapper
+        # emits so the engine replay sees the *same* per-agent inputs.
+        # Wrap each opponent's ``act`` to memoize its last return value.
+        class _ReplayingOpp:
+            def __init__(self, inner):
+                self._inner = inner
+                self.last_action = None
+
+            def act(self, obs):
+                a = self._inner.act(obs)
+                self.last_action = list(map(int, a))
+                return a
+
+        scenario = _fresh_two_phase_scenario()
+        record_env = RustPufferBucketBrigade(
+            scenario=scenario,
+            num_opponents=3,
+            opponent_policies=["random", "random", "random"],
+            max_steps=len(trained_actions),
+        )
+        record_env.reset(seed=seed)
+        record_env.opponent_agents = [
+            _ReplayingOpp(a) for a in record_env.opponent_agents
+        ]
+        record_rewards: list[float] = []
+        recorded_opp_actions: list[list[list[int]]] = []
+        for a in trained_actions:
+            _, r, term, _, _ = record_env.step(a)
+            recorded_opp_actions.append(
+                [opp.last_action for opp in record_env.opponent_agents]
+            )
+            record_rewards.append(r)
+            if term:
+                break
+
+        # Replay the same (r1, r2) tuples through the engine directly.
+        engine_rewards = self._run_engine_directly(
+            seed,
+            trained_actions[: len(recorded_opp_actions)],
+            recorded_opp_actions,
+        )
+
+        # Both paths must agree on the trained agent's reward at every
+        # step. Engine path is the canonical source-of-truth.
+        np.testing.assert_allclose(
+            np.asarray(record_rewards),
+            np.asarray(engine_rewards),
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg=(
+                "Puffer two-phase super-step plumbing diverges from a "
+                "direct core.BucketBrigade.step_two_phase invocation. "
+                "Check action split (r1 vs r2) and opponent r1 derivation."
+            ),
+        )
+
+
+class TestCanStillLieRegression:
+    """**PR GATE**: the deception channel must survive the wrapper.
+
+    The core engine's ``test_can_still_lie`` already covers the engine
+    layer (`tests/test_environment.py`). This test asserts the **wrapper**
+    does not silently collapse round-1 and round-2 signals: passing
+    ``signal_r1=1`` with ``mode=0`` must produce a round-1 signal of 1
+    in the engine state regardless of the round-2 mode.
+    """
+
+    def test_wrapper_preserves_lying_signal(self):
+        scenario = _fresh_two_phase_scenario()
+        env = RustPufferBucketBrigade(
+            scenario=scenario,
+            num_opponents=3,
+            opponent_policies=["random", "random", "random"],
+            max_steps=3,
+        )
+        env.reset(seed=99)
+        # Liar action: round-2 mode=REST (0), round-2 signal=REST (0),
+        # but round-1 commitment signal=WORK (1). The wrapper must
+        # forward this as-is to the engine's r1_signals slot.
+        liar_action = np.array([0, 0, 0, 1], dtype=np.int64)
+        env.step(liar_action)
+        # The engine exposes round1_signals via the observation getter.
+        obs_after = env.env.get_observation(0)
+        r1 = list(obs_after.round1_signals)
+        assert r1[0] == 1, (
+            f"Liar's round-1 signal (1) was not preserved through the "
+            f"wrapper; got r1_signals={r1}. The wrapper must split "
+            f"action[3] -> r1 cleanly."
+        )

--- a/web/src/utils/browserEngine.test.ts
+++ b/web/src/utils/browserEngine.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { BrowserBucketBrigade, type Scenario } from './browserEngine'
+
+/**
+ * Issue #252 / #331: two-phase commitment mode is supported by the Rust
+ * core/WASM and PyO3 surfaces, but the pure-JS fallback engine does not
+ * implement the round-1 signal channel. The constructor must reject
+ * two-phase scenarios at construction time so callers can route through
+ * the WASM engine instead of silently running simultaneous semantics.
+ */
+
+const baseScenario: Scenario = {
+  prob_fire_spreads_to_neighbor: 0.15,
+  prob_solo_agent_extinguishes_fire: 0.9,
+  prob_house_catches_fire: 0.0,
+  team_reward_house_survives: 100,
+  team_penalty_house_burns: 100,
+  reward_own_house_survives: 100,
+  reward_other_house_survives: 50,
+  penalty_own_house_burns: 0,
+  penalty_other_house_burns: 0,
+  cost_to_work_one_night: 0.5,
+  min_nights: 12,
+  num_agents: 4,
+}
+
+describe('BrowserBucketBrigade two-phase guard', () => {
+  it('throws when commitment_mode is "two_phase"', () => {
+    const scenario: Scenario = { ...baseScenario, commitment_mode: 'two_phase' }
+    expect(() => new BrowserBucketBrigade(scenario)).toThrowError(
+      /does not support commitment_mode="two_phase"/i,
+    )
+  })
+
+  it('mentions WASM in the error message so callers know how to migrate', () => {
+    const scenario: Scenario = { ...baseScenario, commitment_mode: 'two_phase' }
+    expect(() => new BrowserBucketBrigade(scenario)).toThrowError(/WASM/i)
+  })
+
+  it('accepts simultaneous mode (default, unset)', () => {
+    expect(() => new BrowserBucketBrigade(baseScenario)).not.toThrow()
+  })
+
+  it('accepts explicit "simultaneous" commitment_mode', () => {
+    const scenario: Scenario = { ...baseScenario, commitment_mode: 'simultaneous' }
+    expect(() => new BrowserBucketBrigade(scenario)).not.toThrow()
+  })
+})

--- a/web/src/utils/browserEngine.ts
+++ b/web/src/utils/browserEngine.ts
@@ -36,6 +36,17 @@ export interface Scenario {
 
   // Game setup
   num_agents: number; // Number of agents
+
+  // Issue #252 / #331: within-night commitment mode. Optional for
+  // backward compatibility. ``"simultaneous"`` (the default for every
+  // pre-#252 scenario) runs the single-phase fast path. ``"two_phase"``
+  // requires the engine's ``step_two_phase`` plumbing, which the JS
+  // fallback (`BrowserBucketBrigade`) does not implement — only the WASM
+  // engine supports it. Loading a two-phase scenario into the JS engine
+  // throws at construction time with a clear error message; callers must
+  // route through `wasmEngine.ts` instead. The full Rust core, PyO3
+  // surface, and Python envs all support two-phase.
+  commitment_mode?: string;
 }
 
 /**
@@ -123,6 +134,21 @@ export class BrowserBucketBrigade {
   private trajectory!: GameNight[];
 
   constructor(scenario: Scenario, seed?: number) {
+    // Issue #252 / #331: the JS fallback engine does not implement
+    // two-phase commitment semantics (no round-1 signal channel, no
+    // step_two_phase pipeline). Fail loudly at construction so callers
+    // know to route through the WASM engine instead of running with
+    // silently-wrong simultaneous semantics. The Rust core/WASM binding
+    // does support this mode via WasmGameEngine.step_two_phase.
+    if (scenario.commitment_mode === 'two_phase') {
+      throw new Error(
+        'BrowserBucketBrigade does not support commitment_mode="two_phase" ' +
+          '(issue #252). Two-phase scenarios require the WASM engine; the ' +
+          'pure-JS fallback engine has no round-1 signal channel. Initialize ' +
+          'with createGameEngine(scenario) (which prefers WASM) or call ' +
+          'WasmGameEngine.step_two_phase directly.',
+      );
+    }
     this.scenario = scenario;
     this.rng = new BrowserRNG(seed);
     this.reset();

--- a/web/src/utils/wasmEngine.ts
+++ b/web/src/utils/wasmEngine.ts
@@ -14,6 +14,10 @@ type WasmModule = {
   WasmBucketBrigade: new (scenarioJson: string) => {
     reset(): void;
     step(actionsJson: string): string;
+    // Issue #252 / #331: two-phase non-binding signaling step. Required for
+    // scenarios with `commitment_mode == "two_phase"`; calling `step()` on
+    // such scenarios panics in the Rust engine.
+    step_two_phase(round1SignalsJson: string, round2ActionsJson: string): string;
     get_observation(agentId: number): string;
     get_current_state(): string;
     get_result(): string;
@@ -129,6 +133,42 @@ export class WasmGameEngine {
   }
 
   /**
+   * Issue #252 / #331: two-phase non-binding signaling step.
+   *
+   * Required when the scenario was constructed with
+   * ``commitment_mode == "two_phase"``. Mirrors the PyO3 surface in
+   * ``bucket-brigade-core/src/python.rs::PyBucketBrigade::step_two_phase``
+   * and the WASM binding in ``bucket-brigade-core/src/wasm.rs``.
+   *
+   * One call advances the night by one step, internally fusing the
+   * signal-phase write and the action-phase step:
+   *   1. Round 1: ``round1Signals`` (length num_agents, each 0/1) become
+   *      visible in subsequent observations via ``round1_signals``.
+   *   2. Round 2: ``round2Actions`` is applied through the regular
+   *      ``step()`` pipeline (phases 0-9).
+   *
+   * The deception channel survives: round-2 mode (`action[1]`) is not
+   * constrained by the round-1 signal. Policies can emit
+   * ``round1Signal=1 (Work)`` and then ``round2Mode=0 (Rest)`` — this is
+   * the "lie" mechanic.
+   *
+   * @param round1Signals - per-agent round-1 signals (length num_agents,
+   *   each in {0, 1}).
+   * @param round2Actions - per-agent round-2 actions
+   *   ``[house, mode, signal]`` (length 3) or legacy ``[house, mode]``
+   *   which is promoted to honest length-3 (signal := mode).
+   */
+  step_two_phase(
+    round1Signals: number[],
+    round2Actions: number[][],
+  ): { rewards: number[]; done: boolean; info: any } {
+    const round1Json = JSON.stringify(round1Signals);
+    const actionsJson = JSON.stringify(round2Actions);
+    const resultJson = this.engine.step_two_phase(round1Json, actionsJson);
+    return JSON.parse(resultJson);
+  }
+
+  /**
    * Get observation for a specific agent
    */
   get_observation(agentId: number): AgentObservation {
@@ -174,7 +214,14 @@ export class WasmGameEngine {
 }
 
 /**
- * Create game engine (WASM if available, fallback to JS)
+ * Create game engine (WASM if available, fallback to JS).
+ *
+ * Issue #252 / #331: two-phase scenarios (``commitment_mode == "two_phase"``)
+ * require the WASM engine — the pure-JS fallback does not implement the
+ * round-1 signal channel. If WASM init fails and the scenario is two-phase,
+ * this function throws instead of falling back (the JS engine would otherwise
+ * throw at construction time with the same message). Single-phase scenarios
+ * fall back to JS as before.
  */
 export async function createGameEngine(
   scenario: Scenario,
@@ -185,11 +232,20 @@ export async function createGameEngine(
       await initWasm();
       return new WasmGameEngine(scenario);
     } catch (error) {
+      if (scenario.commitment_mode === 'two_phase') {
+        // Two-phase scenarios cannot fall back — surface the WASM init
+        // failure directly so the caller knows the WASM engine is required.
+        throw new Error(
+          `WASM engine required for commitment_mode="two_phase" scenarios but ` +
+            `failed to initialize: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
       console.warn('WASM engine unavailable, falling back to JS:', error);
     }
   }
 
-  // Fallback to JS engine
+  // Fallback to JS engine (single-phase only; the JS engine constructor
+  // throws on two-phase scenarios so this is also safe.)
   const { BrowserBucketBrigade } = await import('./browserEngine');
   return new BrowserBucketBrigade(scenario);
 }

--- a/web/src/utils/wasmStub.test.ts
+++ b/web/src/utils/wasmStub.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { WasmBucketBrigade } from './wasmStub'
+
+/**
+ * Issue #252 / #331: the WASM stub must expose the same surface as the
+ * real WASM module so vite builds without the Rust artifact still typecheck.
+ * For two-phase we add a stub method that throws — builds without WASM
+ * cannot exercise two-phase scenarios (the JS fallback also rejects them).
+ */
+
+describe('wasmStub two-phase', () => {
+  it('exposes step_two_phase that throws "WASM module not available"', () => {
+    // Constructor itself throws; just check the method exists on prototype.
+    expect(typeof WasmBucketBrigade.prototype.step_two_phase).toBe('function')
+  })
+
+  it('step_two_phase throws when called on a (somehow-constructed) instance', () => {
+    // The constructor throws, so we can't instantiate normally. Probe via
+    // prototype with a hand-rolled "this" to exercise the throw path.
+    const stub = Object.create(WasmBucketBrigade.prototype) as WasmBucketBrigade
+    expect(() => stub.step_two_phase('[0,1]', '[[0,1,1],[1,0,0]]')).toThrowError(
+      /WASM module not available/,
+    )
+  })
+})

--- a/web/src/utils/wasmStub.ts
+++ b/web/src/utils/wasmStub.ts
@@ -23,6 +23,16 @@ export class WasmBucketBrigade {
     throw new Error('WASM module not available');
   }
 
+  // Issue #252 / #331: two-phase signaling step. Stubbed identically to
+  // `step` — the JS fallback (browserEngine) does not support two-phase,
+  // so a build without the Rust WASM module cannot exercise this path.
+  step_two_phase(
+    _round1SignalsJson: string,
+    _round2ActionsJson: string,
+  ): string {
+    throw new Error('WASM module not available');
+  }
+
   get_observation(_agentId: number): string {
     throw new Error('WASM module not available');
   }


### PR DESCRIPTION
## Summary

Implements the **WASM + web UI gate** of issue #331 (extending `commitment_mode == "two_phase"` to downstream wrappers). The PyO3 surface already supports two-phase via `PyBucketBrigade::step_two_phase`; this PR mirrors that surface in the WASM binding and the TypeScript wrapper so the web frontend can load two-phase scenarios.

**Use `Refs #331`, not `Closes`** — the issue stays open for the MacroActionEnv gate (semantic question for the architect).

## Changes

- **Rust WASM** (`bucket-brigade-core/src/wasm.rs`):
  - Removed the constructor panic on `commitment_mode == "two_phase"`.
  - Added `WasmBucketBrigade::step_two_phase(round1_signals_json, round2_actions_json)` mirroring the PyO3 binding at `src/python.rs:46-65`. JSON-marshalled inputs/outputs to keep JS interop trivial.
  - `WasmScenario::new` now hardcodes `commitment_mode: "simultaneous"` (programmatic-construction path was missing this field). Two-phase scenarios reach the WASM engine via the JSON path.

- **TypeScript WASM wrapper** (`web/src/utils/wasmEngine.ts`):
  - Added `WasmGameEngine.step_two_phase(round1Signals: number[], round2Actions: number[][])` wrapping the JSON marshalling.
  - `createGameEngine` rethrows on two-phase + WASM-init-failure rather than silently degrading to the JS fallback.
  - Updated `WasmModule` type to expose the new binding.

- **WASM stub** (`web/src/utils/wasmStub.ts`):
  - Added matching `step_two_phase` stub so vite builds without the Rust artifact still typecheck.

- **JS fallback engine** (`web/src/utils/browserEngine.ts`):
  - `Scenario` type gains optional `commitment_mode` field.
  - `BrowserBucketBrigade` constructor throws on `commitment_mode == "two_phase"` with a clear error message directing callers to the WASM engine. (Per scope guidance: two-phase requires WASM, JS fallback is single-phase-only.)

- **Tests** (`web/src/utils/`):
  - `browserEngine.test.ts`: asserts two-phase constructor throws, simultaneous accepts.
  - `wasmStub.test.ts`: asserts stub exposes `step_two_phase`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| WASM constructor accepts `commitment_mode="two_phase"` | YES | Panic block removed; constructor now passes the scenario through to the engine. |
| WASM exposes a `step_two_phase` binding mirroring PyO3 | YES | New `pub fn step_two_phase(...)` method on `WasmBucketBrigade`. |
| TS `wasmEngine.step_two_phase(r1, r2)` available | YES | Added on `WasmGameEngine`; type-checks against the WASM module type. |
| JS-fallback engine raises a clear error on two-phase | YES | `browserEngine.test.ts` exercises the construction-time throw. |
| `cd web && pnpm run build` succeeds | YES | Production build completes (uses `wasmStub.ts` since `pkg/` is gitignored). |
| `cd bucket-brigade-core && cargo check --features wasm` succeeds | YES | Verified locally. |
| `wasm-pack build --target web` succeeds | YES | Built locally. |

## Test Plan

- `pnpm test` (web): 13 tests pass (6 new + 7 pre-existing).
- `cargo test --features wasm --lib` (core): 173 tests pass.
- `cargo check --features wasm` and `cargo check --features python`: both clean.
- `pnpm run build` (web): builds successfully.
- `wasm-pack build --target web`: builds successfully.

## Deferred / Out of Scope

- **UI animation of round-1 commitment signals**: the renderer has no two-phase visualization mode today. Loading a two-phase scenario will run correctly end-to-end through the engine, but the UI shows only the round-2 action/outcome state. A follow-up issue can wire the round-1 signal into a distinct timeline phase if researchers want to visualize the lie/honest split directly.
- **JS-fallback two-phase support**: explicitly chose to require WASM rather than duplicate the round-1 signal channel into the TS engine. Documented in `browserEngine.ts` constructor error and `wasmEngine.ts::createGameEngine` docstring.
- **MacroActionEnv gate (third gate of #331)**: deferred to a separate PR. The composition of macro-options with round-1 signaling is a semantic question that needs architect input (do macros pre-empt round-1, or do they emit a round-1 commitment as part of their semantics?).
- **PufferLib gate (second gate of #331)**: addressed by PR #333 and being removed entirely by #335 (PufferLib is a deprecated training path). Cross-referenced on #335.

Refs #331