### PR TITLE
test(nash): specialist exploitability harness for heterogeneous Nash profiles (#361)

### DIFF
--- a/experiments/scripts/test_specialist_exploitability.py
+++ b/experiments/scripts/test_specialist_exploitability.py
@@ -219,9 +219,11 @@ def test_exploitability(
     print()
 
     scenario = get_scenario_by_name(scenario_name, num_agents=4)
-    print(f"Scenario params: β={scenario.prob_fire_spreads_to_neighbor:.2f} "
-          f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f} "
-          f"c={scenario.cost_to_work_one_night:.2f}")
+    print(
+        f"Scenario params: β={scenario.prob_fire_spreads_to_neighbor:.2f} "
+        f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f} "
+        f"c={scenario.cost_to_work_one_night:.2f}"
+    )
     print()
 
     # We reuse HeterogeneousDoubleOracle purely for its evaluator helpers
@@ -231,10 +233,10 @@ def test_exploitability(
         scenario=scenario,
         num_simulations=num_simulations,
         opt_simulations=opt_simulations,
-        max_iterations=1,       # irrelevant; we don't call solve()
+        max_iterations=1,  # irrelevant; we don't call solve()
         epsilon=epsilon,
         seed=seed,
-        num_restarts=1,         # irrelevant; we don't call solve()
+        num_restarts=1,  # irrelevant; we don't call solve()
         verbose=verbose,
         num_workers=num_workers,
     )
@@ -280,16 +282,18 @@ def test_exploitability(
             flush=True,
         )
 
-        per_position.append({
-            "position": i,
-            "equilibrium_payoff": float(eq_payoffs[i]),
-            "best_response_payoff": float(br_payoff),
-            "gap": gap,
-            "exploitable_flag": bool(exploitable),
-            "best_response_closest_archetype": _classify(br_strategy),
-            "best_response_genome": [float(v) for v in br_strategy],
-            "elapsed_seconds": elapsed_pos,
-        })
+        per_position.append(
+            {
+                "position": i,
+                "equilibrium_payoff": float(eq_payoffs[i]),
+                "best_response_payoff": float(br_payoff),
+                "gap": gap,
+                "exploitable_flag": bool(exploitable),
+                "best_response_closest_archetype": _classify(br_strategy),
+                "best_response_genome": [float(v) for v in br_strategy],
+                "elapsed_seconds": elapsed_pos,
+            }
+        )
 
     any_exploitable = any(r["exploitable_flag"] for r in per_position)
 
@@ -345,8 +349,8 @@ def main():
         "--smoke",
         action="store_true",
         help="Smoke-test mode: equivalent to --simulations 20 --opt-simulations 10 "
