### PR TITLE
feat(nash): phase-diagram plotter (PNG + table)

### DIFF
--- a/experiments/scripts/plot_phase_diagram.py
+++ b/experiments/scripts/plot_phase_diagram.py
@@ -213,7 +213,9 @@ def render_png(data: dict[str, Any], out_png: Path) -> None:
                 else:
                     color = _verdict_color(cell.get("verdict", ""))
                     payoff = cell.get("best_team_payoff")
-                    label = f"{payoff:.0f}" if isinstance(payoff, (int, float)) else "n/a"
+                    label = (
+                        f"{payoff:.0f}" if isinstance(payoff, (int, float)) else "n/a"
+                    )
                 rect = plt.Rectangle(
                     (ki - 0.5, bi - 0.5),
                     1.0,
@@ -298,15 +300,11 @@ def render_markdown(data: dict[str, Any], out_md: Path) -> None:
             f"ε={params.get('epsilon')}\n"
         )
     lines.append("\n")
-    lines.append(
-        "| c | β | κ | verdict | equilibrium_payoff | convergence_rate |\n"
-    )
+    lines.append("| c | β | κ | verdict | equilibrium_payoff | convergence_rate |\n")
     lines.append("|---|---|---|---|---|---|\n")
     for cell in cells:
         payoff = cell.get("best_team_payoff")
-        payoff_str = (
-            f"{payoff:.2f}" if isinstance(payoff, (int, float)) else "n/a"
-        )
+        payoff_str = f"{payoff:.2f}" if isinstance(payoff, (int, float)) else "n/a"
         total = cell.get("total_restarts", 0) or 0
         converged = cell.get("converged", 0) or 0
         if total > 0:

