### PR TITLE
ops(nash): launch script + runbook for phase-diagram gap-fill (#390)

### DIFF
--- a/experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md
+++ b/experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md
@@ -1,0 +1,245 @@
+# Phase-diagram preview gap-fill — operator runbook
+
+This runbook is the operator companion to
+[`experiments/scripts/launch_phase_diagram_fill.sh`](../../scripts/launch_phase_diagram_fill.sh).
+It is used to fill the missing cells of the `(β, κ, c)` heterogeneous Nash
+preview grid documented in `RECOVERY_NOTES.md` (committed in PR #387; the
+file will sit alongside this runbook once #387 merges) and tracked by
+[issue #390][issue-390].
+
+[issue-390]: https://github.com/rjwalters/bucket-brigade/issues/390
+
+The launch script does **not** run any compute locally — it shells into a
+remote host listed in `.env`, pulls latest `main`, builds the Rust
+extension, and starts a detached `tmux` session running the driver
+([`compute_nash_phase_diagram.py`](../../scripts/compute_nash_phase_diagram.py))
+scoped to the requested cells. The actual cell-fill completes hours later
+inside the tmux session; the operator's job is to launch, wait, then rsync
+and replot.
+
+## Prerequisites
+
+The two performance / reliability fixes merged on 2026-06-08 must be on
+`main`:
+
+- **#391** — per-restart checkpointing in `HeterogeneousDoubleOracle.solve()`
+  (a host outage now wastes at most 1/20 of a cell instead of a whole cell).
+- **#392** (#389) — persistent `multiprocessing.Pool` + lifted worker cap
+  (cells now saturate all cores instead of running on 1, ≈32× speedup ceiling
+  on 32-core boxes; design budget of ~5.5 h/cell becomes realistic).
+
+Without #392 each cell costs ~14 h wall-clock, which makes the fill
+operationally infeasible on a single host. With #392 the full 11-cell fill
+should complete in ~60 h on a healthy 32-core box, or ~22 h across three
+hosts running in parallel.
+
+The `.env` file at the repo root must define at least one `COMPUTE_HOST_*`
+alias resolvable via the local `~/.ssh/config` (see `.env.example`).
+
+## What is missing
+
+The preview grid is `3 × 3 × N` over `(β, κ, c)` where:
+
+- `β ∈ {0.10, 0.50, 0.90}`
+- `κ ∈ {0.10, 0.50, 0.90}`
+- `c` is operator-chosen — `PREVIEW_C_VALUES` in the driver is `(0.5, 2.0)`
+  giving 18 cells; including `c = 1.0` gives 27.
+
+Cells already committed in `preview/` (sibling of this runbook; arrives
+with PR #387 — 10 cells, all at `c = 0.5`):
+
+| β\κ  | 0.10 | 0.50 | 0.90 |
+|------|------|------|------|
+| 0.10 | ✅    | ❌    | ❌    |
+| 0.50 | ✅    | ✅    | ✅    |
+| 0.90 | ✅    | ✅    | ✅    |
+
+`(7 unique cells + 3 alc-5 freq-cap duplicates)`
+
+**Gaps required by issue #390 acceptance criteria**:
+
+1. **β = 0.10 row, c = 0.50, κ ∈ {0.50, 0.90}** — 2 cells.
+2. **All of c = 2.00** (`3 × 3 = 9` cells).
+3. **All of c = 1.00** (`3 × 3 = 9` cells). *Optional under the 18-cell AC
+   reading; required under the title's "(β=0.1 row, c=1.0, c=2.0)" reading.
+   See the "Scope ambiguity" note below.*
+
+Total: 11 cells (18-cell preview), or 20 cells (27-cell preview).
+
+### Scope ambiguity
+
+The issue body lists "All of c=1.0 and c=2.0 (12 cells)" but its acceptance
+criterion is "All 18 cells of the (β, κ, c) preview grid". `PREVIEW_C_VALUES`
+in the driver is `(0.5, 2.0)`, so 3×3×2 = 18 is the smaller reading and
+excludes c=1.0. The title explicitly mentions c=1.0 though, suggesting the
+author intends to extend the preview to 3×3×3 = 27.
+
+**Operator decision required**: choose one before launching.
+
+- **Minimal (18-cell)**: fill only Plan A and Plan B below. Stops at AC.
+- **Extended (27-cell)**: fill Plan A + Plan B + Plan C. Closes the issue
+  with full title-level coverage and gives the c-axis triangulation the
+  body's rationale section asks for.
+
+The script is identical for both; the extended path just adds the Plan C
+launch.
+
+## Host assignment
+
+The preview can be parallelized across hosts cleanly because the driver's
+per-cell artifacts live under `preview/cells/<tag>/` and are independently
+written (one process per host, but they all write into disjoint cell
+directories that get rsynced back). **Avoid running multiple hosts into
+the *same* `preview/cells/` tree** — rsync afterwards.
+
+Recommended split (assumes 3 healthy 32-core hosts; substitute with what
+you actually have in `.env`):
+
+| Plan | Cells           | Suggested host                  | Approx wall-clock @ 32 cores |
+|------|-----------------|----------------------------------|------------------------------|
+| A    | β=0.10 row gaps | alc-2 (or any reliable 32-core)  | ~11 h (2 cells × ~5.5 h)     |
+| B    | c=2.0 plane     | alc-6 (or replacement for alc-10)| ~50 h (9 cells × ~5.5 h)     |
+| C    | c=1.0 plane     | alc-9                            | ~50 h (9 cells × ~5.5 h)     |
+
+Host reliability ranking (from cluster operations): prefer alc-2 / alc-6 /
+alc-9. **Avoid alc-5** (12.5% reliable, confirmed flaky — requires the
+4.5 GHz frequency cap workaround for any sustained load). **Avoid alc-10**
+until hardware is replaced (offline as of 2026-06-08).
+
+If you only have **one** healthy host, run Plans A → B → C sequentially on
+the same host; the driver caches completed cells via `summary.json` so it
+is safe to re-launch.
+
+## Launch commands (copy-paste)
+
+All commands assume a checkout of `main` (or the merged result of
+PR #387 + this PR) and a working `.env`.
+
+### Plan A — β=0.1 row gaps (c=0.5, κ ∈ {0.5, 0.9})
+
+```bash
+./experiments/scripts/launch_phase_diagram_fill.sh \
+    --host alc-2 \
+    --beta-values 0.1 \
+    --kappa-values 0.5,0.9 \
+    --c-values 0.5
+```
+
+Expected: 2 cells, ~11 h on a 32-core box.
+
+### Plan B — c=2.0 plane (all 9 cells)
+
+```bash
+./experiments/scripts/launch_phase_diagram_fill.sh \
+    --host alc-6 \
+    --beta-values 0.1,0.5,0.9 \
+    --kappa-values 0.1,0.5,0.9 \
+    --c-values 2.0
+```
+
+Expected: 9 cells, ~50 h on a 32-core box.
+
+### Plan C — c=1.0 plane (all 9 cells, optional)
+
+```bash
+./experiments/scripts/launch_phase_diagram_fill.sh \
+    --host alc-9 \
+    --beta-values 0.1,0.5,0.9 \
+    --kappa-values 0.1,0.5,0.9 \
+    --c-values 1.0
+```
+
+Expected: 9 cells, ~50 h on a 32-core box.
+
+### One-host serial fallback (minimal, 18-cell coverage)
+
+```bash
+# Both A and B on one box. The driver appends results into the same
+# preview/cells/ tree, so don't run these concurrently on the same host.
+./experiments/scripts/launch_phase_diagram_fill.sh --host alc-9 \
+    --beta-values 0.1 --kappa-values 0.5,0.9 --c-values 0.5
+
+# Wait for plan A to finish before launching plan B (or use a different
+# tmux session name and accept that the host will time-slice; the
+# checkpointing in #391 makes this safe but slower).
+./experiments/scripts/launch_phase_diagram_fill.sh --host alc-9 \
+    --beta-values 0.1,0.5,0.9 --kappa-values 0.1,0.5,0.9 --c-values 2.0
+```
+
+## Monitoring
+
+The launch script prints the tmux session name (`nash-fill-...`) and log
+path on success. From local:
+
+```bash
+# Live attach
+ssh <host> -t 'tmux attach -t nash-fill-c2.0'
+
+# Tail the log
+ssh <host> 'tail -f bucket-brigade/experiments/nash/phase_diagram/preview/nash-fill-c2.0.log'
+
+# Check checkpoints (per-restart progress, from #391)
+ssh <host> 'find bucket-brigade/experiments/nash/phase_diagram/preview/cells -name restarts_progress.json -newer /tmp/check'
+```
+
+## After cells finish — rsync, regenerate, replot
+
+Once **all** assigned plans on **all** hosts have completed, do the merge
+locally:
+
+```bash
+# 1. Pull per-host outputs into the canonical preview/ tree.
+#    Cells from different hosts land in disjoint cells/<tag>/ subdirs
+#    (Plan A writes b0.10_k0.50_c0.50/ + b0.10_k0.90_c0.50/, Plan B
+#    writes b*_k*_c2.00/, etc.) so rsync is non-destructive.
+for host in alc-2 alc-6 alc-9; do
+    rsync -avz "$host:bucket-brigade/experiments/nash/phase_diagram/preview/cells/" \
+        experiments/nash/phase_diagram/preview/cells/
+done
+
+# 2. Regenerate the aggregate results.json. The driver's --preview default
+#    is 3×3×2; if you ran the optional Plan C, pass explicit --c-values to
+#    include 1.0 in the aggregate.
+# Minimal (18-cell preview):
+uv run python experiments/scripts/compute_nash_phase_diagram.py --preview \
+    --output-dir experiments/nash/phase_diagram/preview
+
+# Extended (27-cell preview):
+uv run python experiments/scripts/compute_nash_phase_diagram.py \
+    --beta-values 0.1,0.5,0.9 --kappa-values 0.1,0.5,0.9 --c-values 0.5,1.0,2.0 \
+    --output-dir experiments/nash/phase_diagram/preview
+
+# 3. Regenerate the PNG + table.
+uv run python experiments/scripts/plot_phase_diagram.py \
+    --results experiments/nash/phase_diagram/preview/results.json \
+    --out-png experiments/nash/phase_diagram/phase_diagram.png \
+    --out-md  experiments/nash/phase_diagram/phase_diagram_table.md
+```
+
+The final `phase_diagram.png` should have no white `—` placeholder cells
+in the `c = 0.50` (and `c = 1.00` if extended) and `c = 2.00` subplots —
+that visual check is the AC for issue #390.
+
+## Updating the notes file
+
+Append a "Plane comparison" section to `RECOVERY_NOTES.md` (sibling file,
+arrives with PR #387) describing whether the c=1.0 and/or c=2.0 planes
+reveal a β-driven transition (the c=0.5 plane was purely κ-driven). That
+answer is the analytical payoff the issue exists to produce.
+
+## Troubleshooting
+
+- **Host unreachable**: the script aborts with exit 4 before consuming
+  any compute. Check `ssh -v <host>` and the host's reachability/power.
+- **Build failure on remote**: if `bucket-brigade-core/build.sh` complains
+  about a stale `.so`, the remote venv is missing pip. The script seeds
+  pip automatically; if that fails, ssh in and run
+  `uv pip install pip && bash bucket-brigade-core/build.sh` once by hand.
+- **Driver crashes mid-cell**: thanks to #391, re-launching the script
+  with the same arguments resumes from the last completed restart in
+  each cell. No `--force` needed.
+- **alc-5 / alc-10 hardware**: alc-5 needs the 4.5 GHz frequency cap
+  (see the freq-cap section of `RECOVERY_NOTES.md` once PR #387 merges:
+  bit-identical results vs boost clocks, with no crashes for 12 h+);
+  alc-10 is still offline as of recovery. Substitute another reliable
+  host from `.env`.

--- a/experiments/scripts/launch_phase_diagram_fill.sh
+++ b/experiments/scripts/launch_phase_diagram_fill.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Launch the heterogeneous Nash phase-diagram driver on a remote host to
+# fill a specified slice of (β, κ, c) cells. Designed for the gap-fill
+# operation tracked in issue #390 (β=0.1 row, c=1.0, c=2.0 planes), but
+# generic: any --beta-values / --kappa-values / --c-values list can be
+# passed and the driver will run that subset, caching previously-completed
+# cells via summary.json (see compute_nash_phase_diagram.py --force).
+#
+# The script does NOT compute anything locally. It only:
+#   1. Reads $COMPUTE_HOST_* aliases from .env to resolve a target host
+#      (unless --host is passed explicitly).
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts
+#      a detached tmux session running compute_nash_phase_diagram.py with
+#      the requested cell filter and --num-workers.
+#   4. Prints monitor / rsync / replot instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual cells fill over
+# hours/days inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Auto-resolve host from .env, fill all of c=2.0 (the alc-10 gap)
+#   ./experiments/scripts/launch_phase_diagram_fill.sh \
+#       --c-values 2.0
+#
+#   # Explicit host, just the β=0.1 row gap at c=0.5 (κ ∈ {0.5, 0.9})
+#   ./experiments/scripts/launch_phase_diagram_fill.sh \
+#       --host alc-2 --beta-values 0.1 --kappa-values 0.5,0.9 --c-values 0.5
+#
+#   # Dry-run prints the ssh + driver command without launching anything
+#   ./experiments/scripts/launch_phase_diagram_fill.sh --c-values 1.0 --dry-run
+#
+# See experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md for the canonical
+# host assignments for the issue #390 fill operation.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Defaults that the operator usually does not need to override.
+DEFAULT_SESSION_PREFIX="nash-fill"
+DEFAULT_NUM_WORKERS=""        # empty => let driver default (cpu_count())
+DEFAULT_BETA_VALUES=""        # empty => omit flag (driver uses --preview defaults if --preview is on, else FULL)
+DEFAULT_KAPPA_VALUES=""
+DEFAULT_C_VALUES=""
+
+HOST=""
+BETA_VALUES="$DEFAULT_BETA_VALUES"
+KAPPA_VALUES="$DEFAULT_KAPPA_VALUES"
+C_VALUES="$DEFAULT_C_VALUES"
+NUM_WORKERS="$DEFAULT_NUM_WORKERS"
+SESSION_NAME=""
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+OUTPUT_DIR="experiments/nash/phase_diagram/preview"
+
+print_usage() {
+    sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    # Source in a subshell-safe way: only export the COMPUTE_HOST_* vars.
+    # Using `set -a` would also export anything else in .env which we
+    # don't want.
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --beta-values)
+            BETA_VALUES="$2"
+            shift 2
+            ;;
+        --kappa-values)
+            KAPPA_VALUES="$2"
+            shift 2
+            ;;
+        --c-values)
+            C_VALUES="$2"
+            shift 2
+            ;;
+        --num-workers)
+            NUM_WORKERS="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+
+if [[ -z "$HOST" ]]; then
+    HOST=$(resolve_host_from_env)
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build driver command + tmux session name
+# ---------------------------------------------------------------------------
+
+if [[ -z "$SESSION_NAME" ]]; then
+    # Compact tag so two concurrent launches on the same host don't collide.
+    tag_parts=()
+    [[ -n "$BETA_VALUES" ]] && tag_parts+=("b$(echo "$BETA_VALUES" | tr ',' '-')")
+    [[ -n "$KAPPA_VALUES" ]] && tag_parts+=("k$(echo "$KAPPA_VALUES" | tr ',' '-')")
+    [[ -n "$C_VALUES" ]] && tag_parts+=("c$(echo "$C_VALUES" | tr ',' '-')")
+    if [[ ${#tag_parts[@]} -gt 0 ]]; then
+        SESSION_NAME="${DEFAULT_SESSION_PREFIX}-$(IFS=_; echo "${tag_parts[*]}")"
+    else
+        SESSION_NAME="$DEFAULT_SESSION_PREFIX"
+    fi
+fi
+
+# Compose the driver invocation as a single shell-safe string.
+DRIVER_CMD="uv run python experiments/scripts/compute_nash_phase_diagram.py --output-dir '$OUTPUT_DIR'"
+[[ -n "$BETA_VALUES" ]] && DRIVER_CMD+=" --beta-values '$BETA_VALUES'"
+[[ -n "$KAPPA_VALUES" ]] && DRIVER_CMD+=" --kappa-values '$KAPPA_VALUES'"
+[[ -n "$C_VALUES" ]] && DRIVER_CMD+=" --c-values '$C_VALUES'"
+[[ -n "$NUM_WORKERS" ]] && DRIVER_CMD+=" --num-workers $NUM_WORKERS"
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default.
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the import before consuming a tmux session for a multi-hour run.
+uv run python -c "from bucket_brigade.equilibrium.double_oracle_heterogeneous import HeterogeneousDoubleOracle; print('ok')"
+
+mkdir -p $OUTPUT_DIR
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && $DRIVER_CMD 2>&1 | tee -a '$OUTPUT_DIR/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_DIR/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+echo "===================================================================="
+echo "Phase-diagram fill launch"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output dir:     $OUTPUT_DIR    (on remote)"
+echo "Beta values:    ${BETA_VALUES:-<driver default>}"
+echo "Kappa values:   ${KAPPA_VALUES:-<driver default>}"
+echo "C values:       ${C_VALUES:-<driver default>}"
+echo "Num workers:    ${NUM_WORKERS:-<driver default = cpu_count()>}"
+echo ""
+echo "Driver command (to be run inside tmux on remote):"
+echo "  $DRIVER_CMD"
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_DIR}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done, rsync results back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_DIR}/ ${OUTPUT_DIR}/"
+echo ""
+echo "  # Regenerate aggregate + figures locally once results are back:"
+echo "  uv run python experiments/scripts/compute_nash_phase_diagram.py --preview \\"
+echo "      --output-dir ${OUTPUT_DIR}   # picks up cached cells, writes results.json"
+echo "  uv run python experiments/scripts/plot_phase_diagram.py \\"
+echo "      --results ${OUTPUT_DIR}/results.json"
+echo "===================================================================="

--- a/tests/test_launch_phase_diagram_fill.py
+++ b/tests/test_launch_phase_diagram_fill.py
@@ -1,0 +1,212 @@
+"""Tests for ``experiments/scripts/launch_phase_diagram_fill.sh``.
+
+The script is the operator-launch wrapper added for issue #390 (fill the
+missing β=0.1 row + c=1.0/2.0 cells of the heterogeneous Nash phase-diagram
+preview). Because it shells out to ``ssh`` to bootstrap a remote tmux
+session, we cannot exercise the live-run path in unit tests. The
+``--dry-run`` flag exists exactly so the wiring (arg parsing, host
+resolution, driver-command synthesis, session-name compaction) can be
+asserted without touching the network.
+
+These tests cover the three operator-facing failure modes plus the canonical
+gap-fill invocations from ``experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_phase_diagram_fill.sh"
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check that the canonical flags appear in the doc string.
+    for flag in (
+        "--host",
+        "--c-values",
+        "--beta-values",
+        "--kappa-values",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+
+
+def test_missing_host_with_no_env_errors_cleanly() -> None:
+    """Without --host and without a .env, the script must fail with exit 3."""
+    # Run in a temp dir with no .env so resolve_host_from_env returns empty.
+    # The script computes REPO_ROOT relative to its own location, so to force
+    # the "no .env" branch we hand it a host-free environment by pointing at
+    # a tmp cwd... but REPO_ROOT is hard-coded to SCRIPT_DIR/../.. so the .env
+    # lookup goes through the real repo root regardless of cwd. We instead
+    # invoke a fake script that wraps the real one with REPO_ROOT overridden
+    # — too brittle. Simpler: just confirm "no host specified" path produces
+    # the documented diagnostic when --host is missing AND .env has no
+    # COMPUTE_HOST_* entries. We do that by temporarily renaming any existing
+    # .env, running, and restoring.
+    env_path = REPO_ROOT / ".env"
+    backup = None
+    if env_path.exists():
+        backup = env_path.read_bytes()
+        env_path.unlink()
+    try:
+        result = _run(["--c-values", "2.0", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+
+    assert result.returncode == 3, (
+        f"expected exit 3 (no host), got {result.returncode}: {result.stderr}"
+    )
+    assert "no host specified" in result.stderr.lower()
+
+
+def test_dry_run_with_explicit_host_emits_driver_command(tmp_path: Path) -> None:
+    """``--dry-run`` must print the synthesized driver invocation."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--beta-values",
+            "0.1",
+            "--kappa-values",
+            "0.5,0.9",
+            "--c-values",
+            "0.5",
+            "--num-workers",
+            "16",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Argument plumbing through to the driver:
+    assert "compute_nash_phase_diagram.py" in out
+    assert "--beta-values '0.1'" in out
+    assert "--kappa-values '0.5,0.9'" in out
+    assert "--c-values '0.5'" in out
+    assert "--num-workers 16" in out
+    # Header echoes the resolved host.
+    assert "fake-host" in out
+    # Dry-run banner must be present so an operator never confuses it
+    # with a real launch.
+    assert "dry-run" in out.lower()
+
+
+def test_dry_run_synthesizes_compact_session_name() -> None:
+    """Session name compaction must include β/κ/c so concurrent fills don't collide."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--c-values",
+            "1.0,2.0",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    # Expect "nash-fill-c1.0-2.0" — c-values joined with dashes inside the
+    # session-name tag, prefixed by nash-fill. (β/κ omitted because they
+    # weren't passed; the driver will use its full-grid defaults.)
+    assert "nash-fill-c1.0-2.0" in result.stdout, result.stdout
+
+
+def test_dry_run_resolves_host_from_env(tmp_path: Path) -> None:
+    """When --host is omitted, the script must pick the first non-empty
+    COMPUTE_HOST_* from .env using the documented priority (PRIMARY first)."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    try:
+        env_path.write_text(
+            textwrap.dedent(
+                """\
+                COMPUTE_HOST_PRIMARY=resolved-primary
+                COMPUTE_HOST_CLUSTER=resolved-cluster
+                """
+            )
+        )
+        result = _run(["--c-values", "2.0", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+        elif env_path.exists():
+            env_path.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved-primary" in result.stdout
+    # CLUSTER should NOT win when PRIMARY is set.
+    assert "resolved-cluster" not in result.stdout
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(["--host", "x", "--not-a-flag", "y", "--dry-run"])
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    "args,expected_in_cmd",
+    [
+        # Issue #390 canonical fills (mirroring LAUNCH_RUNBOOK.md):
+        # 1. β=0.1 row gap at c=0.5 (κ ∈ {0.5, 0.9}) — 2 cells
+        (
+            ["--beta-values", "0.1", "--kappa-values", "0.5,0.9", "--c-values", "0.5"],
+            ["--beta-values '0.1'", "--kappa-values '0.5,0.9'", "--c-values '0.5'"],
+        ),
+        # 2. All of c=2.0 (the alc-10 gap) — 9 cells
+        (
+            ["--c-values", "2.0"],
+            ["--c-values '2.0'"],
+        ),
+        # 3. All of c=1.0 (the missing 3rd plane, if extending preview to 3×3×3)
+        (
+            ["--c-values", "1.0"],
+            ["--c-values '1.0'"],
+        ),
+    ],
+    ids=["beta01_row_gap", "c20_plane", "c10_plane"],
+)
+def test_runbook_canonical_invocations(
+    args: list[str], expected_in_cmd: list[str]
+) -> None:
+    """Lock in the runbook commands so a refactor to the script cannot
+    silently break the documented operator instructions."""
+    result = _run(["--host", "fake-host", *args, "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    for fragment in expected_in_cmd:
+        assert fragment in result.stdout, (
+            f"missing expected driver flag '{fragment}' in:\n{result.stdout}"
+        )


### PR DESCRIPTION
## Summary

Adds operator tooling for filling the 11 (or 20) missing cells of the heterogeneous Nash phase-diagram preview tracked in #390. Option A from the issue plan: a launch script + runbook that converts the opaque "ssh to a host, source .env, build, tmux, run, rsync back" hand-wave into a single reproducible command, plus a 10-case pytest harness that locks the documented invocations in.

This PR does **not** launch any cluster cells. Per CLAUDE.md, multi-day unattended cluster work is operator-driven, not safe for a builder session to spin up and walk away from. The operator runs ./experiments/scripts/launch_phase_diagram_fill.sh ... from this checkout when they're ready.

## What's in the PR

- `experiments/scripts/launch_phase_diagram_fill.sh` (315 lines, executable)
  - Resolves a remote host from `.env` (`COMPUTE_HOST_PRIMARY` → `_CLUSTER` → `_LAMBDA` → `_GCP`, first non-empty wins), or accepts `--host` explicitly.
  - Verifies SSH reachability with `BatchMode=yes -o ConnectTimeout=5` before consuming compute.
  - Remote bootstrap fixes the two CLAUDE.md gotchas: prepends `/opt/homebrew/bin` + `$HOME/.cargo/bin` to PATH (bare under non-interactive SSH on macOS) and seeds pip into the uv venv before `bucket-brigade-core/build.sh` (build.sh needs pip; uv venvs ship without it).
  - Plumbs `--beta-values`, `--kappa-values`, `--c-values`, `--num-workers` through to `compute_nash_phase_diagram.py`. The `--num-workers` flag landed via #392 today; default is `cpu_count()` so cluster boxes saturate.
  - Synthesizes a compact tmux session name (`nash-fill-b...-k...-c...`) so concurrent fills on the same host don't collide.
  - `--dry-run` prints the full ssh + driver command without executing.
  - On launch, prints monitor/tail/rsync/replot instructions.

- `experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md` (245 lines)
  - Documents which cells are missing and the 18-cell vs 27-cell scope ambiguity in the issue body (acceptance criteria say "18 cells" but the title and body both mention `c=1.0` which adds a 3rd c-plane). Operator picks before launching.
  - Three "Plan A/B/C" launch commands: β=0.1 row gap, c=2.0 plane, c=1.0 plane. With copy-paste blocks, expected wall-clock per plan, and a single-host serial fallback.
  - Host assignment with reliability ranking: prefer alc-2 / alc-6 / alc-9; avoid alc-5 (12.5% reliable) and alc-10 (offline since recovery).
  - Post-run merge: per-host rsync into the canonical `preview/cells/` tree (cells from different hosts land in disjoint `cells/<tag>/` subdirs so rsync is non-destructive), aggregate regeneration, replot.

- `tests/test_launch_phase_diagram_fill.py` (10 cases, all passing)
  - `--help` and `--dry-run` smoke tests
  - Exit-code contracts: 0 on `--help`, 3 when no host resolvable, non-zero on unknown flags
  - `.env` auto-resolution picks `_PRIMARY` over `_CLUSTER`
  - Session-name compaction includes β/κ/c so two operators don't accidentally share a tmux name
  - Three parametrized cases lock in the exact runbook commands for the three plans so a refactor to the script can't silently break the documented operator instructions

## Operator action still required

This is the whole point — the PR is tooling, not results. The acceptance criteria of #390 (all preview cells committed, regenerated PNG with no missing cells, RECOVERY_NOTES updated with the β-vs-κ analysis) can only be met by running the script and waiting ~22 h (3 hosts parallel) to ~50 h (single host serial) for cells to fill. The runbook walks through each step.

This also depends on PR #387 merging (preview/ directory + RECOVERY_NOTES.md live there); the runbook calls that out explicitly. #391 and #392 already merged today.

## Test plan

- [x] `uv run pytest tests/test_launch_phase_diagram_fill.py` — 10 passed
- [x] `uv run pytest tests/test_launch_phase_diagram_fill.py tests/test_plot_phase_diagram.py tests/test_compute_nash_df_precheck.py` — 19 passed, 1 skipped (unrelated to this PR)
- [x] `uv run ruff check tests/test_launch_phase_diagram_fill.py` — clean
- [x] `uv run ruff format --check tests/test_launch_phase_diagram_fill.py` — clean
- [x] `bash -n experiments/scripts/launch_phase_diagram_fill.sh` — syntax OK
- [x] `./experiments/scripts/launch_phase_diagram_fill.sh --host fake-host --beta-values 0.1 --kappa-values 0.5,0.9 --c-values 0.5 --num-workers 16 --dry-run` — emits expected driver command, exit 0
- [x] `./experiments/scripts/launch_phase_diagram_fill.sh --c-values 2.0 --dry-run` with empty .env — exits 3 with documented error
- [x] `./experiments/scripts/launch_phase_diagram_fill.sh --c-values 2.0 --dry-run` with stub .env containing `COMPUTE_HOST_PRIMARY` — resolves correctly
- [ ] (operator-only) end-to-end launch on a real host

Note: there are 30 pre-existing ruff errors and 49 pre-existing format issues on `main` (none in files touched by this PR), so a full-repo `ruff check .` is not clean. Files added by this PR pass both `ruff check` and `ruff format --check`.

Closes #390 (operationally — the AC cells will land via the operator running the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)