### PR TITLE
chore: silence bandit findings in run_tier1_cell.py with scoped nosec

### DIFF
--- a/experiments/p3_specialization/run_tier1_cell.py
+++ b/experiments/p3_specialization/run_tier1_cell.py
@@ -40,7 +40,7 @@ import argparse
 import importlib.util
 import json
 import math
-import subprocess
+import subprocess  # nosec B404 (orchestrator spawns train.py with fixed argv)
 import sys
 import time
 from dataclasses import dataclass
@@ -441,13 +441,13 @@ def build_cell_summary(
 def _run_subprocess(argv: Sequence[str], *, cwd: Path) -> int:
     """Run a subprocess and stream its output. Returns the exit code."""
     print(f"\n$ {' '.join(argv)}", flush=True)
-    completed = subprocess.run(list(argv), cwd=str(cwd))
+    completed = subprocess.run(list(argv), cwd=str(cwd))  # nosec B603 (cmd is list, no shell)
     return int(completed.returncode)
 
 
 def _git_sha(cwd: Path) -> str:
     try:
-        out = subprocess.run(
+        out = subprocess.run(  # nosec B603 B607 (git rev-parse — argv is hardcoded, not user input)
             ["git", "rev-parse", "--short", "HEAD"],
             cwd=str(cwd),
             check=True,


### PR DESCRIPTION
## Summary

Closes #348. 3 line-scoped nosec comments matching the #312/#306 pattern.

## Changes

- `experiments/p3_specialization/run_tier1_cell.py:43` — `# nosec B404` on `import subprocess`
- `experiments/p3_specialization/run_tier1_cell.py:444` — `# nosec B603` on `subprocess.run(list(argv), ...)`
- `experiments/p3_specialization/run_tier1_cell.py:450` — `# nosec B603 B607` on git `subprocess.run`

`aggregate_tier1.py` is bandit-clean; no changes needed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bandit reports zero issues for the two files | OK | `uv run --with bandit bandit -c pyproject.toml ...` -> "No issues identified", 4 nosec-skipped |
| `pre-commit run --all-files` bandit hook passes | OK | bandit / ruff / ruff format all `Passed` |
| No behavior change | OK | Comment-only edits; `pytest tests/test_tier1_driver.py` -> 24 passed |

## Test Plan

- [x] `uv run --with bandit bandit -c pyproject.toml experiments/p3_specialization/run_tier1_cell.py experiments/p3_specialization/aggregate_tier1.py` -> 0 issues
- [x] `uv run pre-commit run --all-files` bandit hook -> Passed
- [x] `uv run pytest tests/test_tier1_driver.py -q` -> 24 passed

Closes #348