### PR TITLE
perf(nash): persistent Pool + lift worker cap so phase-diagram saturates cluster

### DIFF
--- a/bucket_brigade/equilibrium/double_oracle_heterogeneous.py
+++ b/bucket_brigade/equilibrium/double_oracle_heterogeneous.py
@@ -111,7 +111,11 @@ class HeterogeneousDoubleOracle:
     seed              : master RNG seed
     num_restarts      : random starting profiles to try
     verbose           : print per-position progress
-    num_workers       : parallel workers for MC evaluation
+    num_workers       : parallel workers for MC evaluation. ``None`` (the
+        default) uses ``cpu_count()``. The phase-diagram driver
+        (``compute_nash_phase_diagram.py``) is CPU-bound on every restart, so
+        leaving this unset is correct for cluster hosts. Set to ``1`` for
+        deterministic sequential execution (used by unit tests).
     """
 
     def __init__(
@@ -134,14 +138,43 @@ class HeterogeneousDoubleOracle:
         self.seed = seed
         self.num_restarts = num_restarts
         self.verbose = verbose
-        self.num_workers = (
-            num_workers if num_workers is not None else min(cpu_count(), 8)
-        )
+        # ``num_workers`` defaults to ``cpu_count()`` so cluster hosts saturate
+        # all cores on the heavy DO loop. Issue #389 traced the 32× single-core
+        # slowdown observed on alc-* during the #383 preview to (a) the
+        # previous ``min(cpu_count(), 8)`` cap leaving 24/32 cores idle, and
+        # (b) the L-BFGS-B inner loop in ``_best_response_for_position``
+        # running the per-call ``opt_simulations`` MC sweep entirely in the
+        # parent process. The fix here addresses (a); the persistent-Pool
+        # refactor below (see ``solve`` + ``_map_sims``) addresses (b).
+        self.num_workers = num_workers if num_workers is not None else cpu_count()
         self._rng = np.random.RandomState(seed)
+        # Persistent Pool, lifetime = one ``solve()`` call. ``None`` outside
+        # ``solve()`` and when ``num_workers <= 1`` (in which case
+        # ``_map_sims`` runs sequentially). See issue #389 for why we keep one
+        # Pool per cell instead of one per ``_evaluate_team`` call.
+        self._pool: Optional[Pool] = None
 
     # ------------------------------------------------------------------
     # Evaluation helpers
     # ------------------------------------------------------------------
+
+    def _map_sims(self, args_list: list[tuple]) -> list[list[float]]:
+        """Run ``_run_heterogeneous_sim`` over ``args_list``, parallel if possible.
+
+        Uses ``self._pool`` (the persistent per-``solve()`` Pool) when set,
+        falls back to a sequential map otherwise. Centralising the dispatch
+        here is what lets the L-BFGS-B inner loop in
+        ``_best_response_for_position`` share the same workers as
+        ``_evaluate_team``: before issue #389 each ``_evaluate_team`` call
+        constructed its own ``Pool`` and the L-BFGS-B closure ran serially in
+        the parent process, capping cluster-host utilisation at 1 core.
+
+        Order is preserved (``pool.map`` is order-preserving), so callers can
+        zip the result back against ``args_list`` for per-sim seed accounting.
+        """
+        if self._pool is not None:
+            return self._pool.map(_run_heterogeneous_sim, args_list)
+        return [_run_heterogeneous_sim(a) for a in args_list]
 
     def _evaluate_team(
         self,
@@ -153,11 +186,7 @@ class HeterogeneousDoubleOracle:
         seeds = [self._rng.randint(0, 2**31 - 1) for _ in range(n_sims)]
         args_list = [(strategy_profile, self.scenario, s) for s in seeds]
 
-        if self.num_workers > 1:
-            with Pool(processes=self.num_workers) as pool:
-                results = pool.map(_run_heterogeneous_sim, args_list)
-        else:
-            results = [_run_heterogeneous_sim(a) for a in args_list]
+        results = self._map_sims(args_list)
 
         rewards = np.array(results)  # (n_sims, 4)
         return list(np.mean(rewards, axis=0))
@@ -210,16 +239,21 @@ class HeterogeneousDoubleOracle:
         _rng_local = np.random.RandomState(opt_seed)
 
         def _objective(theta: np.ndarray) -> float:
-            # Sequential — called many times by L-BFGS-B; spawning a Pool
-            # per call would dominate runtime.
+            # Issue #389: L-BFGS-B calls this O(50) times per BR per position
+            # per outer iter. The dominant per-cell cost is this loop. With a
+            # persistent solver-level Pool (created in ``solve()``) we get the
+            # same parallel speedup as ``_evaluate_team`` without paying
+            # Pool-construction overhead per call. When ``self._pool is None``
+            # (``num_workers <= 1`` or solver called outside ``solve()``)
+            # ``_map_sims`` falls back to a sequential map — historical
+            # behaviour, preserved for tests.
             n = self.opt_simulations
             seeds = [_rng_local.randint(0, 2**31 - 1) for _ in range(n)]
             profile_t = [
                 theta if j == position else others[j - (j > position)] for j in range(4)
             ]
-            results = [
-                _run_heterogeneous_sim((profile_t, self.scenario, s)) for s in seeds
-            ]
+            args_list = [(profile_t, self.scenario, s) for s in seeds]
+            results = self._map_sims(args_list)
             return -float(np.mean([r[position] for r in results]))
 
         res = minimize(
@@ -491,62 +525,92 @@ class HeterogeneousDoubleOracle:
         use_deterministic_per_restart = progress_dir is not None
         base_seed = self.seed if self.seed is not None else 0
 
-        for restart_idx in range(self.num_restarts):
-            if restart_idx in completed_set:
+        # ----- Persistent Pool (issue #389) -----
+        # One Pool per ``solve()`` call instead of one per ``_evaluate_team``.
+        # The previous per-call lifecycle paid Pool-construction overhead on
+        # every evaluation and — more importantly — forced the L-BFGS-B inner
+        # loop in ``_best_response_for_position`` to run serially in the
+        # parent process (constructing a Pool there would have dominated
+        # runtime). With one Pool per cell we get parallel scaling on every
+        # MC call, including the L-BFGS-B loop. ``num_workers <= 1`` disables
+        # the Pool entirely; ``_map_sims`` falls back to a sequential loop,
+        # which is what the unit tests require.
+        pool_cm: Optional[Pool] = (
+            Pool(processes=self.num_workers) if self.num_workers > 1 else None
+        )
+        try:
+            if pool_cm is not None:
+                self._pool = pool_cm
                 if self.verbose:
                     print(
-                        f"[checkpoint] skipping restart {restart_idx + 1}/{self.num_restarts} "
-                        f"(already complete)",
+                        f"[pool] solver Pool engaged: {self.num_workers} workers "
+                        f"(cpu_count={cpu_count()})",
                         flush=True,
                     )
-                continue
 
-            if use_deterministic_per_restart:
-                # Derived seed is stable across resume; high-entropy mix so
-                # adjacent restart indices don't get correlated streams.
-                restart_seed = (
-                    base_seed * 2654435761 + restart_idx * 40503
-                ) & 0x7FFFFFFF
-                self._rng = np.random.RandomState(restart_seed)
+            for restart_idx in range(self.num_restarts):
+                if restart_idx in completed_set:
+                    if self.verbose:
+                        print(
+                            f"[checkpoint] skipping restart {restart_idx + 1}/{self.num_restarts} "
+                            f"(already complete)",
+                            flush=True,
+                        )
+                    continue
 
-            # Sample 4 strategies from the current pool (may include BRs from
-            # earlier restarts — pool grows during the run)
-            n_pool = len(strategy_pool)
-            indices = self._rng.randint(0, n_pool, size=4)
-            initial_profile = [strategy_pool[i].copy() for i in indices]
+                if use_deterministic_per_restart:
+                    # Derived seed is stable across resume; high-entropy mix so
+                    # adjacent restart indices don't get correlated streams.
+                    restart_seed = (
+                        base_seed * 2654435761 + restart_idx * 40503
+                    ) & 0x7FFFFFFF
+                    self._rng = np.random.RandomState(restart_seed)
 
-            if self.verbose:
-                names = [
-                    archetype_names[i] if i < len(archetype_names) else f"BR{i}"
-                    for i in indices
-                ]
-                print(
-                    f"\n{'=' * 60}\n"
-                    f"Restart {restart_idx + 1}/{self.num_restarts} — "
-                    f"start profile: {names}",
-                    flush=True,
-                )
+                # Sample 4 strategies from the current pool (may include BRs from
+                # earlier restarts — pool grows during the run)
+                n_pool = len(strategy_pool)
+                indices = self._rng.randint(0, n_pool, size=4)
+                initial_profile = [strategy_pool[i].copy() for i in indices]
 
-            eq = self._run_restart(initial_profile, strategy_pool, restart_idx)
-            results.append(eq)
-            completed_restarts.append(restart_idx)
+                if self.verbose:
+                    names = [
+                        archetype_names[i] if i < len(archetype_names) else f"BR{i}"
+                        for i in indices
+                    ]
+                    print(
+                        f"\n{'=' * 60}\n"
+                        f"Restart {restart_idx + 1}/{self.num_restarts} — "
+                        f"start profile: {names}",
+                        flush=True,
+                    )
 
-            if self.verbose:
-                status = "CONVERGED" if eq.converged else "MAX_ITER"
-                print(
-                    f"  → {status} in {eq.iterations} rounds, "
-                    f"team_payoff={eq.team_payoff:.1f}",
-                    flush=True,
-                )
+                eq = self._run_restart(initial_profile, strategy_pool, restart_idx)
+                results.append(eq)
+                completed_restarts.append(restart_idx)
 
-            # Persist progress after each completed restart so a crash here
-            # costs at most one restart of work.
-            if progress_path is not None:
-                self._write_progress(
-                    progress_path,
-                    completed_restarts,
-                    results,
-                    strategy_pool,
-                )
+                if self.verbose:
+                    status = "CONVERGED" if eq.converged else "MAX_ITER"
+                    print(
+                        f"  → {status} in {eq.iterations} rounds, "
+                        f"team_payoff={eq.team_payoff:.1f}",
+                        flush=True,
+                    )
+
+                # Persist progress after each completed restart so a crash here
+                # costs at most one restart of work.
+                if progress_path is not None:
+                    self._write_progress(
+                        progress_path,
+                        completed_restarts,
+                        results,
+                        strategy_pool,
+                    )
+        finally:
+            # Always release Pool workers, even on exception, so a crash
+            # mid-cell doesn't leak ``num_workers`` Python processes.
+            if pool_cm is not None:
+                pool_cm.close()
+                pool_cm.join()
+            self._pool = None
 
         return results

--- a/experiments/scripts/compute_nash_phase_diagram.py
+++ b/experiments/scripts/compute_nash_phase_diagram.py
@@ -42,6 +42,15 @@ calibration is ~5–7 h on alc-9 (see ``memory/nash_heterogeneous_calibration.md
 The full 5×5×3 = 75-cell grid is therefore ~450 h wall-clock on a single
 host. The issue recommends a 3×3×2 = 18-cell preview first.
 
+By default the per-cell solver uses a persistent ``multiprocessing.Pool``
+sized to ``cpu_count()`` for parallel MC evaluation. Issue #389 traced a
+32× single-core slowdown observed during the #383 preview to (a) the
+previous worker cap of 8 on 32-core hosts and (b) a per-call Pool lifecycle
+that left the L-BFGS-B inner loop in
+``HeterogeneousDoubleOracle._best_response_for_position`` running serially
+in the parent process. Both are fixed; use ``--num-workers`` to cap if
+sharing a host.
+
 This script ships with a ``--smoke`` mode that runs a 1×1×1 = 1-cell grid
 at trivially small budget (restarts=1, max_iter=1, simulations=20) so the
 driver wiring can be smoke-tested locally in a few minutes. Real runs MUST
@@ -80,6 +89,7 @@ import time
 import argparse
 import dataclasses
 from pathlib import Path
+from typing import Optional
 
 # Allow running from repo root or scripts/
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -233,8 +243,14 @@ def _run_one_cell(
     num_restarts: int,
     seed: int,
     verbose: bool,
+    num_workers: Optional[int] = None,
 ) -> dict:
-    """Run heterogeneous DO on one (β, κ, c) cell. Returns the cell summary dict."""
+    """Run heterogeneous DO on one (β, κ, c) cell. Returns the cell summary dict.
+
+    ``num_workers`` plumbs through to ``HeterogeneousDoubleOracle.solve`` so
+    the cluster wrapper can match Pool size to the host (issue #389). ``None``
+    delegates to the solver default, which is ``cpu_count()``.
+    """
     scenario = _make_scenario(beta, kappa, c, num_agents=4)
     cell_dir.mkdir(parents=True, exist_ok=True)
 
@@ -247,6 +263,7 @@ def _run_one_cell(
         seed=seed,
         num_restarts=num_restarts,
         verbose=verbose,
+        num_workers=num_workers,
     )
 
     t0 = time.time()
@@ -352,6 +369,7 @@ def compute_phase_diagram(
     seed: int,
     verbose: bool,
     force: bool,
+    num_workers: Optional[int] = None,
 ) -> None:
     cells_dir = output_dir / "cells"
     cells_dir.mkdir(parents=True, exist_ok=True)
@@ -418,6 +436,7 @@ def compute_phase_diagram(
                     num_restarts=num_restarts,
                     seed=cell_seed,
                     verbose=verbose,
+                    num_workers=num_workers,
                 )
                 cell_summaries.append(cell_summary)
                 print(
@@ -601,6 +620,19 @@ def main() -> None:
     parser.add_argument(
         "--quiet", action="store_true", help="Suppress per-position DO logs"
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=None,
+        help=(
+            "Pool workers for parallel MC evaluation per cell. ``None`` (the "
+            "default) uses ``cpu_count()`` — recommended for cluster hosts. "
+            "Pass an explicit integer to cap (e.g. ``--num-workers 16`` on a "
+            "32-core box when sharing the machine). Set to 1 to force "
+            "sequential execution (slow but deterministic; mainly for "
+            "debugging). See issue #389."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -671,6 +703,7 @@ def main() -> None:
         seed=args.seed,
         verbose=not args.quiet,
         force=args.force,
+        num_workers=args.num_workers,
     )
 
 

--- a/tests/test_heterogeneous_oracle_pool.py
+++ b/tests/test_heterogeneous_oracle_pool.py
@@ -1,0 +1,201 @@
+"""
+Tests for the persistent ``multiprocessing.Pool`` in ``HeterogeneousDoubleOracle``
+(issue #389).
+
+The phase-diagram driver (``compute_nash_phase_diagram.py``) was observed to
+saturate a single core on 32-core cluster hosts, delivering ~1/32 of the
+expected throughput. Root cause: ``_evaluate_team`` was constructing a fresh
+``Pool`` per call, and the L-BFGS-B inner loop in
+``_best_response_for_position`` ran its per-call ``opt_simulations`` MC sweep
+entirely in the parent process to avoid the per-call Pool-construction cost.
+
+The fix moves Pool lifetime to one ``Pool`` per ``solve()`` call and routes
+every MC dispatch through ``_map_sims`` so the L-BFGS-B loop shares those
+workers. These tests pin down the new invariants:
+
+  - ``num_workers > 1`` ⇒ ``self._pool`` is a ``Pool`` instance while the
+    solver is mid-``solve()`` and ``None`` outside it.
+  - ``num_workers == 1`` ⇒ ``self._pool`` stays ``None`` throughout
+    (preserves the sequential path the unit tests depend on).
+  - ``_map_sims`` is the single dispatch point — every MC call funnels
+    through it, including the L-BFGS-B inner loop. (Before the fix the
+    L-BFGS-B inner loop bypassed any parallel mechanism by construction.)
+  - Results computed with ``num_workers=1`` (sequential) and
+    ``num_workers=2`` (Pool) match bit-for-bit for the same seed.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+
+import pytest
+
+from bucket_brigade.envs import trivial_cooperation_scenario
+from bucket_brigade.equilibrium.double_oracle_heterogeneous import (
+    HeterogeneousDoubleOracle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _solver(num_workers: int, seed: int = 13) -> HeterogeneousDoubleOracle:
+    """Tiny-budget heterogeneous DO solver suitable for unit tests."""
+    scenario = trivial_cooperation_scenario(num_agents=4)
+    return HeterogeneousDoubleOracle(
+        scenario=scenario,
+        num_simulations=6,
+        opt_simulations=3,
+        max_iterations=1,
+        epsilon=10.0,
+        seed=seed,
+        num_restarts=2,
+        verbose=False,
+        num_workers=num_workers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPoolLifecycle:
+    """``self._pool`` invariants across ``solve()`` calls."""
+
+    def test_pool_is_none_outside_solve(self):
+        """The Pool only exists during a ``solve()`` call."""
+        solver = _solver(num_workers=2)
+        assert solver._pool is None
+        solver.solve()
+        assert solver._pool is None  # released after solve()
+
+    def test_pool_active_inside_solve_when_parallel(self, monkeypatch):
+        """With ``num_workers > 1`` the Pool is set before any restart runs."""
+        solver = _solver(num_workers=2)
+        original_run = solver._run_restart
+        observed_pool_types: list[type | None] = []
+
+        def spy_run_restart(initial_profile, strategy_pool, restart_idx):
+            observed_pool_types.append(
+                type(solver._pool) if solver._pool is not None else None
+            )
+            return original_run(initial_profile, strategy_pool, restart_idx)
+
+        monkeypatch.setattr(solver, "_run_restart", spy_run_restart)
+        solver.solve()
+
+        # Every restart observed a live Pool. Without the fix
+        # ``observed_pool_types`` would contain ``None`` entries because the
+        # solver never set ``self._pool``.
+        assert len(observed_pool_types) > 0
+        for t in observed_pool_types:
+            assert t is not None, (
+                "self._pool should be set throughout solve() when num_workers > 1"
+            )
+            # ``mp.Pool`` is a factory (mp.pool.Pool is the class) — accept
+            # either to avoid platform sensitivity.
+            assert "Pool" in t.__name__
+
+    def test_no_pool_when_sequential(self, monkeypatch):
+        """``num_workers == 1`` must keep ``self._pool`` ``None``."""
+        solver = _solver(num_workers=1)
+        original_run = solver._run_restart
+        observed = []
+
+        def spy_run_restart(initial_profile, strategy_pool, restart_idx):
+            observed.append(solver._pool)
+            return original_run(initial_profile, strategy_pool, restart_idx)
+
+        monkeypatch.setattr(solver, "_run_restart", spy_run_restart)
+        solver.solve()
+
+        assert len(observed) > 0
+        assert all(p is None for p in observed), (
+            "Sequential path (num_workers=1) must not allocate a Pool. "
+            "Existing tests in test_heterogeneous_oracle_checkpoint.py rely "
+            "on this for byte-identical behaviour vs the pre-#389 solver."
+        )
+
+
+class TestMapSimsDispatch:
+    """All MC calls route through ``_map_sims`` — including the L-BFGS-B loop."""
+
+    def test_map_sims_called_by_lbfgs_objective(self, monkeypatch):
+        """
+        L-BFGS-B in ``_best_response_for_position`` exercises ``_map_sims``.
+
+        Regression for issue #389: before the fix the L-BFGS-B closure built
+        its result list with a bare list comprehension over
+        ``_run_heterogeneous_sim``, bypassing any pooled execution. The fix
+        funnels every MC dispatch through ``_map_sims`` so the persistent
+        Pool gets exercised on what is, by call count, the dominant per-cell
+        workload.
+        """
+        solver = _solver(num_workers=1)  # sequential for deterministic test
+        original = solver._map_sims
+        call_count = {"n": 0}
+
+        def counting(args_list):
+            call_count["n"] += 1
+            return original(args_list)
+
+        monkeypatch.setattr(solver, "_map_sims", counting)
+        solver.solve()
+
+        # With 2 restarts × 1 max_iter × 4 positions, the BR loop alone
+        # invokes ``_map_sims`` dozens of times. Tight lower bound here
+        # is "anything > the pre-fix count", which was just the
+        # ``_evaluate_team`` callers (~3-4 per BR). Asserting > 20 is a
+        # generous floor that catches accidental regression to the
+        # pre-fix list-comprehension path while staying robust to
+        # L-BFGS-B convergence variability.
+        assert call_count["n"] > 20, (
+            f"_map_sims called only {call_count['n']} times — L-BFGS-B "
+            "inner loop is likely bypassing the pooled dispatch."
+        )
+
+
+class TestSequentialParallelEquivalence:
+    """Bit-identical equilibria across ``num_workers=1`` and ``num_workers>1``.
+
+    This is the strongest correctness guarantee: the Pool change must be a
+    pure parallelisation, not a semantic change. We seed both solvers
+    identically, run both with ``progress_dir`` set (deterministic
+    per-restart seeds, see ``solve``'s ``use_deterministic_per_restart``),
+    and compare the resulting equilibrium signatures.
+    """
+
+    def test_results_match_across_worker_counts(self, tmp_path):
+        # Pool spawning is slow on macOS (uses ``spawn`` start method).
+        # Keep the budget small but representative.
+        seq_solver = _solver(num_workers=1, seed=2026)
+        par_solver = _solver(num_workers=2, seed=2026)
+
+        seq = seq_solver.solve(progress_dir=tmp_path / "seq")
+        par = par_solver.solve(progress_dir=tmp_path / "par")
+
+        assert len(seq) == len(par)
+        for a, b in zip(seq, par):
+            assert a.converged == b.converged
+            assert a.iterations == b.iterations
+            assert a.team_payoff == pytest.approx(b.team_payoff, abs=1e-9)
+            assert a.payoffs == pytest.approx(b.payoffs, abs=1e-9)
+            for s_a, s_b in zip(a.strategy_profile, b.strategy_profile):
+                assert list(map(float, s_a)) == pytest.approx(
+                    list(map(float, s_b)), abs=1e-9
+                )
+
+
+def test_num_workers_default_is_cpu_count():
+    """Default ``num_workers`` is ``cpu_count()`` — no historical ``min(_, 8)`` cap.
+
+    Issue #389 documented that the prior cap left 24/32 cores idle on cluster
+    hosts. The default is now ``cpu_count()``; callers cap explicitly via
+    ``--num-workers`` if they want to share a host.
+    """
+    scenario = trivial_cooperation_scenario(num_agents=4)
+    solver = HeterogeneousDoubleOracle(scenario=scenario, num_workers=None)
+    assert solver.num_workers == mp.cpu_count()


### PR DESCRIPTION
Closes #389.

## Root cause

Phase-diagram cells were running at ~1/32 of expected throughput on 32-core
cluster hosts (`alc-*`) — 99% on one core, 31 idle — due to two compounding
bugs in `HeterogeneousDoubleOracle`:

1. **Worker cap too low**: `__init__` defaulted `num_workers` to
   `min(cpu_count(), 8)`, leaving 24/32 cores idle on cluster hosts even
   when the parallel path engaged.
2. **L-BFGS-B inner loop bypassed the Pool**: `_evaluate_team` built a
   fresh `Pool` per call (paying spawn overhead each time), and the
   L-BFGS-B `_objective` closure in `_best_response_for_position` — which
   calls the MC simulator O(50) times per BR per position per outer iter
   and is by call count the dominant per-cell workload — ran with a bare
   list comprehension in the parent process. Building a per-call Pool
   there would have made things worse, so it was correctly left
   sequential — but that left every cluster cell single-cored on the
   dominant code path.

Net effect: full preview cells were taking ~14h instead of the design
~5.5h. With 18 cells across 4 hosts and the worst-case-cell-per-host
distribution dragging the wall-clock, a full ~100h-budget preview was
projected at ~450h.

## Fix

- Default `num_workers` to `cpu_count()` (no `min(_, 8)` cap). Operators
  cap explicitly via `--num-workers` when sharing a host.
- **One `Pool` per `solve()` call** stored on `self._pool` for the
  lifetime of the call and released in a `finally:` so a mid-cell crash
  doesn't leak workers.
- New `_map_sims(args_list)` is the **single MC dispatch point**. Both
  `_evaluate_team` and the L-BFGS-B `_objective` closure now route
  through it, so the persistent Pool gets exercised on every MC call
  including the dominant inner loop.
- `num_workers == 1` keeps `self._pool` as `None` and `_map_sims` falls
  back to a sequential map, preserving byte-identical behaviour for the
  existing checkpoint tests (#391) that depend on it.
- Plumb `--num-workers` through `compute_nash_phase_diagram.py` so
  operators can cap when sharing a cluster host.

## Validation

**New tests** (`tests/test_heterogeneous_oracle_pool.py`, 6 cases) pin the
invariants:

- `test_pool_is_none_outside_solve` — Pool only exists during `solve()`.
- `test_pool_active_inside_solve_when_parallel` — `self._pool` is set
  before any restart runs when `num_workers > 1`.
- `test_no_pool_when_sequential` — `num_workers == 1` never allocates a
  Pool (required for byte-identical checkpoint resume).
- `test_map_sims_called_by_lbfgs_objective` — regression test that the
  L-BFGS-B inner loop actually invokes the pooled dispatcher (the pre-fix
  list-comprehension path would fail this).
- `test_results_match_across_worker_counts` — bit-identical equilibria
  across `num_workers=1` vs `num_workers=2` with the same seed.
- `test_num_workers_default_is_cpu_count` — pins the new default.

**All hetero-oracle tests pass** (6 new + 7 existing checkpoint tests):

```
tests/test_heterogeneous_oracle_pool.py ......       [6 passed]
tests/test_heterogeneous_oracle_checkpoint.py ....... [7 passed]
============================= 13 passed in 15.82s ==============================
```

**Local CPU saturation observation** on a 28-core box (trivial scenario,
`num_simulations=200, opt_simulations=80, max_iterations=2, num_restarts=3`):

```
parent_pid=21814 cpu_count=28
PID    PPID   %CPU COMMAND
21814  21812 132.6 python   (parent, scheduling + numpy)
21816  21814  19.5 python   spawn_main --multiprocessing-fork
21817  21814  19.5 python   spawn_main --multiprocessing-fork
...    21814  ~19.5 python   (28 child workers)
```

Total: ~28 × 19.5% + 132.6% ≈ **680% CPU**, satisfying the acceptance
criterion ("`ps -o pcpu` showing >>100% on the Python parent process
during MC"). Without the fix the parent would have shown ~100% on one
core with zero child workers during the dominant L-BFGS-B loop.

**Speedup smoke** (tiny budget, spawn overhead dominates):

```
num_workers=1   wallclock=9.75s
num_workers=28  wallclock=5.08s
speedup vs sequential: 1.92x
```

On cluster-sized cells (hours of CPU per cell) the speedup approaches the
full core count — Amdahl-limited only by the small serial sections in
`solve()` (start-profile sampling, checkpoint write).

**No correctness regression**: existing `tests/test_equilibrium.py` and
`tests/test_heterogeneous_oracle_checkpoint.py` both pass unchanged. The
deterministic per-restart seed path from #391 is preserved verbatim
(`use_deterministic_per_restart` block lives inside the new Pool
lifecycle but is otherwise untouched).

## Caveats

- Validated locally on a 28-core macOS box with a synthetic trivial
  scenario. **Not** validated on a cluster host with a real phase-diagram
  cell — that's a multi-hour run that should not be launched from this
  builder session per `CLAUDE.md` compute-resource guidance. Recommend
  re-validating by running one cell (e.g. `b0.50_k0.50_c0.50` at preview
  budgets) on `alc-9` and confirming `ps -o pcpu` shows the saturation
  pattern above.
- The issue body asks for a note in `RECOVERY_NOTES.md`; no such file
  exists in this tree (it was referenced from PR #387 context that's not
  on `main`). The full root-cause + fix is captured in this PR
  description, in commit messages, and in inline comments at the fix
  sites (`double_oracle_heterogeneous.py:141-155, 528-540` and the
  `_map_sims` / `_objective` docstrings).
- macOS uses `spawn` for multiprocessing, which is what the existing
  workers already rely on. Pool worker spawn is paid once per `solve()`
  call now instead of once per `_evaluate_team` — a strict improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)