### PR TITLE
feat(nash): per-restart checkpointing in HeterogeneousDoubleOracle

### DIFF
--- a/bucket_brigade/equilibrium/double_oracle_heterogeneous.py
+++ b/bucket_brigade/equilibrium/double_oracle_heterogeneous.py
@@ -26,8 +26,12 @@ entirely in Rust and accepts a different strategy vector per agent.
 
 from __future__ import annotations
 
+import json
+import os
+import tempfile
 import numpy as np
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 from multiprocessing import Pool, cpu_count
 from scipy.optimize import minimize
@@ -35,6 +39,13 @@ from scipy.optimize import minimize
 import bucket_brigade_core as core
 from bucket_brigade.envs.scenarios_generated import Scenario
 from bucket_brigade.equilibrium.payoff_evaluator_rust import _convert_scenario_to_rust
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint file name (constant so callers can find / clean it up)
+# ---------------------------------------------------------------------------
+
+PROGRESS_FILENAME = "restarts_progress.json"
 
 
 # ---------------------------------------------------------------------------
@@ -293,12 +304,109 @@ class HeterogeneousDoubleOracle:
         )
 
     # ------------------------------------------------------------------
+    # Checkpoint (de)serialisation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _eq_to_state(eq: HeterogeneousNashEquilibrium) -> dict:
+        """Serialise a single equilibrium result to plain JSON types."""
+        return {
+            "strategy_profile": [[float(v) for v in t] for t in eq.strategy_profile],
+            "payoffs": [float(p) for p in eq.payoffs],
+            "team_payoff": float(eq.team_payoff),
+            "iterations": int(eq.iterations),
+            "converged": bool(eq.converged),
+            "start_profile": [[float(v) for v in t] for t in eq.start_profile],
+        }
+
+    @staticmethod
+    def _eq_from_state(state: dict) -> HeterogeneousNashEquilibrium:
+        return HeterogeneousNashEquilibrium(
+            strategy_profile=[
+                np.asarray(t, dtype=float) for t in state["strategy_profile"]
+            ],
+            payoffs=[float(p) for p in state["payoffs"]],
+            team_payoff=float(state["team_payoff"]),
+            iterations=int(state["iterations"]),
+            converged=bool(state["converged"]),
+            start_profile=[np.asarray(t, dtype=float) for t in state["start_profile"]],
+        )
+
+    @staticmethod
+    def _atomic_write_json(path: Path, payload: dict) -> None:
+        """Write JSON atomically: write to temp file in same dir, then rename."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # NamedTemporaryFile in the same directory guarantees same-filesystem
+        # rename, which is atomic on POSIX.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            # Clean up the temp file if anything goes wrong before the rename.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _write_progress(
+        self,
+        progress_path: Path,
+        completed_restarts: list[int],
+        equilibria: list[HeterogeneousNashEquilibrium],
+        strategy_pool: list[np.ndarray],
+    ) -> None:
+        """Persist a per-restart checkpoint atomically."""
+        if equilibria:
+            best_idx_local = max(
+                range(len(equilibria)), key=lambda i: equilibria[i].team_payoff
+            )
+            best_so_far = {
+                "restart_idx": int(completed_restarts[best_idx_local]),
+                "team_payoff": float(equilibria[best_idx_local].team_payoff),
+                "converged": bool(equilibria[best_idx_local].converged),
+            }
+        else:
+            best_so_far = None
+
+        payload = {
+            "schema_version": 1,
+            "num_restarts_target": int(self.num_restarts),
+            "completed_restarts": [int(i) for i in completed_restarts],
+            "equilibria": [self._eq_to_state(e) for e in equilibria],
+            "strategy_pool": [[float(v) for v in s] for s in strategy_pool],
+            "best_so_far": best_so_far,
+        }
+        self._atomic_write_json(progress_path, payload)
+
+    @staticmethod
+    def _read_progress(progress_path: Path) -> Optional[dict]:
+        """Load a checkpoint, or return None if missing / unreadable."""
+        if not progress_path.exists():
+            return None
+        try:
+            with open(progress_path) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            # A corrupt or partially-written checkpoint should not crash the
+            # solver; treat it as "no checkpoint" and start fresh.
+            return None
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
     def solve(
         self,
         initial_pool: Optional[list[np.ndarray]] = None,
+        progress_dir: Optional[Path] = None,
     ) -> list[HeterogeneousNashEquilibrium]:
         """
         Find asymmetric Nash equilibria from multiple random starting profiles.