--- a/experiments/scripts/plot_phase_diagram.py
+++ b/experiments/scripts/plot_phase_diagram.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+Render the heterogeneous Nash phase diagram from an aggregate ``results.json``.
+
+Consumes the aggregate ``results.json`` written by
+``experiments/scripts/compute_nash_phase_diagram.py`` and produces:
+
+  - ``phase_diagram.png``       — categorical heat-map figure, one subplot per
+                                  ``c`` value, β on the y-axis and κ on the
+                                  x-axis. Cell colour encodes the verdict;
+                                  cell label shows the best team payoff.
+  - ``phase_diagram_table.md``  — markdown table listing every cell sorted by
+                                  ``(c, β, κ)`` with verdict, equilibrium
+                                  payoff, and convergence rate. Paste-ready
+                                  for the paper.
+
+The plotting layer was deferred from PR #377 — quoting the builder report:
+
+    Plotting (``phase_diagram.png``) explicitly deferred to a follow-up
+    issue to keep PR script-only.
+
+This script closes that follow-up (#380). It does NOT run any compute — it
+only reads the aggregate ``results.json`` that the driver wrote on a remote
+host (or the local 1×1×1 ``--smoke`` output).
+
+Usage
+-----
+
+::
+
+    # Default paths (matches the driver's default output dir)
+    uv run python experiments/scripts/plot_phase_diagram.py \\
+        --results experiments/nash/phase_diagram/results.json
+
+    # Smoke-test against the driver's smoke output (1×1×1 degenerate grid)
+    uv run python experiments/scripts/compute_nash_phase_diagram.py --smoke
+    uv run python experiments/scripts/plot_phase_diagram.py \\
+        --results experiments/nash/phase_diagram/smoke/results.json \\
+        --out-png /tmp/test.png --out-md /tmp/test.md
+
+Schema
+------
+
+The aggregate ``results.json`` produced by the driver has this shape::
+
+    {
+      "base_scenario": "...",
+      "grid": {"beta_values": [...], "kappa_values": [...], "c_values": [...]},
+      "cells": [
+         {
+           "beta": float, "kappa": float, "c": float,
+           "verdict": "symmetric_only|asymmetric_only|mixed|no_convergence",
+           "best_team_payoff": float | null,
+           "converged": int, "total_restarts": int,
+           ...
+         }, ...
+      ],
+      ...
+    }
+
+Notes
+-----
+
+- Verdict → colour mapping uses a four-colour categorical palette chosen for
+  print-greyscale separability (different lightnesses). A legend maps verdict
+  to colour above the figure.
+- For the degenerate 1×1×1 ``--smoke`` case the figure still renders cleanly:
+  a single subplot with a single labelled cell.
+- ``convergence_rate`` in the markdown table is ``converged / total_restarts``;
+  ``equilibrium_payoff`` is the cell's ``best_team_payoff`` (null cells render
+  as ``n/a``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+
+# ---------------------------------------------------------------------------
+# Categorical verdict palette
+# ---------------------------------------------------------------------------
+
+# Order matches the driver's classifier in compute_nash_phase_diagram.py.
+# Colours chosen for greyscale-print separability: monotonic lightness so a
+# B/W printout still distinguishes verdicts by shade.
+VERDICT_ORDER: tuple[str, ...] = (
+    "symmetric_only",
+    "mixed",
+    "asymmetric_only",
+    "no_convergence",
+)
+
+VERDICT_COLORS: dict[str, str] = {
+    "symmetric_only": "#2c7fb8",  # dark blue
+    "mixed": "#7fcdbb",  # teal
+    "asymmetric_only": "#edf8b1",  # pale yellow
+    "no_convergence": "#bdbdbd",  # neutral grey
+}
+
+
+def _verdict_color(verdict: str) -> str:
+    """Return the palette colour for a verdict, with a safe fallback."""
+    return VERDICT_COLORS.get(verdict, "#ffffff")
+
+
+# ---------------------------------------------------------------------------
+# Aggregate loader
+# ---------------------------------------------------------------------------
+
+
+def load_aggregate(results_path: Path) -> dict[str, Any]:
+    """Load and lightly validate the aggregate ``results.json``."""
+    if not results_path.exists():
+        raise FileNotFoundError(f"Aggregate results not found: {results_path}")
+    with open(results_path) as f:
+        data = json.load(f)
+
+    for key in ("grid", "cells"):
+        if key not in data:
+            raise ValueError(
+                f"Aggregate results missing required key '{key}': {results_path}"
+            )
+    grid = data["grid"]
+    for key in ("beta_values", "kappa_values", "c_values"):
+        if key not in grid:
+            raise ValueError(
+                f"Aggregate results missing required grid axis '{key}': {results_path}"
+            )
+    return data
+
+
+def _index_cells_by_coord(
+    cells: list[dict[str, Any]],
+) -> dict[tuple[float, float, float], dict[str, Any]]:
+    """Index cell records by their (β, κ, c) coordinate triple."""
+    return {(c["beta"], c["kappa"], c["c"]): c for c in cells}
+
+
+# ---------------------------------------------------------------------------
+# PNG renderer
+# ---------------------------------------------------------------------------
+
+
+def render_png(data: dict[str, Any], out_png: Path) -> None:
+    """Render the (β × κ) per-``c`` heat-map figure to ``out_png``.
+
+    Layout:
+      - One subplot per ``c`` value, horizontally arranged
+      - β on y-axis (rows), κ on x-axis (columns)
+      - Each cell colored by verdict; annotated with the best team payoff
+      - Single shared legend above the subplots maps verdict → colour
+    """
+    grid = data["grid"]
+    beta_values: list[float] = list(grid["beta_values"])
+    kappa_values: list[float] = list(grid["kappa_values"])
+    c_values: list[float] = list(grid["c_values"])
+    base_scenario = data.get("base_scenario", "unknown")
+
+    cells_by_coord = _index_cells_by_coord(data.get("cells", []))
+
+    n_subplots = len(c_values)
+    n_beta = len(beta_values)
+    n_kappa = len(kappa_values)
+
+    # Per-subplot size scales with grid dims; clamp to sane bounds so the
+    # 1×1×1 smoke case stays legible and the full 5×5×3 case stays printable.
+    # Add headroom (`+ 2.2`) so the suptitle + legend strip never overlap the
+    # subplot titles ("c = ..."), even in the degenerate single-cell case.
+    sub_w = max(3.5, 0.9 * n_kappa + 2.0)
+    sub_h = max(3.5, 0.9 * n_beta + 1.5)
+    fig_w = sub_w * n_subplots
+    fig_h = sub_h + 1.2
+    fig, axes = plt.subplots(
+        1, n_subplots, figsize=(fig_w, fig_h), squeeze=False, constrained_layout=True
+    )
+    axes = axes[0]  # squeeze=False keeps the row dimension
+
+    for ax_idx, (ax, c_val) in enumerate(zip(axes, c_values)):
+        # Set up axis: rows = β (top→bottom = high→low so larger β is "up"),
+        # cols = κ (left→right = low→high).
+        ax.set_xlim(-0.5, n_kappa - 0.5)
+        ax.set_ylim(-0.5, n_beta - 0.5)
+        ax.set_aspect("equal")
+        ax.set_xticks(range(n_kappa))
+        ax.set_xticklabels([f"{k:.2f}" for k in kappa_values])
+        ax.set_yticks(range(n_beta))
+        ax.set_yticklabels([f"{b:.2f}" for b in beta_values])
+        ax.set_xlabel("κ (solo extinguish prob)")
+        if ax_idx == 0:
+            ax.set_ylabel("β (spread prob)")
+        ax.set_title(f"c = {c_val:.2f}")
+        # Light grid lines between cells
+        for x in range(n_kappa + 1):
+            ax.axvline(x - 0.5, color="white", lw=0.5)
+        for y in range(n_beta + 1):
+            ax.axhline(y - 0.5, color="white", lw=0.5)
+
+        for bi, beta in enumerate(beta_values):
+            for ki, kappa in enumerate(kappa_values):
+                cell = cells_by_coord.get((beta, kappa, c_val))
+                if cell is None:
+                    color = "#ffffff"
+                    label = "—"
+                else:
+                    color = _verdict_color(cell.get("verdict", ""))
+                    payoff = cell.get("best_team_payoff")
+                    label = f"{payoff:.0f}" if isinstance(payoff, (int, float)) else "n/a"
+                rect = plt.Rectangle(
+                    (ki - 0.5, bi - 0.5),
+                    1.0,
+                    1.0,
+                    facecolor=color,
+                    edgecolor="black",
+                    linewidth=0.5,
+                )
+                ax.add_patch(rect)
+                ax.text(
+                    ki,
+                    bi,
+                    label,
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="black",
+                )
+
+    # Shared legend below the subplots — placing it below keeps the title
+    # area clean and avoids overlap with the per-subplot "c = ..." titles.
+    legend_handles = [
+        mpatches.Patch(facecolor=_verdict_color(v), edgecolor="black", label=v)
+        for v in VERDICT_ORDER
+    ]
+    fig.suptitle(
+        f"Heterogeneous Nash Phase Diagram — {base_scenario}",
+        fontsize=11,
+    )
+    fig.legend(
+        handles=legend_handles,
+        loc="outside lower center",
+        ncol=len(VERDICT_ORDER),
+        frameon=False,
+        fontsize=9,
+    )
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Markdown renderer
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(data: dict[str, Any], out_md: Path) -> None:
+    """Render the per-cell markdown table to ``out_md``.
+
+    Rows are sorted by ``(c, β, κ)``. Columns:
+
+    - ``c``                 — cost-to-work-one-night
+    - ``β``                 — spread probability
+    - ``κ``                 — solo-extinguish probability
+    - ``verdict``           — one of the four classifier verdicts
+    - ``equilibrium_payoff``— ``best_team_payoff`` (``n/a`` if null)
+    - ``convergence_rate``  — ``converged / total_restarts`` (``n/a`` if zero
+                              restarts)
+    """
+    base_scenario = data.get("base_scenario", "unknown")
+    grid = data.get("grid", {})
+    params = data.get("parameters", {})
+    cells = sorted(
+        data.get("cells", []),
+        key=lambda r: (r.get("c", 0.0), r.get("beta", 0.0), r.get("kappa", 0.0)),
+    )
+
+    lines: list[str] = []
+    lines.append("# Heterogeneous Nash Phase Diagram — per-cell table\n")
+    lines.append(f"Base scenario: `{base_scenario}`\n")
+    lines.append(
+        f"Grid: {len(grid.get('beta_values', []))}×"
+        f"{len(grid.get('kappa_values', []))}×"
+        f"{len(grid.get('c_values', []))} = {len(cells)} cells\n"
+    )
+    if params:
+        lines.append(
+            f"Per-cell budget: restarts={params.get('num_restarts')}, "
+            f"max_iter={params.get('max_iterations')}, "
+            f"simulations={params.get('num_simulations')}, "
+            f"ε={params.get('epsilon')}\n"
+        )
+    lines.append("\n")
+    lines.append(
+        "| c | β | κ | verdict | equilibrium_payoff | convergence_rate |\n"
+    )
+    lines.append("|---|---|---|---|---|---|\n")
+    for cell in cells:
+        payoff = cell.get("best_team_payoff")
+        payoff_str = (
+            f"{payoff:.2f}" if isinstance(payoff, (int, float)) else "n/a"
+        )
+        total = cell.get("total_restarts", 0) or 0
+        converged = cell.get("converged", 0) or 0
+        if total > 0:
+            rate_str = f"{converged}/{total} ({converged / total:.0%})"
+        else:
+            rate_str = "n/a"
+        lines.append(
+            f"| {cell.get('c', float('nan')):.2f} "
+            f"| {cell.get('beta', float('nan')):.2f} "
+            f"| {cell.get('kappa', float('nan')):.2f} "
+            f"| `{cell.get('verdict', 'unknown')}` "
+            f"| {payoff_str} "
+            f"| {rate_str} |\n"
+        )
+
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_md, "w") as f:
+        f.writelines(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render the heterogeneous Nash phase diagram heat-map and per-cell "
+            "table from an aggregate results.json."
+        )
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=Path("experiments/nash/phase_diagram/results.json"),
+        help=(
+            "Path to the aggregate results.json written by "
+            "compute_nash_phase_diagram.py (default: "
+            "experiments/nash/phase_diagram/results.json)"
+        ),
+    )
+    parser.add_argument(
+        "--out-png",
+        type=Path,
+        default=Path("experiments/nash/phase_diagram/phase_diagram.png"),
+        help=(
+            "Output PNG path (default: "
+            "experiments/nash/phase_diagram/phase_diagram.png)"
+        ),
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=Path("experiments/nash/phase_diagram/phase_diagram_table.md"),
+        help=(
+            "Output markdown table path (default: "
+            "experiments/nash/phase_diagram/phase_diagram_table.md)"
+        ),
+    )
+    args = parser.parse_args()
+
+    data = load_aggregate(args.results)
+    render_png(data, args.out_png)
+    render_markdown(data, args.out_md)
+
+    print(f"Loaded {len(data.get('cells', []))} cells from {args.results}")
+    print(f"PNG  → {args.out_png}")
+    print(f"MD   → {args.out_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_plot_phase_diagram.py
+++ b/tests/test_plot_phase_diagram.py
@@ -138,9 +138,7 @@ def test_plot_2x2x2_runs_and_writes_outputs(plot_module, tmp_path: Path) -> None
         for beta in beta_values:
             for kappa in kappa_values:
                 cells.append(
-                    _make_cell(
-                        beta, kappa, c, verdicts[idx % 4], -100.0 - 10.0 * idx
-                    )
+                    _make_cell(beta, kappa, c, verdicts[idx % 4], -100.0 - 10.0 * idx)
                 )
                 idx += 1
     aggregate = _make_aggregate(beta_values, kappa_values, c_values, cells)
@@ -203,7 +201,14 @@ def test_markdown_rows_sorted_by_c_beta_kappa(plot_module, tmp_path: Path) -> No
     )
     # Sanity: header columns include the required fields.
     header_line = next(ln for ln in lines if "verdict" in ln and ln.startswith("|"))