-             "--positions 0. Use to verify the script wires correctly without "
-             "spending hours of compute.",
+        "--positions 0. Use to verify the script wires correctly without "
+        "spending hours of compute.",
     )
     parser.add_argument(
         "--output-dir",
@@ -372,7 +376,9 @@ def main():
     # Output path
     if args.output_dir is None:
         repo_root = Path(__file__).resolve().parents[2]
-        args.output_dir = repo_root / "experiments" / "nash" / "heterogeneous" / args.scenario
+        args.output_dir = (
+            repo_root / "experiments" / "nash" / "heterogeneous" / args.scenario
+        )
     args.output_dir.mkdir(parents=True, exist_ok=True)
     out_name = "exploitability_smoke.json" if args.smoke else "exploitability.json"
     out_path = args.output_dir / out_name

--- a/experiments/scripts/test_specialist_exploitability.py
+++ b/experiments/scripts/test_specialist_exploitability.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Specialist exploitability test for heterogeneous Nash equilibria.
+
+Given a converged 4-player asymmetric profile (from
+`compute_nash_heterogeneous.py`), verify that no single position can gain
+more than `epsilon` by unilaterally deviating to a different strategy.
+
+Algorithm
+---------
+For each position i in {0,1,2,3}:
+  1. Hold the other 3 positions fixed at the equilibrium strategy.
+  2. Call `HeterogeneousDoubleOracle._best_response_for_position`, which:
+       - grid-scans the 5 archetype strategies, picks the best
+       - refines with L-BFGS-B on the 10-d parameter vector
+       - re-evaluates with the full MC budget for verification
+  3. Compute gap = best_response_payoff - equilibrium_position_payoff.
+  4. Flag as exploitable iff gap > epsilon.
+
+If all 4 positions are within epsilon of their best response, the profile
+is confirmed as an epsilon-Nash equilibrium.  If any gap > epsilon, the
+profile is NOT a Nash equilibrium and the upstream claim is wrong.
+
+Profiles
+--------
+Two canonical profiles are hard-coded so the test is reproducible without
+depending on a particular `results.json` artifact:
+
+  - `rest_trap`:                FR | FR | FR | FF  (issue #355 winner, payoff~2984)
+  - `minimal_specialization`:   Hero | Hero | Hero | Hero  (issue #355 winner, payoff~-756)
+
+The `--profile-file` flag lets a caller supply a different profile as a JSON
+file with a `strategy_profile` list of {"genome": [...]} dicts, matching the
+shape emitted by `compute_nash_heterogeneous.py`.
+
+Output
+------
+    experiments/nash/heterogeneous/<scenario>/exploitability.json
+
+Schema:
+    {
+      "scenario": "rest_trap",
+      "profile_label": "free_rider | free_rider | free_rider | firefighter",
+      "epsilon": 50.0,
+      "num_simulations": 1000,
+      "opt_simulations": 300,
+      "seed": 42,
+      "elapsed_seconds": 6123.4,
+      "equilibrium_team_payoff": 2984.0,
+      "per_position": [
+        {
+          "position": 0,
+          "equilibrium_payoff": 2981.2,
+          "best_response_payoff": 2982.5,
+          "gap": 1.3,
+          "exploitable_flag": false,
+          "best_response_closest_archetype": "free_rider(d=0.00)"
+        },
+        ...
+      ],
+      "any_exploitable": false
+    }
+
+Compute
+-------
+CPU-bound; ~10 min per position at default settings, so ~40 min per profile
+and ~1.5h for both profiles on alc-9.  **DO NOT RUN LOCALLY** — push to
+$COMPUTE_HOST_PRIMARY or $COMPUTE_HOST_CLUSTER from .env.
+
+Usage
+-----
+    # Full run on remote host (per-scenario)
+    uv run python experiments/scripts/test_specialist_exploitability.py rest_trap
+    uv run python experiments/scripts/test_specialist_exploitability.py minimal_specialization
+
+    # Smoke test (single position, tiny budget) — safe to run locally
+    uv run python experiments/scripts/test_specialist_exploitability.py rest_trap \\
+        --smoke --positions 0 --simulations 20 --opt-simulations 10
+
+    # Custom profile from a results.json equilibrium entry
+    uv run python experiments/scripts/test_specialist_exploitability.py rest_trap \\
+        --profile-file path/to/profile.json
+"""
+
+from __future__ import annotations
+
+import sys
+import json
+import time
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+# Allow running from repo root or scripts/
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bucket_brigade.envs import get_scenario_by_name
+from bucket_brigade.agents.archetypes import (
+    FIREFIGHTER_PARAMS,
+    FREE_RIDER_PARAMS,
+    HERO_PARAMS,
+    COORDINATOR_PARAMS,
+    LIAR_PARAMS,
+)
+from bucket_brigade.equilibrium.double_oracle_heterogeneous import (
+    HeterogeneousDoubleOracle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical equilibrium profiles from PR #355 heterogeneous Nash sweep
+# ---------------------------------------------------------------------------
+
+# rest_trap: FR | FR | FR | FF (issue #355 best converged asymmetric, payoff=2984.04)
+# Source: experiments/nash/heterogeneous/rest_trap/results.json (PR #355 branch)
+REST_TRAP_PROFILE: list[np.ndarray] = [
+    FREE_RIDER_PARAMS.copy(),
+    FREE_RIDER_PARAMS.copy(),
+    FREE_RIDER_PARAMS.copy(),
+    FIREFIGHTER_PARAMS.copy(),
+]
+
+# minimal_specialization: Hero | Hero | Hero | Hero (positive control: dominant symmetric NE,
+# payoff=-756.36). Per #355, this is `symmetric_ne_superior`; symmetric Hero strictly beats
+# the best asymmetric profile here.
+MINIMAL_SPECIALIZATION_PROFILE: list[np.ndarray] = [
+    HERO_PARAMS.copy(),
+    HERO_PARAMS.copy(),
+    HERO_PARAMS.copy(),
+    HERO_PARAMS.copy(),
+]
+
+CANONICAL_PROFILES: dict[str, list[np.ndarray]] = {
+    "rest_trap": REST_TRAP_PROFILE,
+    "minimal_specialization": MINIMAL_SPECIALIZATION_PROFILE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Strategy-pool + classification helpers (mirrors compute_nash_heterogeneous.py)
+# ---------------------------------------------------------------------------
+
+ARCHETYPE_POOL: dict[str, np.ndarray] = {
+    "firefighter": FIREFIGHTER_PARAMS,
+    "free_rider": FREE_RIDER_PARAMS,
+    "hero": HERO_PARAMS,
+    "coordinator": COORDINATOR_PARAMS,
+    "liar": LIAR_PARAMS,
+}
+
+
+def _classify(theta: np.ndarray) -> str:
+    """Return name of closest archetype by L2 distance."""
+    best_name, best_dist = "unknown", np.inf
+    for name, params in ARCHETYPE_POOL.items():
+        d = float(np.linalg.norm(theta - params))
+        if d < best_dist:
+            best_dist = d
+            best_name = name
+    return f"{best_name}(d={best_dist:.2f})"
+
+
+def _profile_label(profile: list[np.ndarray]) -> str:
+    return " | ".join(_classify(t) for t in profile)
+
+
+def _load_profile_from_file(path: Path) -> list[np.ndarray]:
+    """Load a 4-position profile from a JSON file.
+
+    Expected shape (compatible with `compute_nash_heterogeneous.py` output):
+        {"strategy_profile": [{"genome": [10 floats]}, ... x4]}
+    Also accepts a bare list of 4 genomes.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    if isinstance(data, dict) and "strategy_profile" in data:
+        entries = data["strategy_profile"]
+        if len(entries) != 4:
+            raise ValueError(
+                f"Expected 4 positions in profile file, got {len(entries)}"
+            )
+        return [np.asarray(e["genome"], dtype=float) for e in entries]
+    if isinstance(data, list) and len(data) == 4:
+        return [np.asarray(g, dtype=float) for g in data]
+    raise ValueError(
+        f"Unrecognised profile format in {path}; expected dict with "
+        f"'strategy_profile' or 4-element list."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exploitability test
+# ---------------------------------------------------------------------------
+
+
+def test_exploitability(
+    scenario_name: str,
+    profile: list[np.ndarray],
+    positions: list[int],
+    num_simulations: int,
+    opt_simulations: int,
+    epsilon: float,
+    seed: int,
+    num_workers: int | None,
+    verbose: bool,
+) -> dict:
+    """Run per-position exploitability test, return results dict."""
+
+    print("=" * 70)
+    print("Specialist exploitability test")
+    print("=" * 70)
+    print(f"Scenario:        {scenario_name}")
+    print(f"Profile:         {_profile_label(profile)}")
+    print(f"Positions:       {positions}")
+    print(f"Simulations:     {num_simulations} (opt: {opt_simulations})")
+    print(f"Epsilon:         {epsilon}")
+    print(f"Seed:            {seed}")
+    print()
+
+    scenario = get_scenario_by_name(scenario_name, num_agents=4)
+    print(f"Scenario params: β={scenario.prob_fire_spreads_to_neighbor:.2f} "
+          f"κ={scenario.prob_solo_agent_extinguishes_fire:.2f} "
+          f"c={scenario.cost_to_work_one_night:.2f}")
+    print()
+
+    # We reuse HeterogeneousDoubleOracle purely for its evaluator helpers
+    # (_evaluate_team, _position_payoff, _best_response_for_position).
+    # No `solve()` loop is invoked.
+    solver = HeterogeneousDoubleOracle(
+        scenario=scenario,
+        num_simulations=num_simulations,
+        opt_simulations=opt_simulations,
+        max_iterations=1,       # irrelevant; we don't call solve()
+        epsilon=epsilon,
+        seed=seed,
+        num_restarts=1,         # irrelevant; we don't call solve()
+        verbose=verbose,
+        num_workers=num_workers,
+    )
+
+    # Strategy pool used as the L-BFGS-B grid-scan starting set: the 5 archetypes.
+    strategy_pool = [
+        FIREFIGHTER_PARAMS.copy(),
+        FREE_RIDER_PARAMS.copy(),
+        HERO_PARAMS.copy(),
+        COORDINATOR_PARAMS.copy(),
+        LIAR_PARAMS.copy(),
+    ]
+
+    # --- Equilibrium per-position payoffs (full MC budget) ---
+    print("Evaluating equilibrium profile at full MC budget...", flush=True)
+    eq_payoffs = solver._evaluate_team(profile)
+    eq_team = float(np.mean(eq_payoffs))
+    print(f"  team_payoff = {eq_team:.2f}")
+    for i, p in enumerate(eq_payoffs):
+        print(f"  pos {i}: {p:.2f}")
+    print()
+
+    # --- Per-position best-response search ---
+    per_position = []
+    for i in positions:
+        print(f"--- Position {i} best-response search ---", flush=True)
+        t_pos = time.time()
+        br_strategy, br_payoff = solver._best_response_for_position(
+            position=i,
+            profile=profile,
+            strategy_pool=strategy_pool,
+        )
+        elapsed_pos = time.time() - t_pos
+
+        gap = float(br_payoff) - float(eq_payoffs[i])
+        exploitable = gap > epsilon
+
+        print(
+            f"  eq_payoff={eq_payoffs[i]:.2f}  BR_payoff={br_payoff:.2f}  "
+            f"gap={gap:+.2f}  ε={epsilon}  "
+            f"{'EXPLOITABLE' if exploitable else 'safe'}  "
+            f"({elapsed_pos:.1f}s)",
+            flush=True,
+        )
+
+        per_position.append({
+            "position": i,
+            "equilibrium_payoff": float(eq_payoffs[i]),
+            "best_response_payoff": float(br_payoff),
+            "gap": gap,
+            "exploitable_flag": bool(exploitable),
+            "best_response_closest_archetype": _classify(br_strategy),
+            "best_response_genome": [float(v) for v in br_strategy],
+            "elapsed_seconds": elapsed_pos,
+        })
+
+    any_exploitable = any(r["exploitable_flag"] for r in per_position)
+
+    return {
+        "scenario": scenario_name,
+        "profile_label": _profile_label(profile),
+        "profile_genomes": [[float(v) for v in g] for g in profile],
+        "epsilon": epsilon,
+        "num_simulations": num_simulations,
+        "opt_simulations": opt_simulations,
+        "seed": seed,
+        "equilibrium_team_payoff": eq_team,
+        "equilibrium_per_position_payoffs": [float(p) for p in eq_payoffs],
+        "positions_tested": positions,
+        "per_position": per_position,
+        "any_exploitable": bool(any_exploitable),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Per-position exploitability test for heterogeneous Nash profile."
+    )
+    parser.add_argument(
+        "scenario",
+        choices=sorted(CANONICAL_PROFILES.keys()),
+        help="Scenario name (also selects the canonical profile to test).",
+    )
+    parser.add_argument(
+        "--profile-file",
+        type=Path,
+        default=None,
+        help="Override canonical profile with a JSON file (see module docstring).",
+    )
+    parser.add_argument(
+        "--positions",
+        type=int,
+        nargs="+",
+        default=[0, 1, 2, 3],
+        help="Positions to test (default: all 4).",
+    )
+    parser.add_argument("--simulations", type=int, default=1000)
+    parser.add_argument("--opt-simulations", type=int, default=300)
+    parser.add_argument("--epsilon", type=float, default=50.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num-workers", type=int, default=None)
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Smoke-test mode: equivalent to --simulations 20 --opt-simulations 10 "
+             "--positions 0. Use to verify the script wires correctly without "
+             "spending hours of compute.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: experiments/nash/heterogeneous/<scenario>/).",
+    )
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.simulations = min(args.simulations, 20)
+        args.opt_simulations = min(args.opt_simulations, 10)
+        if args.positions == [0, 1, 2, 3]:
+            args.positions = [0]
+
+    # Profile
+    if args.profile_file is not None:
+        profile = _load_profile_from_file(args.profile_file)
+    else:
+        profile = [s.copy() for s in CANONICAL_PROFILES[args.scenario]]
+
+    # Output path
+    if args.output_dir is None:
+        repo_root = Path(__file__).resolve().parents[2]
+        args.output_dir = repo_root / "experiments" / "nash" / "heterogeneous" / args.scenario
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_name = "exploitability_smoke.json" if args.smoke else "exploitability.json"
+    out_path = args.output_dir / out_name
+
+    t0 = time.time()
+    results = test_exploitability(
+        scenario_name=args.scenario,
+        profile=profile,
+        positions=args.positions,
+        num_simulations=args.simulations,
+        opt_simulations=args.opt_simulations,
+        epsilon=args.epsilon,
+        seed=args.seed,
+        num_workers=args.num_workers,
+        verbose=not args.quiet,
+    )
+    results["elapsed_seconds"] = time.time() - t0
+    results["smoke_test"] = bool(args.smoke)
+
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2)
+
+    print()
+    print("=" * 70)
+    print(f"Wrote {out_path}")
+    print(f"Total elapsed: {results['elapsed_seconds']:.1f}s")
+    print(f"any_exploitable: {results['any_exploitable']}")
+    for r in results["per_position"]:
+        flag = "EXPLOITABLE" if r["exploitable_flag"] else "safe"
+        print(f"  pos {r['position']}: gap={r['gap']:+.2f}  {flag}")
+    print("=" * 70)
+
+    # Non-zero exit if any position is exploitable, so the script can be
+    # used in CI / wrapper scripts to gate downstream work.
+    sys.exit(1 if results["any_exploitable"] else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #361 — **script-only scope; full remote run deferred**.

## Summary

Adds `experiments/scripts/test_specialist_exploitability.py`, a per-position best-response check that verifies a 4-player heterogeneous Nash profile is exploitation-robust.

For each position `i in {0,1,2,3}`:
1. Hold the other three positions fixed at the equilibrium strategy.
2. Call `HeterogeneousDoubleOracle._best_response_for_position` (5-archetype grid-scan + L-BFGS-B on the 10-d parameter vector + full-MC re-evaluation).
3. Flag as exploitable iff `gap = BR_payoff - equilibrium_payoff > epsilon`.

Two canonical profiles are hard-coded from PR #355's converged equilibria so the test is reproducible without dependency on a particular `results.json` artifact:

| Scenario | Profile | Source payoff |
|---|---|---|
| `rest_trap` | `FR \| FR \| FR \| FF` | 2984 (asymmetric NE) |
| `minimal_specialization` | `Hero \| Hero \| Hero \| Hero` | -756 (positive control; dominant symmetric NE per #355 verdict `symmetric_ne_superior`) |

A `--profile-file` flag lets a caller pass a different profile from a `compute_nash_heterogeneous.py` `results.json` entry.

Output: `experiments/nash/heterogeneous/<scenario>/exploitability.json` with per-position `{equilibrium_payoff, best_response_payoff, gap, exploitable_flag, best_response_closest_archetype}` plus an aggregate `any_exploitable` flag. Exit code is non-zero when any position is exploitable so the script can gate downstream work in CI.

## Why script-only (compute deferral)

Per `CLAUDE.md`, Nash analysis must run remotely. The full sweep is ~10 min per position x 4 positions x 2 profiles ~ **1.5h on alc-9** — would melt the local CPU and not finish in reasonable time. Issue #361's acceptance criterion *"all four `exploitable_flag` values are False at epsilon=50"* therefore requires a follow-up manual remote run:

```bash
ssh $COMPUTE_HOST_PRIMARY    # or $COMPUTE_HOST_CLUSTER
cd ~/GitHub/bucket-brigade && git fetch origin && git checkout feature/issue-361
tmux new -s exploit
uv run python experiments/scripts/test_specialist_exploitability.py rest_trap
uv run python experiments/scripts/test_specialist_exploitability.py minimal_specialization
# both should print any_exploitable: false; JSON artifacts land in
# experiments/nash/heterogeneous/{rest_trap,minimal_specialization}/exploitability.json
```

PR #355 should be merged or fetched first so the canonical profiles match the `results.json` they were extracted from — though since the profiles use exact `FREE_RIDER_PARAMS` / `FIREFIGHTER_PARAMS` / `HERO_PARAMS` archetype vectors, the script is self-contained even without #355.

## Local smoke verification

Ran on this laptop with `--smoke` flag (`--simulations 20 --opt-simulations 10 --positions 0`) for both scenarios:

- `rest_trap` smoke: completed in 13s, wrote `exploitability_smoke.json` with valid schema. Reported EXPLOITABLE with gap=+353 — meaningless at n=20 (MC noise dominates), but confirms the harness wires correctly.
- `minimal_specialization` smoke: completed in 15s, same schema verification.

The smoke artifacts were intentionally not committed.

## Test plan

- [x] `ruff check experiments/scripts/test_specialist_exploitability.py` passes
- [x] Smoke test on `rest_trap` produces valid JSON and non-zero exit on flag
- [x] Smoke test on `minimal_specialization` produces valid JSON
- [ ] Full remote run on `$COMPUTE_HOST_PRIMARY` / `$COMPUTE_HOST_CLUSTER` produces `any_exploitable: false` at epsilon=50 for both profiles (deferred — requires ~1.5h CPU)

Generated with [Claude Code](https://claude.com/claude-code)