@@ -306,6 +414,18 @@ class HeterogeneousDoubleOracle:
         Returns a list of HeterogeneousNashEquilibrium objects — one per
         restart.  Converged entries are epsilon-Nash equilibria; non-converged
         entries are the best profile found within max_iterations rounds.
+
+        Parameters
+        ----------
+        initial_pool : optional list of seed strategies. Defaults to the five
+            archetype parameter vectors.
+        progress_dir : optional directory in which to write
+            ``restarts_progress.json`` after each completed restart. If the
+            file already exists in this directory, the already-completed
+            restart indices are skipped and their stored equilibria are
+            replayed verbatim into the result list. When ``None`` (the
+            default) no checkpoint file is written or read — exactly the
+            historical behaviour. See issue #388.
         """
         from bucket_brigade.agents.archetypes import (
             FIREFIGHTER_PARAMS,
@@ -315,7 +435,40 @@ class HeterogeneousDoubleOracle:
             LIAR_PARAMS,
         )
 
-        if initial_pool is None:
+        archetype_names = ["FF", "FR", "Hero", "Coord", "Liar"]
+
+        # ----- Resume from checkpoint, if requested and present -----
+        progress_path: Optional[Path] = None
+        completed_restarts: list[int] = []
+        results: list[HeterogeneousNashEquilibrium] = []
+        resumed_pool: Optional[list[np.ndarray]] = None
+
+        if progress_dir is not None:
+            progress_dir = Path(progress_dir)
+            progress_dir.mkdir(parents=True, exist_ok=True)
+            progress_path = progress_dir / PROGRESS_FILENAME
+            existing = self._read_progress(progress_path)
+            if existing is not None:
+                completed_restarts = [
+                    int(i) for i in existing.get("completed_restarts", [])
+                ]
+                results = [
+                    self._eq_from_state(s) for s in existing.get("equilibria", [])
+                ]
+                pool_state = existing.get("strategy_pool")
+                if pool_state:
+                    resumed_pool = [np.asarray(s, dtype=float) for s in pool_state]
+                if self.verbose and completed_restarts:
+                    print(
+                        f"[checkpoint] resuming from {progress_path}: "
+                        f"{len(completed_restarts)}/{self.num_restarts} restarts already complete",
+                        flush=True,
+                    )
+
+        # ----- Initial strategy pool -----
+        if resumed_pool is not None:
+            strategy_pool = resumed_pool
+        elif initial_pool is None:
             strategy_pool = [
                 FIREFIGHTER_PARAMS.copy(),
                 FREE_RIDER_PARAMS.copy(),
@@ -326,11 +479,36 @@ class HeterogeneousDoubleOracle:
         else:
             strategy_pool = [s.copy() for s in initial_pool]
 
-        archetype_names = ["FF", "FR", "Hero", "Coord", "Liar"]
+        completed_set = set(completed_restarts)
 
-        results: list[HeterogeneousNashEquilibrium] = []
+        # When checkpointing is enabled we use a deterministic per-restart
+        # seed derived from (self.seed, restart_idx) instead of the shared
+        # self._rng. This makes a resumed run produce the same equilibria as
+        # an uninterrupted run with the same progress_dir, regardless of how
+        # many restarts had completed before the interruption. When
+        # progress_dir is None we preserve the historical RNG-sharing
+        # behaviour byte-for-byte (existing tests depend on it).
+        use_deterministic_per_restart = progress_dir is not None
+        base_seed = self.seed if self.seed is not None else 0
 
         for restart_idx in range(self.num_restarts):
+            if restart_idx in completed_set:
+                if self.verbose:
+                    print(
+                        f"[checkpoint] skipping restart {restart_idx + 1}/{self.num_restarts} "
+                        f"(already complete)",
+                        flush=True,
+                    )
+                continue
+
+            if use_deterministic_per_restart:
+                # Derived seed is stable across resume; high-entropy mix so
+                # adjacent restart indices don't get correlated streams.
+                restart_seed = (
+                    base_seed * 2654435761 + restart_idx * 40503
+                ) & 0x7FFFFFFF
+                self._rng = np.random.RandomState(restart_seed)
+
             # Sample 4 strategies from the current pool (may include BRs from
             # earlier restarts — pool grows during the run)
             n_pool = len(strategy_pool)
@@ -351,6 +529,7 @@ class HeterogeneousDoubleOracle:
 
             eq = self._run_restart(initial_profile, strategy_pool, restart_idx)
             results.append(eq)
+            completed_restarts.append(restart_idx)
 
             if self.verbose:
                 status = "CONVERGED" if eq.converged else "MAX_ITER"
@@ -358,6 +537,16 @@ class HeterogeneousDoubleOracle:
                     f"  → {status} in {eq.iterations} rounds, "
                     f"team_payoff={eq.team_payoff:.1f}",
                     flush=True,
+                )
+
+            # Persist progress after each completed restart so a crash here
+            # costs at most one restart of work.
+            if progress_path is not None:
+                self._write_progress(
+                    progress_path,
+                    completed_restarts,
+                    results,
+                    strategy_pool,
                 )
 
         return results

--- a/experiments/scripts/compute_nash_phase_diagram.py
+++ b/experiments/scripts/compute_nash_phase_diagram.py
@@ -250,7 +250,11 @@ def _run_one_cell(
     )
 
     t0 = time.time()
-    equilibria = solver.solve()
+    # Pass cell_dir as the progress directory so the solver writes a
+    # per-restart checkpoint (restarts_progress.json) inside this cell's
+    # artifact dir. Resuming the script after a crash replays already-
+    # completed restarts and only runs the missing ones. See issue #388.
+    equilibria = solver.solve(progress_dir=cell_dir)
     elapsed = time.time() - t0
 
     converged = [e for e in equilibria if e.converged]

--- a/tests/test_heterogeneous_oracle_checkpoint.py
+++ b/tests/test_heterogeneous_oracle_checkpoint.py
@@ -1,0 +1,258 @@
+"""
+Tests for per-restart checkpointing in HeterogeneousDoubleOracle (issue #388).
+
+The phase-diagram driver runs the asymmetric Nash solver in cells that take
+many hours apiece; a host crash mid-cell used to lose every completed restart
+inside that cell. ``HeterogeneousDoubleOracle.solve`` now writes
+``restarts_progress.json`` after every successfully-completed restart and
+replays already-completed restarts on resume, capping the worst-case loss at
+one restart instead of one cell.
+
+These tests use the smallest possible budget compatible with the solver
+contract (no compute time on the heavy Nash workload — this is the
+``trivial_cooperation`` scenario at ~10 simulations per call).
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from bucket_brigade.envs import trivial_cooperation_scenario
+from bucket_brigade.equilibrium.double_oracle_heterogeneous import (
+    PROGRESS_FILENAME,
+    HeterogeneousDoubleOracle,
+    HeterogeneousNashEquilibrium,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_solver(seed: int = 123) -> HeterogeneousDoubleOracle:
+    """Build a tiny-budget solver suitable for unit tests (~seconds, not hours).
+
+    The verdicts produced here are not meaningful — we only care about
+    checkpoint semantics: how many restarts ran, whether the file is on disk
+    and parseable, and whether the resumed run is byte-equivalent to an
+    uninterrupted one.
+    """
+    scenario = trivial_cooperation_scenario(num_agents=4)
+    return HeterogeneousDoubleOracle(
+        scenario=scenario,
+        num_simulations=8,
+        opt_simulations=4,
+        max_iterations=1,
+        epsilon=10.0,
+        seed=seed,
+        num_restarts=4,
+        verbose=False,
+        num_workers=1,
+    )
+
+
+def _eq_signature(eq: HeterogeneousNashEquilibrium) -> tuple:
+    """Stable signature of an equilibrium result, used for equality checks."""
+    return (
+        bool(eq.converged),
+        int(eq.iterations),
+        tuple(round(float(p), 6) for p in eq.payoffs),
+        round(float(eq.team_payoff), 6),
+        tuple(tuple(round(float(v), 6) for v in t) for t in eq.strategy_profile),
+        tuple(tuple(round(float(v), 6) for v in t) for t in eq.start_profile),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointing:
+    """Per-restart checkpointing for HeterogeneousDoubleOracle.solve()."""
+
+    def test_no_progress_dir_writes_nothing(self, tmp_path):
+        """Default (no progress_dir) path is byte-identical to historical behaviour."""
+        solver = _make_solver()
+        results = solver.solve()
+        assert len(results) == 4
+        # Nothing should have been written anywhere.
+        assert not (tmp_path / PROGRESS_FILENAME).exists()
+
+    def test_progress_file_grows_per_restart(self, tmp_path):
+        """``restarts_progress.json`` exists with N entries after N restarts."""
+        solver = _make_solver()
+        results = solver.solve(progress_dir=tmp_path)
+
+        assert len(results) == 4
+        progress_path = tmp_path / PROGRESS_FILENAME
+        assert progress_path.exists()
+
+        with open(progress_path) as f:
+            payload = json.load(f)
+
+        assert payload["schema_version"] == 1
+        assert payload["num_restarts_target"] == 4
+        assert payload["completed_restarts"] == [0, 1, 2, 3]
+        assert len(payload["equilibria"]) == 4
+        # Strategy pool grows at least to the seed-pool size (5 archetypes).
+        assert len(payload["strategy_pool"]) >= 5
+        for genome in payload["strategy_pool"]:
+            assert len(genome) == 10
+            assert all(isinstance(v, float) for v in genome)
+        assert payload["best_so_far"] is not None
+        assert "restart_idx" in payload["best_so_far"]
+        assert "team_payoff" in payload["best_so_far"]
+
+    def test_resume_after_simulated_crash(self, tmp_path, monkeypatch):
+        """
+        Crash after K of N restarts; resume; verify only the missing restarts
+        run and the final result matches an uninterrupted run.
+        """
+        # ----- Phase 1: uninterrupted reference run -----
+        ref_solver = _make_solver(seed=7)
+        ref_results = ref_solver.solve(progress_dir=tmp_path / "ref")
+
+        # Sanity: reference produced the expected number of restarts.
+        assert len(ref_results) == 4
+
+        # ----- Phase 2: interrupted run -----
+        crash_dir = tmp_path / "crash"
+        crash_solver = _make_solver(seed=7)
+
+        original_run_restart = crash_solver._run_restart
+        call_count = {"n": 0}
+        K = 2  # let 2 of 4 restarts complete, then explode
+
+        def flaky_run_restart(initial_profile, strategy_pool, restart_idx):
+            if call_count["n"] >= K:
+                raise RuntimeError("simulated host crash mid-restart")
+            call_count["n"] += 1
+            return original_run_restart(initial_profile, strategy_pool, restart_idx)
+
+        monkeypatch.setattr(crash_solver, "_run_restart", flaky_run_restart)
+
+        with pytest.raises(RuntimeError, match="simulated host crash"):
+            crash_solver.solve(progress_dir=crash_dir)
+
+        # Checkpoint must have K completed restarts on disk.
+        progress_path = crash_dir / PROGRESS_FILENAME
+        assert progress_path.exists()
+        with open(progress_path) as f:
+            mid_payload = json.load(f)
+        assert mid_payload["completed_restarts"] == list(range(K))
+        assert len(mid_payload["equilibria"]) == K
+
+        # ----- Phase 3: resume on a fresh solver instance -----
+        resume_solver = _make_solver(seed=7)
+        # Record how many *new* restart calls happen post-resume.
+        resume_calls = {"n": 0}
+        original_resume_run_restart = resume_solver._run_restart
+
+        def counting_run_restart(initial_profile, strategy_pool, restart_idx):
+            resume_calls["n"] += 1
+            return original_resume_run_restart(
+                initial_profile, strategy_pool, restart_idx
+            )
+
+        monkeypatch.setattr(resume_solver, "_run_restart", counting_run_restart)
+
+        resume_results = resume_solver.solve(progress_dir=crash_dir)
+
+        # Only the missing restarts (N - K) should have actually run.
+        assert resume_calls["n"] == 4 - K
+
+        # All N restarts present in the final result list.
+        assert len(resume_results) == 4
+
+        # Final summary equals the uninterrupted reference run.
+        ref_sigs = [_eq_signature(e) for e in ref_results]
+        resume_sigs = [_eq_signature(e) for e in resume_results]
+        assert ref_sigs == resume_sigs, (
+            "Resumed run must produce the same equilibria as the uninterrupted "
+            "reference run when both use the same progress_dir and seed."
+        )
+
+        # Final checkpoint contains all N entries.
+        with open(progress_path) as f:
+            final_payload = json.load(f)
+        assert final_payload["completed_restarts"] == [0, 1, 2, 3]
+        assert len(final_payload["equilibria"]) == 4
+
+    def test_corrupt_checkpoint_starts_fresh(self, tmp_path):
+        """A garbage / truncated checkpoint must not crash the solver."""
+        progress_path = tmp_path / PROGRESS_FILENAME
+        progress_path.write_text("{ this is not valid json")
+
+        solver = _make_solver()
+        results = solver.solve(progress_dir=tmp_path)
+        assert len(results) == 4
+
+        # The corrupt file was overwritten with a real checkpoint.
+        with open(progress_path) as f:
+            payload = json.load(f)
+        assert payload["completed_restarts"] == [0, 1, 2, 3]
+
+    def test_atomic_write_no_stray_tmp_files(self, tmp_path):
+        """Successful run leaves no ``*.tmp`` siblings of the progress file."""
+        solver = _make_solver()
+        solver.solve(progress_dir=tmp_path)
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == [], f"Unexpected temp files left behind: {leftovers}"
+
+    def test_resume_when_all_complete_is_noop(self, tmp_path, monkeypatch):
+        """If every restart is already in the checkpoint, no restart re-runs."""
+        # Phase 1: complete a run.
+        solver1 = _make_solver(seed=99)
+        results1 = solver1.solve(progress_dir=tmp_path)
+        assert len(results1) == 4
+
+        # Phase 2: a fresh solver should run zero restarts.
+        solver2 = _make_solver(seed=99)
+        call_count = {"n": 0}
+        original = solver2._run_restart
+
+        def counting(*args, **kwargs):
+            call_count["n"] += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(solver2, "_run_restart", counting)
+        results2 = solver2.solve(progress_dir=tmp_path)
+
+        assert call_count["n"] == 0
+        assert len(results2) == 4
+        # The replayed equilibria match the originals.
+        assert [_eq_signature(e) for e in results1] == [
+            _eq_signature(e) for e in results2
+        ]
+
+
+class TestSerialisationHelpers:
+    """Lightweight round-trip tests for the JSON (de)serialisation helpers."""
+
+    def test_eq_state_round_trip(self):
+        eq = HeterogeneousNashEquilibrium(
+            strategy_profile=[np.linspace(0.1, 0.9, 10) for _ in range(4)],
+            payoffs=[1.0, 2.0, 3.0, 4.0],
+            team_payoff=2.5,
+            iterations=7,
+            converged=True,
+            start_profile=[np.zeros(10) for _ in range(4)],
+        )
+        state = HeterogeneousDoubleOracle._eq_to_state(eq)
+        # Round-trip through JSON to catch numpy-type leaks.
+        state = json.loads(json.dumps(state))
+        eq2 = HeterogeneousDoubleOracle._eq_from_state(state)
+
+        assert eq2.converged is True
+        assert eq2.iterations == 7
+        assert eq2.team_payoff == pytest.approx(2.5)
+        assert eq2.payoffs == pytest.approx([1.0, 2.0, 3.0, 4.0])
+        for a, b in zip(eq.strategy_profile, eq2.strategy_profile):
+            np.testing.assert_allclose(a, b)
+        for a, b in zip(eq.start_profile, eq2.start_profile):
+            np.testing.assert_allclose(a, b)


### PR DESCRIPTION
Closes #388

## Summary

Adds per-restart checkpointing to `HeterogeneousDoubleOracle.solve()` so a host crash during a multi-hour Nash phase-diagram cell loses at most 1 of 20 restarts instead of the whole cell (~14h worst case during #383's preview run).

## Design

- New optional `progress_dir: Path | None = None` kwarg on `solve()`.
  - When `None` (default), behaviour is byte-identical to today — existing callers and tests are unaffected.
  - When set, after each completed restart the solver writes `{progress_dir}/restarts_progress.json` atomically (tempfile in the same directory, fsync, `os.replace`).
  - On entry, if the file exists, completed restart indices are skipped and their stored equilibria + strategy pool are replayed verbatim.
- When checkpointing is active the solver switches to a deterministic per-restart seed derived from `(self.seed, restart_idx)` so a resumed run produces the *same* equilibria as an uninterrupted run with the same `progress_dir`. Without that, the shared `_rng` would drift between interrupted and uninterrupted runs and resume couldn't be tested for equivalence.
- A corrupt or partial checkpoint (e.g. from a power loss mid-write) is treated as "no checkpoint" and the solver starts fresh rather than crashing.

## Files changed

- `bucket_brigade/equilibrium/double_oracle_heterogeneous.py` — new `progress_dir` kwarg, `_eq_to_state` / `_eq_from_state` / `_atomic_write_json` / `_write_progress` / `_read_progress` helpers, exported `PROGRESS_FILENAME` constant.
- `experiments/scripts/compute_nash_phase_diagram.py` — `_run_one_cell` now calls `solver.solve(progress_dir=cell_dir)` so the checkpoint lands inside each cell's artifact dir (alongside `summary.json` / `results.json`).
- `tests/test_heterogeneous_oracle_checkpoint.py` (new).

## Test plan

- [x] `tests/test_heterogeneous_oracle_checkpoint.py` — 7 new tests, all pass:
  - no-progress-dir path writes nothing (historical behaviour preserved)
  - progress file grows per restart with the documented schema
  - **crash mid-run + resume only runs missing restarts and matches an uninterrupted reference run** (the acceptance test from the issue)
  - corrupt checkpoint starts fresh
  - successful run leaves no stray `*.tmp` siblings
  - fully-complete checkpoint replays with zero new restart calls
  - round-trip serialisation of `HeterogeneousNashEquilibrium`
- [x] `tests/test_equilibrium.py` — existing equilibrium tests still pass (5 pass, 2 slow-skipped — same as `main`).
- [x] `ruff check` and `ruff format --check` clean on the 3 touched files.
- [x] Smoke check: `_run_one_cell` from the phase-diagram driver writes `restarts_progress.json` alongside `summary.json`/`results.json` as expected.
- [x] Pre-existing failures in `tests/test_evolution.py` (2 cases) confirmed unrelated — present on `main` without my changes.

## Out of scope

- Per-iteration checkpointing inside a single restart (still loses up to 1 restart; finer granularity is a separate ticket if needed).
- Parallel-restart execution (the Pool engagement ticket).

Generated with Claude Code