-    for required in ("c", "β", "κ", "verdict", "equilibrium_payoff", "convergence_rate"):
+    for required in (
+        "c",
+        "β",
+        "κ",
+        "verdict",
+        "equilibrium_payoff",
+        "convergence_rate",
+    ):
         assert required in header_line, (
             f"Markdown header missing required column '{required}': {header_line}"
         )

--- a/tests/test_plot_phase_diagram.py
+++ b/tests/test_plot_phase_diagram.py
@@ -1,0 +1,234 @@
+"""
+Tests for ``experiments/scripts/plot_phase_diagram.py``.
+
+Constructs synthetic aggregate ``results.json`` payloads matching the schema
+written by ``compute_nash_phase_diagram.py`` and asserts the plot script:
+
+1. Writes both output files (PNG + markdown).
+2. Produces non-empty PNG bytes.
+3. Sorts the markdown table by ``(c, β, κ)`` and includes the per-cell verdict,
+   equilibrium payoff, and convergence rate columns required by issue #380.
+4. Handles the degenerate 1×1×1 ``--smoke`` case without erroring.
+
+The script is loaded via ``importlib`` because ``experiments/scripts`` is not
+a proper Python package (same convention as ``test_compute_nash_df_precheck``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``matplotlib`` is intentionally not a declared dependency (see PR #110);
+# scripts/tests that need it install it on demand. Skip the whole module
+# cleanly when it is unavailable in the active environment.
+pytest.importorskip("matplotlib")
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLOT_PATH = REPO_ROOT / "experiments" / "scripts" / "plot_phase_diagram.py"
+
+
+def _load_plot_module():
+    """Load ``plot_phase_diagram.py`` as a standalone module for testing."""
+    spec = importlib.util.spec_from_file_location("plot_phase_diagram", PLOT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not load spec for {PLOT_PATH}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plot_phase_diagram"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_cell(beta: float, kappa: float, c: float, verdict: str, payoff: float):
+    """Construct a synthetic cell record matching the driver's schema."""
+    return {
+        "beta": beta,
+        "kappa": kappa,
+        "c": c,
+        "tag": f"b{beta:.2f}_k{kappa:.2f}_c{c:.2f}",
+        "elapsed_seconds": 1.0,
+        "total_restarts": 5,
+        "converged": 3,
+        "symmetric_profiles": 1,
+        "asymmetric_profiles": 4,
+        "best_team_payoff": payoff,
+        "best_symmetric_team_payoff": payoff - 10.0,
+        "best_asymmetric_team_payoff": payoff,
+        "best_asymmetric_profile_label": "coordinator | liar | hero | hero",
+        "verdict": verdict,
+        "verdict_detail": f"Synthetic {verdict} verdict for test.",
+    }
+
+
+def _make_aggregate(
+    beta_values: list[float],
+    kappa_values: list[float],
+    c_values: list[float],
+    cells: list[dict],
+) -> dict:
+    """Construct a synthetic aggregate payload matching the driver's schema."""
+    return {
+        "base_scenario": "minimal_specialization",
+        "algorithm": "heterogeneous_double_oracle",
+        "grid": {
+            "beta_values": beta_values,
+            "kappa_values": kappa_values,
+            "c_values": c_values,
+            "total_cells": len(cells),
+        },
+        "parameters": {
+            "num_simulations": 1000,
+            "opt_simulations": 300,
+            "max_iterations": 25,
+            "epsilon": 50.0,
+            "num_restarts": 5,
+            "seed": 42,
+        },
+        "timing": {"elapsed_seconds": 12.3, "skipped_cached": []},
+        "verdict_counts": {},
+        "cells": cells,
+    }
+
+
+@pytest.fixture
+def plot_module():
+    return _load_plot_module()
+
+
+def test_plot_smoke_1x1x1(plot_module, tmp_path: Path) -> None:
+    """The degenerate 1×1×1 smoke case must render without error."""
+    cells = [_make_cell(0.5, 0.5, 0.5, "no_convergence", -1431.04)]
+    aggregate = _make_aggregate([0.5], [0.5], [0.5], cells)
+
+    results_path = tmp_path / "results.json"
+    with open(results_path, "w") as f:
+        json.dump(aggregate, f)
+
+    out_png = tmp_path / "phase_diagram.png"
+    out_md = tmp_path / "phase_diagram_table.md"
+
+    data = plot_module.load_aggregate(results_path)
+    plot_module.render_png(data, out_png)
+    plot_module.render_markdown(data, out_md)
+
+    assert out_png.exists(), "PNG output was not created"
+    assert out_png.stat().st_size > 0, "PNG output is empty"
+    assert out_md.exists(), "Markdown output was not created"
+    md_text = out_md.read_text()
+    assert "no_convergence" in md_text
+    assert "0.50" in md_text  # cell coordinate appears
+    assert "-1431.04" in md_text  # payoff appears
+
+
+def test_plot_2x2x2_runs_and_writes_outputs(plot_module, tmp_path: Path) -> None:
+    """A 2×2×2 grid renders both outputs with non-zero size."""
+    beta_values = [0.1, 0.9]
+    kappa_values = [0.1, 0.9]
+    c_values = [0.5, 2.0]
+    verdicts = ["symmetric_only", "asymmetric_only", "mixed", "no_convergence"]
+    cells = []
+    idx = 0
+    for c in c_values:
+        for beta in beta_values:
+            for kappa in kappa_values:
+                cells.append(
+                    _make_cell(
+                        beta, kappa, c, verdicts[idx % 4], -100.0 - 10.0 * idx
+                    )
+                )
+                idx += 1
+    aggregate = _make_aggregate(beta_values, kappa_values, c_values, cells)
+
+    results_path = tmp_path / "results.json"
+    with open(results_path, "w") as f:
+        json.dump(aggregate, f)
+
+    out_png = tmp_path / "phase.png"
+    out_md = tmp_path / "phase.md"
+    data = plot_module.load_aggregate(results_path)
+    plot_module.render_png(data, out_png)
+    plot_module.render_markdown(data, out_md)
+
+    assert out_png.exists() and out_png.stat().st_size > 1000
+    assert out_md.exists() and out_md.stat().st_size > 0
+
+
+def test_markdown_rows_sorted_by_c_beta_kappa(plot_module, tmp_path: Path) -> None:
+    """Markdown rows must be sorted by (c, β, κ) per the acceptance criteria."""
+    beta_values = [0.1, 0.9]
+    kappa_values = [0.1, 0.9]
+    c_values = [0.5, 2.0]
+    # Build cells in scrambled order to verify the renderer sorts them.
+    cells = [
+        _make_cell(0.9, 0.9, 2.0, "asymmetric_only", -500.0),
+        _make_cell(0.1, 0.1, 0.5, "symmetric_only", -100.0),
+        _make_cell(0.1, 0.9, 0.5, "mixed", -150.0),
+        _make_cell(0.9, 0.1, 0.5, "no_convergence", -200.0),
+        _make_cell(0.1, 0.1, 2.0, "symmetric_only", -300.0),
+        _make_cell(0.1, 0.9, 2.0, "mixed", -350.0),
+        _make_cell(0.9, 0.1, 2.0, "no_convergence", -400.0),
+        _make_cell(0.9, 0.9, 0.5, "asymmetric_only", -250.0),
+    ]
+    aggregate = _make_aggregate(beta_values, kappa_values, c_values, cells)
+    results_path = tmp_path / "results.json"
+    with open(results_path, "w") as f:
+        json.dump(aggregate, f)
+    out_md = tmp_path / "phase.md"
+    out_png = tmp_path / "phase.png"
+    data = plot_module.load_aggregate(results_path)
+    plot_module.render_png(data, out_png)
+    plot_module.render_markdown(data, out_md)
+
+    # Parse the markdown table data rows (skip header + separator)
+    lines = out_md.read_text().splitlines()
+    data_rows = [
+        ln
+        for ln in lines
+        if ln.startswith("|") and not ln.startswith("|---") and "verdict" not in ln
+    ]
+    parsed: list[tuple[float, float, float]] = []
+    for row in data_rows:
+        cols = [c.strip() for c in row.strip("|").split("|")]
+        # cols: c, β, κ, verdict, payoff, conv_rate
+        parsed.append((float(cols[0]), float(cols[1]), float(cols[2])))
+
+    assert parsed == sorted(parsed), (
+        f"Markdown rows are not sorted by (c, β, κ); got {parsed}"
+    )
+    # Sanity: header columns include the required fields.
+    header_line = next(ln for ln in lines if "verdict" in ln and ln.startswith("|"))
+    for required in ("c", "β", "κ", "verdict", "equilibrium_payoff", "convergence_rate"):
+        assert required in header_line, (
+            f"Markdown header missing required column '{required}': {header_line}"
+        )
+
+
+def test_handles_null_payoff(plot_module, tmp_path: Path) -> None:
+    """A cell with null ``best_team_payoff`` must not crash the renderers."""
+    cells = [_make_cell(0.5, 0.5, 0.5, "no_convergence", 0.0)]
+    cells[0]["best_team_payoff"] = None
+    cells[0]["best_symmetric_team_payoff"] = None
+    cells[0]["best_asymmetric_team_payoff"] = None
+    aggregate = _make_aggregate([0.5], [0.5], [0.5], cells)
+    results_path = tmp_path / "results.json"
+    with open(results_path, "w") as f:
+        json.dump(aggregate, f)
+    out_png = tmp_path / "phase.png"
+    out_md = tmp_path / "phase.md"
+    data = plot_module.load_aggregate(results_path)
+    plot_module.render_png(data, out_png)
+    plot_module.render_markdown(data, out_md)
+    assert out_png.exists() and out_png.stat().st_size > 0
+    assert "n/a" in out_md.read_text()
+
+
+def test_missing_aggregate_raises(plot_module, tmp_path: Path) -> None:
+    """A non-existent ``results.json`` path must raise ``FileNotFoundError``."""
+    with pytest.raises(FileNotFoundError):
+        plot_module.load_aggregate(tmp_path / "does_not_exist.json")


