### PR TITLE
fix(build): pass --features wasm to wasm-pack in CF Pages build

### DIFF
--- a/scripts/cf-pages-build.sh
+++ b/scripts/cf-pages-build.sh
@@ -50,7 +50,13 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 echo "::group::build wasm"
-(cd bucket-brigade-core && wasm-pack build --target web)
+# `--features wasm` is required: the `wasm` module in
+# `bucket-brigade-core/src/lib.rs` is gated behind `#[cfg(feature = "wasm")]`.
+# Without it, wasm-pack still emits a `pkg/` directory, but the WASM binary
+# contains no `#[wasm_bindgen]`-exported symbols and the JS/TS shim is a thin
+# loader with no class bindings (see issue #338, canonical form documented in
+# `web/WASM.md`).
+(cd bucket-brigade-core && wasm-pack build --target web --features wasm)
 echo "::endgroup::"
 
 echo "::group::research content"


### PR DESCRIPTION
## Summary

Single-line fix: add `--features wasm` to the `wasm-pack` invocation in `scripts/cf-pages-build.sh` so the `#[cfg(feature = "wasm")]`-gated module's bindings are emitted.

The `wasm` module in `bucket-brigade-core/src/lib.rs:9-10` is feature-gated. Without `--features wasm`, `wasm-pack build --target web` succeeds but silently produces a thin loader: a 1039-byte `bucket_brigade_core_bg.wasm` with no `#[wasm_bindgen]`-exported symbols, and a 31-line `.d.ts` with no class declarations. The deployed CF Pages site at `bucket-brigade.rjwalters.info` likely runs only off cached/older `pkg/` output.

## Changes

- `scripts/cf-pages-build.sh:53` — append `--features wasm` to the `wasm-pack build` call, with an inline comment pointing at the feature gate in `lib.rs` and the canonical form documented in `web/WASM.md`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pkg/bucket_brigade_core.js` exports `WasmBucketBrigade`, `WasmScenario`, `get_scenario`, `get_scenario_names` | ✅ | `grep "^export " pkg/bucket_brigade_core.js` shows all four |
| `pkg/bucket_brigade_core.d.ts` includes type declarations for the above | ✅ | 112-line `.d.ts` (vs. 31-line broken) contains `export class WasmBucketBrigade` and `export class WasmScenario` |
| `pkg/bucket_brigade_core_bg.wasm` materially larger than 1 KB | ✅ | 205,196 bytes (~205 KB) vs. 1039-byte broken thin-loader |
| `scripts/cf-pages-build.sh` passes `--features wasm` | ✅ | See diff |
| Secondary `commitment_mode` field bug | ✅ | Already fixed by merged PR #337 (`commitment_mode: "simultaneous".to_string()` at `src/wasm.rs:269` on `main`) — build compiles cleanly |

## Test Plan

- [x] `bash -n scripts/cf-pages-build.sh` — syntax clean
- [x] `rm -rf bucket-brigade-core/pkg && cd bucket-brigade-core && wasm-pack build --target web --features wasm` — succeeds (`Finished release profile [optimized] target(s) in 18.43s`, `Done in 20.21s`)
- [x] Verified `pkg/` contents per acceptance criteria above
- [ ] CF Pages deploy verification (Champion/maintainer can confirm on next deploy)

Closes #338