### PR TITLE
feat(env): vectorized env wrapper (slice 2/5 of #365)

### DIFF
--- a/bucket_brigade/__init__.py
+++ b/bucket_brigade/__init__.py
@@ -5,6 +5,8 @@ Public entry points:
 - :func:`make` — Gym/Gymnasium-compatible factory keyed on a versioned
   scenario ID (e.g. ``"minimal_specialization-v1"``). See
   :mod:`bucket_brigade.envs.registry` for the version-bump policy.
+- :func:`make_vec` — synchronous vectorized factory returning a
+  :class:`~bucket_brigade.envs.vector.SyncVectorEnv` (issue #370).
 - :func:`list_envs` — list every registered frozen scenario ID.
 
 Example:
@@ -33,10 +35,12 @@ if (
     TYPE_CHECKING
 ):  # pragma: no cover - type hint only, avoid hard gym import at import time
     from .envs.gym_adapter import BucketBrigadeGymEnv
+    from .envs.vector import SyncVectorEnv
 
 
 __all__ = [
     "make",
+    "make_vec",
     "list_envs",
     "DEFAULT_NUM_AGENTS",
     "SCENARIO_VERSIONS",
@@ -92,6 +96,49 @@ def make(
     n = int(num_agents) if num_agents is not None else DEFAULT_NUM_AGENTS
     scenario = get_scenario_by_id(id, num_agents=n)
     return BucketBrigadeGymEnv(scenario=scenario, scenario_id=id)
+
+
+def make_vec(
+    id: str,
+    num_envs: int,
+    *,
+    num_agents: Optional[int] = None,
+) -> "SyncVectorEnv":
+    """Construct a synchronous vectorized Bucket Brigade env (issue #370).
+
+    Returns a :class:`bucket_brigade.envs.vector.SyncVectorEnv` wrapping
+    ``num_envs`` independent :class:`BucketBrigadeGymEnv` instances built
+    from the same versioned scenario ``id``. The vectorized env exposes
+    the Gymnasium-style batched ``step`` / ``reset`` API with auto-reset
+    semantics (terminal observations surfaced via ``info["final_observation"]``
+    / ``info["final_info"]``).
+
+    Args:
+        id: A versioned scenario ID — see :func:`make` for the contract.
+        num_envs: Number of parallel sub-envs (>= 1).
+        num_agents: Optional per-sub-env override; same caveat as
+            :func:`make` regarding reproducibility guarantees.
+
+    Returns:
+        A :class:`bucket_brigade.envs.vector.SyncVectorEnv` instance.
+
+    Raises:
+        KeyError: If ``id`` is not a registered frozen scenario ID.
+        ValueError: If ``num_envs < 1``.
+
+    Example:
+        >>> import bucket_brigade
+        >>> vec = bucket_brigade.make_vec("minimal_specialization-v1", num_envs=8)
+        >>> obs, info = vec.reset(seed=0)
+        >>> obs.shape[0]
+        8
+    """
+    # Local import for the same reason as ``make``: keep top-level import
+    # of ``bucket_brigade`` cheap and avoid a hard gymnasium dependency
+    # until the user actually constructs an env.
+    from .envs.vector import make_vec as _make_vec
+
+    return _make_vec(id, num_envs, num_agents=num_agents)
 
 
 def list_envs() -> List[str]:

--- a/bucket_brigade/envs/vector.py
+++ b/bucket_brigade/envs/vector.py
@@ -1,0 +1,389 @@
+"""Synchronous vectorized env wrapper for Bucket Brigade (issue #370).
+
+This module exposes :class:`SyncVectorEnv` and the public factory
+:func:`make_vec`, providing a Gymnasium-compatible vectorized view over
+:class:`~bucket_brigade.envs.gym_adapter.BucketBrigadeGymEnv`.
+
+Design choices
+--------------
+
+- **Sync / in-process only.** No multiprocessing, no asyncio. Bucket
+  Brigade dynamics are cheap (pure-Python with optional Rust acceleration
+  in the underlying env) so the per-step cross-process IPC overhead would
+  dominate. A subprocess backend is a follow-up if benchmark numbers
+  demand it (see issue #365 parent epic).
+- **Gymnasium auto-reset convention.** When a sub-env reports
+  ``terminated`` or ``truncated``, this wrapper resets that sub-env
+  in-place and surfaces the **terminal** observation/info under the
+  ``final_observation`` / ``final_info`` keys of the batched ``info``
+  dict, while the batched ``observations`` slot for that sub-env is
+  the **post-reset** observation. This matches
+  :class:`gymnasium.vector.SyncVectorEnv` exactly so SB3 / CleanRL
+  consumers can swap in without code changes.
+- **Per-sub-env seed plumbing.** ``reset(seed=base)`` seeds sub-env ``i``
+  with ``base + i`` so each lane gets a distinct deterministic stream
+  while preserving reproducibility across constructions. Passing a list
+  of seeds is also supported (one seed per sub-env).
+- **Single shared scenario, num_envs independent envs.** Each sub-env
+  is constructed via :func:`bucket_brigade.make` with the same ``id`` and
+  ``num_agents`` kwargs, so they share the frozen scenario contract but
+  hold independent state. The auto-reset semantics rely on this — each
+  sub-env is fully isolated.
+
+See :func:`make_vec` for the public entry point.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from gymnasium import spaces
+
+from .gym_adapter import BucketBrigadeGymEnv
+
+
+__all__ = ["SyncVectorEnv", "make_vec"]
+
+
+# A seed argument to ``reset()`` can be either a single ``int`` (we expand
+# to ``[seed, seed+1, ..., seed+num_envs-1]`` so each lane is distinct) or
+# an explicit per-sub-env sequence. ``None`` means "don't re-seed".
+_SeedArg = Optional[Union[int, Sequence[Optional[int]]]]
+
+
+class SyncVectorEnv:
+    """Synchronous vectorized wrapper over N independent Bucket Brigade envs.
+
+    The API matches :class:`gymnasium.vector.SyncVectorEnv`:
+
+    - :meth:`reset` returns ``(obs, info)`` where ``obs`` is a stacked
+      ``(num_envs, *obs_shape)`` ndarray and ``info`` is a dict of
+      batched / list-valued sub-env info entries.
+    - :meth:`step` returns ``(obs, rewards, terminated, truncated, info)``
+      with batched ndarray fields plus a Gymnasium-convention info dict.
+      Sub-envs that report done are auto-reset in-place; their terminal
+      observation and info are surfaced under ``info["final_observation"]``
+      and ``info["final_info"]``.
+
+    The wrapper is **synchronous** — every ``step()`` call iterates over
+    sub-envs in order in the current process. This is the cheapest backend
+    and is sufficient for the workloads in this repo (CPU-bound dynamics,
+    small per-step cost). A multiprocessing backend may be added later if
+    PPO rollout throughput becomes a bottleneck.
+
+    Attributes:
+        num_envs: Number of sub-envs.
+        envs: List of underlying :class:`BucketBrigadeGymEnv` instances.
+        single_observation_space: ``Box`` matching a single sub-env's
+            observation_space (NOT batched).
+        single_action_space: ``MultiDiscrete`` matching a single sub-env's
+            action_space (NOT batched).
+        observation_space: Batched ``Box`` of shape
+            ``(num_envs, *single_observation_space.shape)``.
+        action_space: Batched ``MultiDiscrete`` of shape
+            ``(num_envs, *single_action_space.shape)``.
+        metadata: Forwarded from the first sub-env.
+
+    Example:
+        >>> import bucket_brigade
+        >>> vec = bucket_brigade.make_vec("minimal_specialization-v1", num_envs=8)
+        >>> obs, info = vec.reset(seed=0)
+        >>> obs.shape[0] == 8
+        True
+        >>> actions = vec.action_space.sample()
+        >>> obs, rewards, terminated, truncated, info = vec.step(actions)
+        >>> rewards.shape
+        (8,)
+    """
+
+    def __init__(self, envs: Sequence[BucketBrigadeGymEnv]) -> None:
+        if len(envs) == 0:
+            raise ValueError("SyncVectorEnv requires at least one sub-env.")
+        self.envs: List[BucketBrigadeGymEnv] = list(envs)
+        self.num_envs: int = len(self.envs)
+
+        # Sanity: every sub-env must share the same observation/action
+        # space shape. Different shapes would break the batched ndarray
+        # contract.
+        e0 = self.envs[0]
+        self.single_observation_space: spaces.Box = e0.observation_space
+        self.single_action_space: spaces.MultiDiscrete = e0.action_space
+        for i, e in enumerate(self.envs[1:], start=1):
+            if e.observation_space.shape != self.single_observation_space.shape:
+                raise ValueError(
+                    f"Sub-env {i} observation_space.shape "
+                    f"{e.observation_space.shape} != "
+                    f"{self.single_observation_space.shape}"
+                )
+            if not np.array_equal(
+                np.asarray(e.action_space.nvec),
+                np.asarray(self.single_action_space.nvec),
+            ):
+                raise ValueError(
+                    f"Sub-env {i} action_space.nvec disagrees with sub-env 0."
+                )
+
+        # Batched spaces. Gymnasium represents these as Box / MultiDiscrete
+        # with a leading num_envs axis. We mirror that convention so
+        # ``self.action_space.sample()`` returns a ``(num_envs, *action_shape)``
+        # batched action ready for ``step()``.
+        obs_shape = (self.num_envs,) + tuple(self.single_observation_space.shape)
+        self.observation_space = spaces.Box(
+            low=float(self.single_observation_space.low.min()),
+            high=float(self.single_observation_space.high.max()),
+            shape=obs_shape,
+            dtype=self.single_observation_space.dtype,
+        )
+        # Tile MultiDiscrete nvec across the leading num_envs axis. This
+        # yields the same per-position bounds for every lane.
+        per_lane_nvec = np.asarray(self.single_action_space.nvec, dtype=np.int64)
+        batched_nvec = np.tile(per_lane_nvec, (self.num_envs, 1))
+        self.action_space = spaces.MultiDiscrete(batched_nvec)
+
+        # Forward metadata from sub-env 0 (typically carries ``scenario_id``).
+        self.metadata: Dict[str, Any] = dict(e0.metadata)
+        self.metadata["num_envs"] = self.num_envs
+
+        # Whether reset() has been called — Gymnasium convention is to
+        # require it before the first step().
+        self._reset_called: bool = False
+
+    # ------------------------------------------------------------------
+    # Gymnasium VectorEnv API
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        *,
+        seed: _SeedArg = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+        """Reset every sub-env and return a batched ``(obs, info)``.
+
+        Args:
+            seed: Either ``None`` (no re-seed), a single ``int`` (sub-env
+                ``i`` is seeded with ``seed + i``), or a sequence of
+                ``num_envs`` ints / ``None`` values (one per sub-env).
+            options: Forwarded verbatim to each sub-env. Currently unused
+                by :class:`BucketBrigadeGymEnv`.
+
+        Returns:
+            Tuple ``(obs, info)``:
+
+            - ``obs`` is a ``(num_envs, *single_obs_shape)`` ndarray
+              matching ``self.observation_space.dtype``.
+            - ``info`` is a dict whose values are length-``num_envs``
+              lists (one entry per sub-env) — this matches Gymnasium's
+              "list-of-info" convention for the sync backend.
+        """
+        seeds = self._expand_seeds(seed)
+
+        obs_list: List[np.ndarray] = []
+        infos: List[Dict[str, Any]] = []
+        for env, s in zip(self.envs, seeds):
+            o, info = env.reset(seed=s, options=options)
+            obs_list.append(o)
+            infos.append(info)
+
+        self._reset_called = True
+        return self._stack_obs(obs_list), self._batch_info(infos)
+
+    def step(
+        self, actions: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Dict[str, Any]]:
+        """Step every sub-env with one row of ``actions`` each.
+
+        Args:
+            actions: A ``(num_envs, *single_action_shape)`` ndarray. Each
+                row is forwarded to the corresponding sub-env's
+                ``step()``. The flat ``(num_envs * action_dim,)`` shape
+                is also accepted and auto-reshaped for caller convenience.
+
+        Returns:
+            Tuple ``(obs, rewards, terminated, truncated, info)``:
+
+            - ``obs`` is a ``(num_envs, *obs_shape)`` ndarray. For
+              sub-envs that hit done, the row is the **post-reset**
+              observation; the **terminal** observation appears under
+              ``info["final_observation"][i]``.
+            - ``rewards`` is a ``(num_envs,)`` float32 ndarray.
+            - ``terminated`` is a ``(num_envs,)`` bool ndarray reflecting
+              the pre-auto-reset done flags.
+            - ``truncated`` is a ``(num_envs,)`` bool ndarray (always
+              all-False under the current Bucket Brigade dynamics, but
+              we surface the field for forward compatibility).
+            - ``info`` is a dict of list-of-sub-env-info values plus the
+              Gymnasium auto-reset bookkeeping keys
+              ``"final_observation"`` (list, ``None`` for non-done lanes)
+              and ``"final_info"`` (list, ``None`` for non-done lanes).
+        """
+        if not self._reset_called:
+            raise RuntimeError(
+                "SyncVectorEnv.step() called before reset(). Call reset() "
+                "before the first step()."
+            )
+
+        actions = np.asarray(actions)
+        # Accept flat ``(num_envs * D,)`` for convenience (mirrors the
+        # single-env adapter's reshape path).
+        single_action_size = int(np.prod(self.single_action_space.shape))
+        if actions.ndim == 1 and actions.size == self.num_envs * single_action_size:
+            actions = actions.reshape(self.num_envs, *self.single_action_space.shape)
+
+        if actions.shape[0] != self.num_envs:
+            raise ValueError(
+                f"actions has leading dim {actions.shape[0]}, expected "
+                f"num_envs={self.num_envs}"
+            )
+
+        obs_list: List[np.ndarray] = []
+        rewards = np.zeros(self.num_envs, dtype=np.float32)
+        terminated = np.zeros(self.num_envs, dtype=bool)
+        truncated = np.zeros(self.num_envs, dtype=bool)
+        infos: List[Dict[str, Any]] = []
+        # Per-Gymnasium convention: for non-done lanes these entries are
+        # ``None`` so callers can ``zip``-iterate safely.
+        final_observations: List[Optional[np.ndarray]] = [None] * self.num_envs
+        final_infos: List[Optional[Dict[str, Any]]] = [None] * self.num_envs
+
+        for i, env in enumerate(self.envs):
+            obs, reward, term, trunc, info = env.step(actions[i])
+            rewards[i] = reward
+            terminated[i] = term
+            truncated[i] = trunc
+
+            if term or trunc:
+                # Auto-reset: stash the terminal observation/info, then
+                # roll the sub-env into a fresh episode. The batched
+                # ``obs[i]`` row carries the post-reset observation,
+                # matching gymnasium.vector.SyncVectorEnv semantics.
+                final_observations[i] = obs
+                final_infos[i] = info
+                reset_obs, reset_info = env.reset()
+                obs_list.append(reset_obs)
+                infos.append(reset_info)
+            else:
+                obs_list.append(obs)
+                infos.append(info)
+
+        batched_info = self._batch_info(infos)
+        batched_info["final_observation"] = final_observations
+        batched_info["final_info"] = final_infos
+        return (
+            self._stack_obs(obs_list),
+            rewards,
+            terminated,
+            truncated,
+            batched_info,
+        )
+
+    def close(self) -> None:
+        """Close every sub-env. Safe to call multiple times."""
+        for env in self.envs:
+            env.close()
+
+    def render(self) -> None:
+        """Render is a no-op (matching the single-env adapter)."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _expand_seeds(self, seed: _SeedArg) -> List[Optional[int]]:
+        """Normalize the ``seed=`` kwarg into a length-``num_envs`` list.
+
+        - ``None`` → ``[None] * num_envs`` (no explicit re-seed).
+        - ``int`` → ``[seed, seed+1, ..., seed+num_envs-1]`` so each lane
+          gets a distinct deterministic stream.
+        - sequence → returned as-is after length validation.
+        """
+        if seed is None:
+            return [None] * self.num_envs
+        if isinstance(seed, (int, np.integer)):
+            return [int(seed) + i for i in range(self.num_envs)]
+        seeds = list(seed)
+        if len(seeds) != self.num_envs:
+            raise ValueError(
+                f"Got {len(seeds)} seeds for {self.num_envs} sub-envs; "
+                "lengths must match."
+            )
+        return seeds
+
+    def _stack_obs(self, obs_list: Sequence[np.ndarray]) -> np.ndarray:
+        """Stack sub-env observations into a single batched ndarray."""
+        return np.ascontiguousarray(
+            np.stack(obs_list, axis=0),
+            dtype=self.single_observation_space.dtype,
+        )
+
+    @staticmethod
+    def _batch_info(infos: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+        """Convert a list of per-sub-env info dicts into a dict of lists.
+
+        Matches Gymnasium's sync-vector convention: keys are the union of
+        all per-sub-env keys; values are length-``num_envs`` lists with
+        ``None`` filling slots where a given sub-env did not produce that
+        key. Callers that prefer a plain "list of dicts" can also access
+        ``info["_per_env"]`` which is exactly that.
+        """
+        keys = set()
+        for d in infos:
+            keys.update(d.keys())
+        batched: Dict[str, Any] = {
+            k: [d.get(k, None) for d in infos] for k in keys
+        }
+        # Stash the raw list-of-dicts under a private-ish key so callers
+        # that prefer that shape don't have to re-zip.
+        batched["_per_env"] = list(infos)
+        return batched
+
+
+def make_vec(
+    id: str,
+    num_envs: int,
+    *,
+    num_agents: Optional[int] = None,
+) -> SyncVectorEnv:
+    """Construct a synchronous vectorized Bucket Brigade env.
+
+    Args:
+        id: A versioned scenario ID registered in
+            :data:`bucket_brigade.envs.registry.SCENARIO_VERSIONS`
+            (e.g. ``"minimal_specialization-v1"``). Use
+            :func:`bucket_brigade.list_envs` to enumerate.
+        num_envs: Number of independent parallel sub-envs.
+        num_agents: Optional override for the number of agents in each
+            sub-env. Defaults to
+            :data:`~bucket_brigade.envs.registry.DEFAULT_NUM_AGENTS`. As
+            with :func:`bucket_brigade.make`, overriding here means the
+            env is no longer covered by the frozen ID's reproducibility
+            guarantee and downstream consumers should record the override
+            in experiment metadata.
+
+    Returns:
+        A :class:`SyncVectorEnv` wrapping ``num_envs`` independent
+        :class:`bucket_brigade.envs.gym_adapter.BucketBrigadeGymEnv`
+        instances.
+
+    Raises:
+        KeyError: If ``id`` is not a registered frozen scenario ID.
+        ValueError: If ``num_envs < 1``.
+
+    Example:
+        >>> import bucket_brigade
+        >>> vec = bucket_brigade.make_vec("minimal_specialization-v1", num_envs=4)
+        >>> obs, info = vec.reset(seed=0)
+        >>> obs.shape[0]
+        4
+    """
+    # Local import to avoid a circular ``bucket_brigade.__init__`` <->
+    # ``bucket_brigade.envs.vector`` dependency at module-import time.
+    from .. import make as _make_single
+
+    if int(num_envs) < 1:
+        raise ValueError(f"num_envs must be >= 1, got {num_envs}")
+
+    envs = [_make_single(id, num_agents=num_agents) for _ in range(int(num_envs))]
+    return SyncVectorEnv(envs)

--- a/bucket_brigade/envs/vector.py
+++ b/bucket_brigade/envs/vector.py
@@ -331,9 +331,7 @@ class SyncVectorEnv:
         keys = set()
         for d in infos:
             keys.update(d.keys())
-        batched: Dict[str, Any] = {
-            k: [d.get(k, None) for d in infos] for k in keys
-        }
+        batched: Dict[str, Any] = {k: [d.get(k, None) for d in infos] for k in keys}
         # Stash the raw list-of-dicts under a private-ish key so callers
         # that prefer that shape don't have to re-zip.
         batched["_per_env"] = list(infos)

--- a/tests/test_vector_env.py
+++ b/tests/test_vector_env.py
@@ -119,9 +119,7 @@ class TestShapes:
     def test_step_rejects_wrong_leading_dim(self):
         vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
         vec.reset(seed=0)
-        bad = np.zeros(
-            (5,) + vec.single_action_space.shape, dtype=np.int64
-        )
+        bad = np.zeros((5,) + vec.single_action_space.shape, dtype=np.int64)
         with pytest.raises(ValueError):
             vec.step(bad)
 

--- a/tests/test_vector_env.py
+++ b/tests/test_vector_env.py
@@ -1,0 +1,352 @@
+"""Tests for the synchronous vectorized env wrapper (issue #370).
+
+Covers the acceptance criteria from the issue body:
+
+1. ``make_vec(id, num_envs=N)`` returns a working VectorEnv.
+2. Auto-reset: when a sub-env terminates, the wrapper resets that lane
+   in-place and surfaces ``final_observation`` / ``final_info``.
+3. Determinism: identical seeds across two independent constructions
+   yield identical trajectories.
+
+All tests are intentionally tiny (small num_envs, short rollouts) — the
+vec wrapper is pure Python over the existing Gym adapter so there is no
+need for "heavy" coverage. See parent epic #365 for the broader release
+infrastructure context.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import bucket_brigade
+from bucket_brigade.envs.vector import SyncVectorEnv
+
+
+_PRIMARY_ID = "minimal_specialization-v1"
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """Smoke tests for the factory and the class constructor."""
+
+    def test_make_vec_returns_sync_vector_env(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        assert isinstance(vec, SyncVectorEnv)
+        assert vec.num_envs == 4
+
+    def test_make_vec_exposes_through_package(self):
+        # Acceptance from the issue body: ``bucket_brigade.make_vec`` works.
+        assert hasattr(bucket_brigade, "make_vec")
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        assert vec.num_envs == 2
+
+    def test_make_vec_rejects_zero(self):
+        with pytest.raises(ValueError):
+            bucket_brigade.make_vec(_PRIMARY_ID, num_envs=0)
+
+    def test_make_vec_rejects_negative(self):
+        with pytest.raises(ValueError):
+            bucket_brigade.make_vec(_PRIMARY_ID, num_envs=-1)
+
+    def test_unknown_id_raises(self):
+        with pytest.raises(KeyError):
+            bucket_brigade.make_vec("nope-v999", num_envs=2)
+
+    def test_metadata_carries_scenario_id_and_num_envs(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
+        assert vec.metadata.get("scenario_id") == _PRIMARY_ID
+        assert vec.metadata.get("num_envs") == 3
+
+
+# ---------------------------------------------------------------------------
+# Shape checks (Acceptance: returns batched observations/rewards)
+# ---------------------------------------------------------------------------
+
+
+class TestShapes:
+    """Verify the batched shape contract."""
+
+    @pytest.mark.parametrize("num_envs", [1, 2, 8])
+    def test_reset_obs_shape(self, num_envs):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=num_envs)
+        obs, info = vec.reset(seed=0)
+        assert obs.shape[0] == num_envs
+        assert obs.shape[1:] == vec.single_observation_space.shape
+
+    @pytest.mark.parametrize("num_envs", [1, 2, 8])
+    def test_step_returns_batched_5_tuple(self, num_envs):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=num_envs)
+        vec.reset(seed=0)
+        actions = vec.action_space.sample()
+        out = vec.step(actions)
+        assert len(out) == 5
+        obs, rewards, terminated, truncated, info = out
+        assert obs.shape[0] == num_envs
+        assert rewards.shape == (num_envs,)
+        assert terminated.shape == (num_envs,)
+        assert truncated.shape == (num_envs,)
+        assert rewards.dtype == np.float32
+        assert terminated.dtype == bool
+        assert truncated.dtype == bool
+
+    def test_reset_obs_in_observation_space_for_each_lane(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        obs, _ = vec.reset(seed=0)
+        single_space = vec.single_observation_space
+        for i in range(vec.num_envs):
+            assert single_space.contains(obs[i]), (
+                f"lane {i} reset obs not in single_observation_space"
+            )
+
+    def test_action_space_shape_matches_num_envs(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        sample = vec.action_space.sample()
+        assert sample.shape[0] == vec.num_envs
+
+    def test_step_accepts_flat_action_layout(self):
+        """A flat ``(num_envs * D,)`` action must be auto-reshaped."""
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
+        vec.reset(seed=0)
+        flat = vec.action_space.sample().reshape(-1)
+        obs, *_ = vec.step(flat)
+        assert obs.shape[0] == 3
+
+    def test_step_rejects_wrong_leading_dim(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
+        vec.reset(seed=0)
+        bad = np.zeros(
+            (5,) + vec.single_action_space.shape, dtype=np.int64
+        )
+        with pytest.raises(ValueError):
+            vec.step(bad)
+
+
+# ---------------------------------------------------------------------------
+# Determinism (Acceptance: same seeds → same trajectory)
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Same seeds + same action sequence => identical trajectories."""
+
+    def test_reset_same_seed_same_obs(self):
+        v1 = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        v2 = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        o1, _ = v1.reset(seed=42)
+        o2, _ = v2.reset(seed=42)
+        np.testing.assert_array_equal(o1, o2)
+
+    def test_trajectory_same_seed_same_actions(self):
+        """Drive both vec-envs with the same seeded RNG and assert equality."""
+        v1 = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        v2 = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=4)
+        v1.reset(seed=123)
+        v2.reset(seed=123)
+
+        # Pre-generate a fixed action sequence so we drive both vec-envs
+        # with exactly identical inputs. Using a local RNG keeps test
+        # independence from global numpy state.
+        rng = np.random.default_rng(0)
+        action_shape = (v1.num_envs,) + v1.single_action_space.shape
+        per_lane_nvec = np.asarray(v1.single_action_space.nvec)
+        action_seq = []
+        for _ in range(10):
+            a = rng.integers(low=0, high=per_lane_nvec, size=action_shape)
+            action_seq.append(a)
+
+        for a in action_seq:
+            o1, r1, t1, tr1, _ = v1.step(a)
+            o2, r2, t2, tr2, _ = v2.step(a)
+            np.testing.assert_array_equal(o1, o2)
+            np.testing.assert_array_equal(r1, r2)
+            np.testing.assert_array_equal(t1, t2)
+            np.testing.assert_array_equal(tr1, tr2)
+
+    def test_different_lanes_get_different_seeds(self):
+        """Single int seed must expand to ``[seed, seed+1, ...]`` per lane.
+
+        With a non-trivial action sequence, two lanes with distinct
+        seeds should produce distinct trajectories over a short rollout.
+        If the wrapper accidentally seeded both lanes with the same seed
+        the two columns would be identical.
+        """
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        vec.reset(seed=999)
+
+        # Drive with random but identical-across-lanes actions so any
+        # observed divergence between lane 0 and lane 1 must come from
+        # the seed plumbing, not the action signal.
+        rng = np.random.default_rng(0)
+        per_lane_nvec = np.asarray(vec.single_action_space.nvec)
+        diverged = False
+        for _ in range(20):
+            a_lane = rng.integers(low=0, high=per_lane_nvec)
+            # Broadcast the same per-lane action across all num_envs lanes.
+            a = np.tile(a_lane, (vec.num_envs, 1))
+            obs, *_ = vec.step(a)
+            if not np.array_equal(obs[0], obs[1]):
+                diverged = True
+                break
+        assert diverged, (
+            "Lanes seeded with seed=999, seed=1000 produced identical obs "
+            "across 20 steps — seed-per-lane expansion is broken."
+        )
+
+    def test_explicit_per_sub_env_seed_sequence(self):
+        """Passing a sequence of seeds (one per lane) is supported."""
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
+        obs, _ = vec.reset(seed=[1, 2, 3])
+        assert obs.shape[0] == 3
+
+    def test_seed_sequence_length_mismatch_raises(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=3)
+        with pytest.raises(ValueError):
+            vec.reset(seed=[1, 2])  # wrong length
+
+
+# ---------------------------------------------------------------------------
+# Auto-reset (Acceptance: auto-reset on episode end with final_observation)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReset:
+    """When a sub-env reports done, the wrapper resets it in-place and
+    surfaces the terminal obs/info under ``final_observation`` /
+    ``final_info`` per the Gymnasium convention."""
+
+    def test_step_before_reset_raises(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        with pytest.raises(RuntimeError):
+            vec.step(vec.action_space.sample())
+
+    def test_info_contains_final_observation_keys(self):
+        """After a single step, ``final_observation`` / ``final_info``
+        keys must exist regardless of whether any lane terminated.
+        """
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        vec.reset(seed=0)
+        _, _, _, _, info = vec.step(vec.action_space.sample())
+        assert "final_observation" in info
+        assert "final_info" in info
+        assert len(info["final_observation"]) == vec.num_envs
+        assert len(info["final_info"]) == vec.num_envs
+
+    def test_auto_reset_surfaces_terminal_obs_and_resets_lane(self):
+        """Roll a forced episode to termination; verify the auto-reset
+        bookkeeping is correct.
+
+        We drive every sub-env with the same action sequence so they all
+        terminate on the same step (the dynamics are deterministic given
+        the seed). When termination fires:
+
+        - ``terminated[i]`` is True for the lane that terminated,
+        - ``info["final_observation"][i]`` carries the **pre-reset**
+          observation (the lane's actual terminal obs),
+        - ``info["final_info"][i]`` carries the lane's terminal info,
+        - the batched ``obs[i]`` is the **post-reset** observation,
+          which must equal what a fresh ``reset()`` of that sub-env
+          would produce.
+        """
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        vec.reset(seed=0)
+
+        # Drive a long enough rollout that termination is guaranteed.
+        # Use random actions for variety; the env terminates by dynamics
+        # (all fires out or all houses ruined past min_nights).
+        rng = np.random.default_rng(0)
+        per_lane_nvec = np.asarray(vec.single_action_space.nvec)
+        action_shape = (vec.num_envs,) + vec.single_action_space.shape
+
+        saw_termination = False
+        max_steps = 500
+        for _ in range(max_steps):
+            a = rng.integers(low=0, high=per_lane_nvec, size=action_shape)
+            obs, rewards, terminated, truncated, info = vec.step(a)
+            done_mask = terminated | truncated
+            if not done_mask.any():
+                # Sanity: non-done lanes have ``None`` finals.
+                for i in range(vec.num_envs):
+                    if not done_mask[i]:
+                        assert info["final_observation"][i] is None
+                        assert info["final_info"][i] is None
+                continue
+
+            saw_termination = True
+            for i in range(vec.num_envs):
+                if done_mask[i]:
+                    # Terminal observation / info MUST be surfaced.
+                    final_obs = info["final_observation"][i]
+                    final_info = info["final_info"][i]
+                    assert final_obs is not None, (
+                        f"lane {i} terminated but final_observation is None"
+                    )
+                    assert final_info is not None, (
+                        f"lane {i} terminated but final_info is None"
+                    )
+                    assert final_obs.shape == vec.single_observation_space.shape
+                    # And the batched ``obs[i]`` row is the post-reset
+                    # observation, which must lie in the observation
+                    # space (not e.g. an all-zeros sentinel).
+                    assert vec.single_observation_space.contains(obs[i])
+                else:
+                    assert info["final_observation"][i] is None
+                    assert info["final_info"][i] is None
+            break
+
+        assert saw_termination, (
+            f"No termination observed in {max_steps} steps — either "
+            f"the env never terminates or the wrapper is consuming the "
+            f"done signal."
+        )
+
+    def test_auto_reset_obs_matches_fresh_reset(self):
+        """The post-auto-reset obs in a terminated lane must equal the
+        obs from a brand-new env reset with the same (advanced) RNG.
+
+        We can't easily reach into the underlying env's RNG, so the
+        weaker but still useful check: the post-reset obs is in the
+        observation_space AND running the same action again from the
+        post-reset state produces another valid obs (i.e. the lane is
+        usable, not a half-broken sentinel).
+        """
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=1)
+        vec.reset(seed=0)
+        rng = np.random.default_rng(0)
+        per_lane_nvec = np.asarray(vec.single_action_space.nvec)
+
+        for _ in range(500):
+            a = rng.integers(
+                low=0, high=per_lane_nvec, size=(1,) + vec.single_action_space.shape
+            )
+            obs, _, terminated, truncated, info = vec.step(a)
+            if (terminated | truncated).any():
+                # Post-reset lane must be live: another step succeeds and
+                # produces a valid obs.
+                a2 = rng.integers(
+                    low=0,
+                    high=per_lane_nvec,
+                    size=(1,) + vec.single_action_space.shape,
+                )
+                obs2, *_ = vec.step(a2)
+                assert vec.single_observation_space.contains(obs2[0])
+                return
+
+        pytest.fail("Episode did not terminate within 500 steps.")
+
+
+# ---------------------------------------------------------------------------
+# Close
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    def test_close_is_safe(self):
+        vec = bucket_brigade.make_vec(_PRIMARY_ID, num_envs=2)
+        vec.reset(seed=0)
+        vec.close()  # Must not raise.
+        vec.close()  # Idempotent.


### PR DESCRIPTION
Closes #370

## Summary

Adds `bucket_brigade.make_vec(id, num_envs)` returning a `SyncVectorEnv` — a synchronous in-process vectorized wrapper around N independent `BucketBrigadeGymEnv` instances. Matches the Gymnasium `SyncVectorEnv` API so SB3 / CleanRL / Tianshou consumers can swap in without code changes.

This is slice 2/5 of the M4 release infrastructure epic (#365). Slice 1 (#369) landed the `make()` adapter + versioned scenario registry that this PR builds on.

## What's in scope

- `bucket_brigade/envs/vector.py` — `SyncVectorEnv` class + `make_vec` factory.
- `bucket_brigade/__init__.py` — re-export of `make_vec` as the top-level public entry point.
- `tests/test_vector_env.py` — 26 test cases covering construction, shape contract, determinism, and auto-reset.

## API highlights

- Batched `(num_envs, *single_obs_shape)` observations, `(num_envs,)` rewards / terminated / truncated.
- Per-Gymnasium auto-reset: when a sub-env terminates or truncates, its lane is reset in-place and the terminal observation/info are surfaced under `info["final_observation"][i]` / `info["final_info"][i]`. Non-done lanes get `None` in those slots so callers can `zip`-iterate safely.
- Seed-per-lane expansion: `reset(seed=N)` seeds sub-env `i` with `N + i` so each lane gets a distinct deterministic stream. Per-lane seed sequences `reset(seed=[a, b, c])` are also accepted.
- Tiled `MultiDiscrete` action_space (shape `(num_envs, *single_action_shape)`) so `vec.action_space.sample()` returns a ready-to-use batched action.

## Out of scope (documented as follow-ups)

- Asyncio / multiprocessing backend — env dynamics are cheap so per-step IPC overhead would dominate; sync backend is the right default for the workloads in this repo. File a follow-up if PPO rollout throughput becomes a bottleneck.
- Replacing the existing training-time vectorization in `bucket_brigade/training/` — left for a separate slice.

## Test plan

- [x] `uv run pytest tests/test_vector_env.py -v` — 26 passed (construction, shapes, determinism, auto-reset, close).
- [x] `uv run pytest tests/test_env_registry.py -v` — 58 passed (slice-1 regression check).
- [x] `uv run ruff check bucket_brigade/envs/vector.py bucket_brigade/__init__.py tests/test_vector_env.py` — clean.

## Acceptance criteria (from issue body)

- [x] `make_vec('minimal_specialization-v1', num_envs=8)` returns a working VectorEnv.
- [x] Auto-reset verified by test (`test_auto_reset_surfaces_terminal_obs_and_resets_lane`, `test_auto_reset_obs_matches_fresh_reset`).
- [x] Determinism: same seeds → same trajectory across runs (`test_trajectory_same_seed_same_actions`).