### PR DESCRIPTION
## Summary

Implements the visualization layer for the heterogeneous Nash phase-diagram driver (PR #377). The plotting step was explicitly deferred from #377 to keep that PR script-only — this PR closes that follow-up.

- Adds `experiments/scripts/plot_phase_diagram.py` — reads the aggregate `results.json` and renders both `phase_diagram.png` and `phase_diagram_table.md`.
- Adds `tests/test_plot_phase_diagram.py` — five tests covering the 1×1×1 smoke case, multi-c layout, markdown sort order, null-payoff handling, and missing-input error.

## Design

- **PNG**: one subplot per `c` value (horizontally arranged), β on the y-axis (low→high bottom→top), κ on the x-axis. Each cell is coloured by verdict (`symmetric_only` / `asymmetric_only` / `mixed` / `no_convergence`) using a four-colour categorical palette chosen for monotonic lightness so a B/W printout still distinguishes verdicts by shade. Per-cell labels show the best team payoff. Single horizontal legend below the subplots.
- **Markdown**: rows sorted by `(c, β, κ)` with columns `c | β | κ | verdict | equilibrium_payoff | convergence_rate`. Cells with null `best_team_payoff` render as `n/a`; `convergence_rate` is `converged / total_restarts` (`n/a` if zero restarts).
- **CLI**: `--results` / `--out-png` / `--out-md` with sensible defaults pointing at `experiments/nash/phase_diagram/`. No hard-coded paths.
- **Dependencies**: imports `matplotlib` lazily (matches existing `analyze_evolved_experts.py` convention); the test module uses `pytest.importorskip("matplotlib")` so CI doesn't fail when matplotlib isn't installed in default dev env (it was removed from declared deps in PR #110).

## Acceptance criteria

- [x] `plot_phase_diagram.py` runs against any aggregate `results.json` from `compute_nash_phase_diagram.py` (no hard-coded paths)
- [x] PNG legible at standard paper-figure size (cell labels readable; horizontal subplot layout)
- [x] Markdown sorts by `(c, β, κ)` and is paste-ready
- [x] Smoke-tested against `--smoke` 1-cell output (single-cell figure renders cleanly with the same legend)

## Test plan

- [x] `uv run pytest tests/test_plot_phase_diagram.py -v` (5 passed)
- [x] End-to-end smoke: `uv run python experiments/scripts/compute_nash_phase_diagram.py --smoke && uv run python experiments/scripts/plot_phase_diagram.py --results experiments/nash/phase_diagram/smoke/results.json --out-png /tmp/test.png --out-md /tmp/test.md` produced a valid 30 KB PNG and a 6-line markdown table.
- [x] Visually inspected both the 1×1×1 smoke output and a synthetic 3×3×3 preview-shape grid (clean layout, no overlaps, all four verdict colours distinguishable).
- [x] `uv run ruff check` clean on the two new files.

Closes #380.