### PR TITLE
ops(p3): tier-1 sweep launcher + runbook + matrix doc (#343)

### DIFF
--- a/experiments/p3_specialization/TIER1_LAUNCH_RUNBOOK.md
+++ b/experiments/p3_specialization/TIER1_LAUNCH_RUNBOOK.md
@@ -1,0 +1,245 @@
+# Tier-1 sweep — operator runbook
+
+This runbook is the operator companion to
+[`experiments/scripts/launch_tier1_sweep.sh`](../scripts/launch_tier1_sweep.sh).
+It runs the Tier-1 row of the trainer matrix tracked by
+[issue #343][issue-343] using the per-cell driver shipped in
+[`run_tier1_cell.py`](run_tier1_cell.py) (PR #346) and the post-sweep
+aggregator [`aggregate_tier1.py`](aggregate_tier1.py).
+
+[issue-343]: https://github.com/rjwalters/bucket-brigade/issues/343
+
+The launch script does **not** run any compute locally — it shells into a
+remote host listed in `.env`, pulls latest `main`, builds the Rust
+extension, and starts a detached `tmux` session running each Tier-1 cell
+sequentially. The actual sweep completes hours later inside the tmux
+session; the operator's job is to launch, wait, then rsync and read the
+verdict table.
+
+## Prerequisites
+
+- `.env` at the repo root defines at least one `COMPUTE_HOST_*` alias
+  resolvable via the local `~/.ssh/config` (see `.env.example`).
+- The remote host can build the Rust extension (`cargo`, `rustc`,
+  Python ≥ 3.10, `uv`). The launcher's bootstrap handles the two
+  CLAUDE.md gotchas (bare PATH under non-interactive ssh, missing pip in
+  uv-created venvs) automatically.
+- PR [#346][pr-346] (Tier-1 driver) is on `main`. Verify via
+  `git log main --grep '#346'` — the launcher's remote import-check will
+  fail loudly otherwise.
+
+[pr-346]: https://github.com/rjwalters/bucket-brigade/pull/346
+
+## Scope — what gets launched
+
+By default the launcher runs the canonical Tier-1 launch set defined in
+[`TIER1_SWEEP_MATRIX.md`](TIER1_SWEEP_MATRIX.md):
+
+| Trainers (12)        | Scenario               | Seeds        | Iters | Rollout |
+|----------------------|------------------------|--------------|-------|---------|
+| `mappo`, `high_lambda`, `bc_init_continuation`, `bc_init_high_lambda`, `lola`, `hca`, `influence`, `nhr`, `progress`, `macro_actions`, `reinforce`, `pbt` | `minimal_specialization` | `42 43 44`   | `50`  | `2048`  |
+
+Excluded by default: `ippo` (baseline; rerun adds no info) and `coma`
+(author-deprioritized per #271). Both are re-enableable via `--trainers`.
+
+### Compute estimate
+
+Per the parent issue's budget (~30 min / cell on `COMPUTE_HOST_PRIMARY`):
+
+| Path                    | Cells | Wall-clock @ primary |
+|-------------------------|-------|----------------------|
+| Default launch (12 cells) | 12    | ~6 h                 |
+| + ippo + coma (14 cells)  | 14    | ~7 h                 |
+| Cross-scenario × 3 scenarios | 36    | ~18 h                |
+
+PBT is the slowest individual cell (~1 h+ depending on `--iters-per-gen`);
+budget accordingly if running a single-trainer launch.
+
+## Launch commands (copy-paste)
+
+All commands assume a checkout of `main` (or the merged result of this PR)
+and a working `.env` with at least one `COMPUTE_HOST_*` alias.
+
+### Plan A — default Tier-1 launch (12 cells, ~6 h)
+
+```bash
+./experiments/scripts/launch_tier1_sweep.sh
+```
+
+Auto-resolves the host from `.env` (PRIMARY > CLUSTER > LAMBDA > GCP),
+runs the full launch set on `minimal_specialization`, and ends with
+`aggregate_tier1.py` writing `tier1_verdict.md` + `.json`.
+
+### Plan B — sharded across multiple hosts
+
+Split the launch set across two or three hosts to halve / third wall
+clock. Each shard runs `--skip-aggregate` so the per-host outputs don't
+race on the verdict file; the operator aggregates after rsync.
+
+```bash
+# Host 1 — cheap PPO-family arms (3 cells, ~1.5 h)
+./experiments/scripts/launch_tier1_sweep.sh \
+    --host alc-2 \
+    --trainers mappo,high_lambda,reinforce \
+    --skip-aggregate
+
+# Host 2 — credit-assignment family (4 cells, ~2 h)
+./experiments/scripts/launch_tier1_sweep.sh \
+    --host alc-6 \
+    --trainers lola,hca,influence,coma \
+    --skip-aggregate
+
+# Host 3 — env-side + BC-init + PBT (5 cells, ~3 h)
+./experiments/scripts/launch_tier1_sweep.sh \
+    --host alc-9 \
+    --trainers nhr,progress,macro_actions,bc_init_continuation,bc_init_high_lambda,pbt \
+    --skip-aggregate
+```
+
+After all three hosts finish, rsync each into the same local
+`tier1_runs/` tree and aggregate locally (see "After cells finish"
+below).
+
+Host reliability ranking (from cluster operations): prefer alc-2 /
+alc-6 / alc-9. **Avoid alc-5** (12.5% reliable per
+`reference_cluster_host_reliability.md`). **Avoid alc-10** until
+hardware is replaced.
+
+### Plan C — robustness recheck on a Tier-1 candidate
+
+If Plan A surfaces a trainer with `gap_closed_mean ≥ 0.49`, re-run that
+single trainer on the three-scenario rotation called out in the parent
+issue's "Open questions":
+
+```bash
+./experiments/scripts/launch_tier1_sweep.sh \
+    --trainers <winning_trainer> \
+    --scenarios minimal_specialization,default,chain_reaction \
+    --output-root experiments/p3_specialization/tier1_runs_robustness
+```
+
+A verdict that holds at `≥ 0.49` on all three scenarios closes #343
+with "PPO gap closed-by-trainer". A verdict that survives only on
+`minimal_specialization` is reported in the comment thread and motivates
+Tier-3 cross-product.
+
+### Smoke test (local, ~30 s) — not for verdicts
+
+```bash
+./experiments/scripts/launch_tier1_sweep.sh \
+    --trainers mappo \
+    --num-iterations 1 \
+    --rollout-steps 64 \
+    --dry-run
+```
+
+Confirms argv plumbing without consuming compute. **Never use `--num-iterations
+1 --rollout-steps 64` for verdict-eligible cells** — the trailing-5 mean is
+meaningless at that horizon.
+
+## Monitoring
+
+The launch script prints the tmux session name (e.g. `tier1-sweep-n12-mappo`)
+and log path on success. From local:
+
+```bash
+# Live attach
+ssh <host> -t 'tmux attach -t tier1-sweep-n12-mappo'
+
+# Tail the log
+ssh <host> 'tail -f bucket-brigade/experiments/p3_specialization/tier1_runs/tier1-sweep-n12-mappo.log'
+
+# Per-cell progress (as cells complete, each writes its cell_summary.json)
+ssh <host> 'ls -la bucket-brigade/experiments/p3_specialization/tier1_runs/*/cell_summary.json'
+```
+
+## After cells finish — rsync, aggregate, report
+
+Once **all** assigned plans on **all** hosts have completed, do the merge
+locally:
+
+```bash
+# 1. Pull per-host outputs into the canonical tier1_runs/ tree.
+#    Cells from different hosts land in disjoint <trainer>_<scenario>/
+#    subdirs (Host 1 writes mappo_*/+high_lambda_*/+reinforce_*/, Host 2
+#    writes lola_*/+hca_*/+influence_*/+coma_*/, etc.) so rsync is
+#    non-destructive.
+for host in alc-2 alc-6 alc-9; do
+    rsync -avz "$host:bucket-brigade/experiments/p3_specialization/tier1_runs/" \
+        experiments/p3_specialization/tier1_runs/
+done
+
+# 2. Regenerate the verdict table from the merged cells.
+uv run python experiments/p3_specialization/aggregate_tier1.py \
+    --tier1-root experiments/p3_specialization/tier1_runs
+
+# 3. Inspect.
+cat experiments/p3_specialization/tier1_runs/tier1_verdict.md
+```
+
+The verdict table sorts trainers by `gap_closed_mean` descending and tags
+each with one of:
+
+- `closed` (`>= 0.88`) — stunning near-specialist; PPO failure becomes mysterious
+- `partial_upper` (`[0.49, 0.88)`) — **anti-attractor confirmed**, closes the PPO gap
+- `partial_lower` (`[0.20, 0.49)`) — basin-trap consistent, ≈ PPO ceiling
+- `insufficient` (`< 0.20`) — random-play basin
+- `no_data` — cell missing or all seeds failed
+
+## Reporting the verdict back to #343
+
+Per the parent issue's "Test plan", #343 is closed when at least one
+Tier-1 cell reaches `gap_closed ≥ 0.49`. Comment template:
+
+```markdown
+Tier-1 launch complete (`<sweep tag>`, git SHA `<sha>`).
+
+Verdict table: `experiments/p3_specialization/tier1_runs/tier1_verdict.md`.
+
+Top cell:
+- `<trainer>` — `gap_closed_mean = <value>` (verdict: `<tier>`).
+
+[ ] Above the 0.49 bar → "PPO gap closed-by-trainer", #343 closeable.
+[ ] All below 0.20 → algorithm space alone insufficient, file Tier-2.
+[ ] Mixed → file Tier-3 (top-3 × top-3 cross product).
+```
+
+Then commit the merged `tier1_runs/` tree (the per-cell directories +
+`tier1_verdict.md` + `tier1_verdict.json`) under
+`experiments/p3_specialization/diagnostics/results/issue343_tier1/` or
+similar, mirroring the precedent set by prior diagnostic runs
+(`issue220_obsfix/`, `issue231_mappo/`, etc.).
+
+## Troubleshooting
+
+- **Host unreachable**: the launcher aborts with exit 4 before consuming
+  any compute. Check `ssh -v <host>` and the host's reachability/power.
+- **Unknown trainer**: the launcher aborts with exit 5 before connecting.
+  See the `KNOWN_TRAINERS` block in `launch_tier1_sweep.sh` and the
+  authoritative `TRAINERS` table in `run_tier1_cell.py`.
+- **Build failure on remote**: if `bucket-brigade-core/build.sh` complains
+  about a stale `.so`, the remote venv is missing pip. The script seeds
+  pip automatically; if that fails, ssh in and run
+  `uv pip install pip && bash bucket-brigade-core/build.sh` once by hand.
+- **One cell crashes mid-sweep**: the launcher uses `;` (not `&&`) between
+  cells so a single failure does not abort the remaining sweep. The
+  failed cell still gets a `cell_summary.json` with `verdict_tier =
+  no_data`; the aggregator surfaces that explicitly in the verdict table.
+- **PBT writes wrong-shaped artifacts**: the PBT orchestrator
+  (`run_issue288_pbt.py`) writes per-seed metrics under
+  `seed_<S>/metrics.json` matching the schema the aggregator expects.
+  If the PBT cell shows `n_seeds_completed = 0` despite running, inspect
+  `tier1_runs/pbt_minimal_specialization/seed_*/metrics.json` and check
+  the PBT script's `--output-dir` semantics.
+- **Cross-host clock skew**: rsync uses size+mtime, which can lose a
+  partial cell if the remote clock is significantly off. Use
+  `rsync -avz --checksum` if you suspect this.
+
+## See also
+
+- [Matrix decision doc](TIER1_SWEEP_MATRIX.md) — why these 12 cells.
+- [Driver source](run_tier1_cell.py) — the `TRAINERS` dispatch table.
+- [Aggregator source](aggregate_tier1.py) — verdict ladder + table format.
+- [Parent issue #343](https://github.com/rjwalters/bucket-brigade/issues/343).
+- [Driver PR #346](https://github.com/rjwalters/bucket-brigade/pull/346).
+- [Option-A precedent (Nash phase-diagram)](../nash/phase_diagram/LAUNCH_RUNBOOK.md).

--- a/experiments/p3_specialization/TIER1_SWEEP_MATRIX.md
+++ b/experiments/p3_specialization/TIER1_SWEEP_MATRIX.md
@@ -1,0 +1,187 @@
+# Tier-1 sweep matrix — design decisions for the #343 trainer screen
+
+This document is the concrete decomposition of the Tier-1 row of the
+[`#343`](https://github.com/rjwalters/bucket-brigade/issues/343) sweep
+matrix into the actual cells the operator will launch via
+[`experiments/scripts/launch_tier1_sweep.sh`](../scripts/launch_tier1_sweep.sh).
+
+It complements:
+
+- The trainer / env-mode / scenario tables in the #343 body (the
+  exhaustive enumeration of the design space).
+- [`run_tier1_cell.py`](run_tier1_cell.py) (the uniform per-cell driver
+  shipped in #346) and its 14-row [`TRAINERS`](run_tier1_cell.py) table.
+- [`aggregate_tier1.py`](aggregate_tier1.py) (the post-sweep verdict
+  aggregator shipped in the same PR).
+- [`TIER1_LAUNCH_RUNBOOK.md`](TIER1_LAUNCH_RUNBOOK.md) (the operator's
+  copy-paste companion to the launcher).
+
+This doc answers "which combos should we actually run, and which should we
+defer or exclude, and why?" — the curator's question that the parent issue
+explicitly leaves to a sub-decision. It does **not** define the per-cell
+schema; that lives in `run_tier1_cell.py`'s `build_cell_summary` and the
+parent issue's curator note.
+
+## TL;DR — the Tier-1 launch set
+
+| # | Trainer key (driver) | Scenario              | Seeds       | Iters | Status / notes                          |
+|---|----------------------|-----------------------|-------------|-------|-----------------------------------------|
+| 1 | `mappo`              | minimal_specialization| 42 43 44    | 50    | already verified ≤ IPPO (#208/#232); rerun for matrix completeness |
+| 2 | `high_lambda`        | minimal_specialization| 42 43 44    | 50    | no sweep yet (#282 / #295)              |
+| 3 | `bc_init_continuation`| minimal_specialization| 42 43 44   | 50    | tests if BC fit (gap_closed=0.934) survives PPO continuation (#270/#278) |
+| 4 | `bc_init_high_lambda`| minimal_specialization| 42 43 44    | 50    | composition test (#285/#304); depends on #3 |
+| 5 | `lola`               | minimal_specialization| 42 43 44    | 50    | (#287/#303)                             |
+| 6 | `hca`                | minimal_specialization| 42 43 44    | 50    | (#289/#301)                             |
+| 7 | `influence`          | minimal_specialization| 42 43 44    | 50    | (#290/#302), α=0.5 from driver default  |
+| 8 | `nhr`                | minimal_specialization| 42 43 44    | 50    | (#283/#300), λ=0.5 from driver default  |
+| 9 | `progress`           | minimal_specialization| 42 43 44    | 50    | (#265/#299), coef=1.0 from driver default |
+| 10| `macro_actions`      | minimal_specialization| 42 43 44    | 50    | (#286/#298)                             |
+| 11| `reinforce`          | minimal_specialization| 42 43 44    | 50    | positive-control / off-PPO diagnostic (#273/#320) |
+| 12| `pbt`                | minimal_specialization| 42 43 44    | 50    | orchestrator-shaped (#288/#306); slowest cell |
+
+**Excluded from Tier-1**:
+
+- `ippo` — already the baseline. Re-running adds no new information past
+  `0.182` (#257). Included in `aggregate_tier1.py` output only if a prior
+  cell exists in `tier1_runs/`.
+- `coma` — author-deprioritized per #271 thesis pivot. The driver still
+  dispatches it for completeness, but it is not in the Tier-1 launch set
+  unless the operator explicitly asks for it via the launcher.
+
+## Decision rationale (per axis)
+
+### Trainers — why 12, not 14?
+
+The parent issue enumerates 14 rows. We collapse to 12 in the launch set
+because:
+
+1. **`ippo` is the baseline.** Its `gap_closed ≈ 0.182` is the number every
+   other cell is compared against; running it again is wasted compute.
+   The aggregator (`aggregate_tier1.py`) already treats any IPPO cell in
+   `tier1_runs/` as the comparison row.
+2. **`coma` is deprioritized.** The author note in #271 explicitly pivots
+   away from COMA after the thesis update. Including it in the auto-launch
+   would consume a remote cell (~30 min) on a known-low-value arm.
+   Operators can re-enable it via `--trainers coma` if they want to close
+   the loop empirically.
+
+Everything else gets one cell. The 12 cells are independent; the launcher
+dispatches them sequentially within one tmux session by default (operator
+can shard with `--trainers` for parallel hosts).
+
+### Scenario — why only `minimal_specialization`?
+
+The parent issue lists 6 registered scenarios. Tier-1 runs only on
+`minimal_specialization` because:
+
+1. **It is the canonical P3 substrate** — the entire learnability gap is
+   defined on it (`MINSPEC_RANDOM = 1.067`, `MINSPEC_SPECIALIST = 2.0`,
+   PPO ceiling ≈ `1.237`; see `bucket_brigade/baselines.py`).
+2. **Cross-scenario rotation is a Tier-3 question.** The parent issue's
+   "Open questions" section explicitly asks whether to rotate across
+   `{default, minimal_specialization, chain_reaction}`. That is a
+   robustness check after a candidate is found, not a screen.
+3. **Compute budget.** Adding 2 more scenarios trebles Tier-1 to
+   ~54 hours. That is acceptable, but only if Tier-1 actually produces a
+   candidate worth robustifying. The launcher supports `--scenario` so
+   the rotation can be added post-hoc without a code change.
+
+If Tier-1 produces a trainer with `gap_closed ≥ 0.49`, the natural
+follow-up is to re-launch that trainer with
+`--scenarios default,minimal_specialization,chain_reaction` and require
+the verdict to hold across all three.
+
+### Seeds — why `42 43 44`?
+
+The parent issue's "How to file a Tier-1 sub-issue" template fixes
+`--seeds 42 43 44`. Three seeds is the minimum to compute a meaningful
+mean ± std with the standard deviation calculation in
+`build_cell_summary` (`statistics.pstdev` requires ≥ 2 samples). The
+parent issue committed to 3 seeds in its compute-budget estimate
+(~30 min × 3 seeds × 50 iters per cell).
+
+Five seeds would double the wall-clock to ~60 hours total and is reserved
+for Tier-3 cross-product cells where we want tighter error bars on a
+candidate that already cleared the Tier-1 0.49 bar.
+
+### `--num-iterations 50` — why?
+
+This is the parent issue's commitment in both the compute-budget table
+and the sub-issue template. 50 iterations is enough to clear the
+"first-iteration random play" floor and observe the trailing-5 plateau
+that `gap_closed_mean` is computed on (see
+`run_tier1_cell.TRAILING_N = 5`).
+
+Shorter (e.g. 25) would underreport plateau cells whose trajectories are
+still climbing; longer (e.g. 100) doubles the wall-clock without changing
+verdicts in the historical diagnostic literature (`analyze_270.py`,
+`analyze_282.py`, etc., all use 50–100 iters and converge on the same
+verdict tier).
+
+### `--rollout-steps 2048` — why the driver default?
+
+Driver default from `run_tier1_cell.py` (`p.add_argument("--rollout-steps",
+type=int, default=2048)`). Matches the canonical training budget in
+`experiments/p3_specialization/train.py` and the historical sweeps under
+`experiments/p3_specialization/diagnostics/`. Smoke tests use
+`--rollout-steps 64` to keep wall-clock under 1 s; that is **only** for
+verifying argv plumbing, never for verdict-eligible cells.
+
+## Sub-issue plan — what gets filed downstream
+
+Per the parent issue's "How to file a Tier-1 sub-issue" section, each of
+the 12 launch-set rows should become a thin sub-issue that:
+
+1. Cites this matrix doc.
+2. Names a single trainer (the value of `--trainer`).
+3. References the launch command from `TIER1_LAUNCH_RUNBOOK.md`.
+4. Lists the verdict thresholds the aggregator will apply.
+
+The sub-issues are uniform-shaped, so a single Curator pass can file all
+12 from the trainer keys in the table above. We deliberately do **not**
+file them in this PR — the parent issue is the meta-tracker, the launcher
++ runbook + matrix doc are the buildable artifacts, and the per-trainer
+sub-issues are the next decomposition step (handled by Curator after
+review).
+
+## Excluded combos and what to do if Tier-1 fails
+
+If **all 12 Tier-1 cells land with `gap_closed_mean < 0.20`**, the
+algorithm space alone is insufficient. The parent issue's decision
+framework then escalates to **Tier-2** (env-mode screens on
+`minimal_specialization` with IPPO as the trainer) — a separate launcher
+will be authored if that path is needed. The trainer-only matrix is
+self-contained; this PR does not block Tier-2.
+
+If **some Tier-1 cells land in `[0.20, 0.49)` but none above 0.49**, the
+parent issue specifies **Tier-3** (top-3 × top-3 cross product). That,
+too, is a separate launcher. The hooks in `aggregate_tier1.py` (sorting
+by `gap_closed_mean` desc, surfacing top cells) are designed to feed that
+selection directly.
+
+If **any Tier-1 cell lands `gap_closed_mean ≥ 0.49`**, declare "PPO gap
+closed-by-trainer" and the parent issue can be closed with the verdict
+ladder applied. No Tier-2 / Tier-3 launches are needed.
+
+## What this PR does *not* do
+
+- It does **not** launch the sweep. Per `CLAUDE.md`, multi-hour cluster
+  work is operator-driven, not safe for an autonomous Builder session to
+  start and walk away from.
+- It does **not** file the 12 Tier-1 sub-issues. That is the natural next
+  Curator action once this PR merges.
+- It does **not** modify `run_tier1_cell.py` or `aggregate_tier1.py`. The
+  driver + aggregator shipped in #346 are sufficient for the launch set
+  above; the launcher only orchestrates them on a remote host.
+- It does **not** define Tier-2 or Tier-3 launchers. Those are filed as
+  follow-ups if and only if Tier-1 fails to produce a `≥ 0.49` cell.
+
+## References
+
+- Parent issue: [#343](https://github.com/rjwalters/bucket-brigade/issues/343) (meta).
+- Driver issue: [#345](https://github.com/rjwalters/bucket-brigade/issues/345) / PR [#346](https://github.com/rjwalters/bucket-brigade/pull/346).
+- Verdict ladder source: [`experiments/p3_specialization/diagnostics/random_mlp_search.py`](diagnostics/random_mlp_search.py) (`_classify_verdict`).
+- Baseline constants: [`bucket_brigade/baselines.py`](../../bucket_brigade/baselines.py).
+- Launcher: [`experiments/scripts/launch_tier1_sweep.sh`](../scripts/launch_tier1_sweep.sh).
+- Runbook: [`TIER1_LAUNCH_RUNBOOK.md`](TIER1_LAUNCH_RUNBOOK.md).
+- Option-A precedent (Nash phase-diagram fill): PR [#393](https://github.com/rjwalters/bucket-brigade/pull/393).

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# Launch the Tier-1 sweep matrix (issue #343 / driver #346) on a remote
+# host. Dispatches experiments/p3_specialization/run_tier1_cell.py once per
+# trainer, then runs aggregate_tier1.py to produce the verdict table.
+#
+# The script does NOT compute anything locally. It only:
+#   1. Reads $COMPUTE_HOST_* aliases from .env to resolve a target host
+#      (unless --host is passed explicitly).
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts
+#      a detached tmux session running the Tier-1 cells sequentially.
+#   4. Prints monitor / rsync / aggregate instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual cells fill over
+# hours inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Auto-resolve host from .env, run the full Tier-1 launch set (12 cells)
+#   ./experiments/scripts/launch_tier1_sweep.sh
+#
+#   # Explicit host, only the cheap PPO-family arms (3 cells)
+#   ./experiments/scripts/launch_tier1_sweep.sh \
+#       --host alc-2 \
+#       --trainers mappo,high_lambda,reinforce
+#
+#   # Add COMA back in (deprioritized but useful for the full grid)
+#   ./experiments/scripts/launch_tier1_sweep.sh \
+#       --trainers mappo,high_lambda,coma,lola
+#
+#   # Cross-scenario robustness check after a candidate emerges
+#   ./experiments/scripts/launch_tier1_sweep.sh \
+#       --trainers bc_init_continuation \
+#       --scenarios minimal_specialization,default,chain_reaction
+#
+#   # Dry-run prints the ssh + driver commands without launching anything
+#   ./experiments/scripts/launch_tier1_sweep.sh --trainers mappo --dry-run
+#
+# See experiments/p3_specialization/TIER1_LAUNCH_RUNBOOK.md for the
+# canonical host assignments and merge / aggregate procedure.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Canonical Tier-1 launch set (see TIER1_SWEEP_MATRIX.md). 12 of the 14
+# trainers in the parent issue's table — ippo (baseline) and coma
+# (author-deprioritized per #271) are excluded by default but can be
+# re-enabled via --trainers explicitly.
+DEFAULT_TRAINERS="mappo,high_lambda,bc_init_continuation,bc_init_high_lambda,lola,hca,influence,nhr,progress,macro_actions,reinforce,pbt"
+DEFAULT_SCENARIOS="minimal_specialization"
+DEFAULT_SEEDS="42 43 44"
+DEFAULT_NUM_ITERATIONS="50"
+DEFAULT_ROLLOUT_STEPS="2048"
+DEFAULT_OUTPUT_ROOT="experiments/p3_specialization/tier1_runs"
+DEFAULT_SESSION_PREFIX="tier1-sweep"
+
+HOST=""
+TRAINERS="$DEFAULT_TRAINERS"
+SCENARIOS="$DEFAULT_SCENARIOS"
+SEEDS="$DEFAULT_SEEDS"
+NUM_ITERATIONS="$DEFAULT_NUM_ITERATIONS"
+ROLLOUT_STEPS="$DEFAULT_ROLLOUT_STEPS"
+OUTPUT_ROOT="$DEFAULT_OUTPUT_ROOT"
+SESSION_NAME=""
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+SKIP_AGGREGATE=0
+
+print_usage() {
+    sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --trainers)
+            TRAINERS="$2"
+            shift 2
+            ;;
+        --scenarios)
+            SCENARIOS="$2"
+            shift 2
+            ;;
+        --seeds)
+            SEEDS="$2"
+            shift 2
+            ;;
+        --num-iterations)
+            NUM_ITERATIONS="$2"
+            shift 2
+            ;;
+        --rollout-steps)
+            ROLLOUT_STEPS="$2"
+            shift 2
+            ;;
+        --output-root)
+            OUTPUT_ROOT="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        --skip-aggregate)
+            # Skip the post-sweep aggregate_tier1.py call. Useful when
+            # sharding across multiple hosts — the operator aggregates
+            # after the rsync-merge step.
+            SKIP_AGGREGATE=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate trainer list against the driver's known names
+# ---------------------------------------------------------------------------
+
+# Source of truth: experiments/p3_specialization/run_tier1_cell.py TRAINERS
+# table. Listed here verbatim so the launcher can fail fast on a typo
+# before consuming any remote compute. Keep in sync with that file.
+KNOWN_TRAINERS=(
+    ippo
+    mappo
+    high_lambda
+    bc_init_continuation
+    bc_init_high_lambda
+    lola
+    coma
+    hca
+    influence
+    nhr
+    progress
+    macro_actions
+    reinforce
+    pbt
+)
+
+is_known_trainer() {
+    local name="$1"
+    for t in "${KNOWN_TRAINERS[@]}"; do
+        if [[ "$t" == "$name" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Parse the comma-separated trainer list into an array and check every entry.
+IFS=',' read -r -a TRAINER_ARRAY <<<"$TRAINERS"
+for tr in "${TRAINER_ARRAY[@]}"; do
+    if ! is_known_trainer "$tr"; then
+        echo "ERROR: unknown trainer '$tr'" >&2
+        echo "       Known trainers: ${KNOWN_TRAINERS[*]}" >&2
+        echo "       Source of truth: experiments/p3_specialization/run_tier1_cell.py" >&2
+        exit 5
+    fi
+done
+
+IFS=',' read -r -a SCENARIO_ARRAY <<<"$SCENARIOS"
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+
+if [[ -z "$HOST" ]]; then
+    HOST=$(resolve_host_from_env)
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build per-cell driver commands + tmux session name
+# ---------------------------------------------------------------------------
+
+if [[ -z "$SESSION_NAME" ]]; then
+    # Compact tag so two concurrent launches on the same host don't collide.
+    # Use the trainer count + first trainer name as a stable fingerprint.
+    tag="n${#TRAINER_ARRAY[@]}-${TRAINER_ARRAY[0]}"
+    SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${tag}"
+fi
+
+# Compose the per-cell driver invocations as a sequential shell-safe string.
+# Each cell runs to completion before the next starts — the driver's
+# subprocess plumbing already streams output, so tee'ing the whole tmux
+# session captures everything in one log.
+DRIVER_CMDS=""
+for sc in "${SCENARIO_ARRAY[@]}"; do
+    for tr in "${TRAINER_ARRAY[@]}"; do
+        cell_cmd="uv run python experiments/p3_specialization/run_tier1_cell.py"
+        cell_cmd+=" --trainer '$tr'"
+        cell_cmd+=" --scenario '$sc'"
+        cell_cmd+=" --seeds $SEEDS"
+        cell_cmd+=" --num-iterations $NUM_ITERATIONS"
+        cell_cmd+=" --rollout-steps $ROLLOUT_STEPS"
+        cell_cmd+=" --output-root '$OUTPUT_ROOT'"
+        if [[ -z "$DRIVER_CMDS" ]]; then
+            DRIVER_CMDS="$cell_cmd"
+        else
+            # Use `;` not `&&` so one failing cell doesn't abort the sweep —
+            # the driver writes cell_summary.json with verdict=no_data on
+            # failure and we want the aggregator to surface that, not stop.
+            DRIVER_CMDS+=" ; $cell_cmd"
+        fi
+    done
+done
+
+if [[ "$SKIP_AGGREGATE" -eq 0 ]]; then
+    AGG_CMD="uv run python experiments/p3_specialization/aggregate_tier1.py --tier1-root '$OUTPUT_ROOT'"
+    DRIVER_CMDS+=" ; $AGG_CMD"
+fi
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default.
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the import before consuming a tmux session for a multi-hour run.
+uv run python -c "from experiments.p3_specialization.run_tier1_cell import TRAINERS; print(f'driver ok, {len(TRAINERS)} trainers')"
+
+mkdir -p $OUTPUT_ROOT
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && ( $DRIVER_CMDS ) 2>&1 | tee -a '$OUTPUT_ROOT/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_ROOT/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+echo "===================================================================="
+echo "Tier-1 sweep launch (issue #343)"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output root:    $OUTPUT_ROOT    (on remote)"
+echo "Trainers:       $TRAINERS    (${#TRAINER_ARRAY[@]} cells per scenario)"
+echo "Scenarios:      $SCENARIOS"
+echo "Seeds:          $SEEDS"
+echo "Num iterations: $NUM_ITERATIONS"
+echo "Rollout steps:  $ROLLOUT_STEPS"
+echo "Aggregate:      $([ "$SKIP_AGGREGATE" -eq 0 ] && echo "yes (aggregate_tier1.py)" || echo "no (--skip-aggregate)")"
+echo ""
+echo "Per-cell driver commands (to be run inside tmux on remote, sequentially):"
+# Pretty-print one per line for the operator's sanity check.
+echo "$DRIVER_CMDS" | tr ';' '\n' | sed 's/^ *//; s/^/  /'
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_ROOT}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done, rsync results back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_ROOT}/ ${OUTPUT_ROOT}/"
+echo ""
+echo "  # Regenerate the verdict table locally once results are back:"
+echo "  uv run python experiments/p3_specialization/aggregate_tier1.py \\"
+echo "      --tier1-root ${OUTPUT_ROOT}   # writes tier1_verdict.md + .json"
+echo "===================================================================="

--- a/tests/test_launch_tier1_sweep.py
+++ b/tests/test_launch_tier1_sweep.py
@@ -1,0 +1,459 @@
+"""Tests for ``experiments/scripts/launch_tier1_sweep.sh``.
+
+The script is the operator-launch wrapper for the Tier-1 row of the #343
+trainer matrix. Because it shells out to ``ssh`` to bootstrap a remote
+tmux session, we cannot exercise the live-run path in unit tests. The
+``--dry-run`` flag exists exactly so the wiring (arg parsing, host
+resolution, trainer validation, per-cell driver-command synthesis,
+session-name compaction) can be asserted without touching the network.
+
+These tests cover:
+
+* operator-facing failure modes (unknown trainer, missing host)
+* host resolution from .env
+* default launch set (12 cells, one per trainer in the launch set)
+* sharding by --trainers
+* multi-scenario expansion
+* --skip-aggregate
+* canonical runbook invocations from TIER1_LAUNCH_RUNBOOK.md
+
+We also assert that the launcher's KNOWN_TRAINERS list stays in sync with
+the driver's TRAINERS dict in ``run_tier1_cell.py``. A drift between the
+two would mean a typo in the launcher silently rejects (or accepts) a
+trainer the driver knows about.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_tier1_sweep.sh"
+DRIVER = REPO_ROOT / "experiments" / "p3_specialization" / "run_tier1_cell.py"
+RUNBOOK = REPO_ROOT / "experiments" / "p3_specialization" / "TIER1_LAUNCH_RUNBOOK.md"
+MATRIX_DOC = REPO_ROOT / "experiments" / "p3_specialization" / "TIER1_SWEEP_MATRIX.md"
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+# The dry-run stdout contains the per-cell commands twice: once in the
+# pretty-printed plan block (two-space-indented, one cell per line) and
+# once inside the embedded REMOTE_BOOTSTRAP script (concatenated with `;`
+# inside the tmux invocation). For test assertions about cell count we
+# only count the pretty-printed lines because that's the operator-facing
+# representation that must match the plan.
+_PLAN_LINE_RE = re.compile(
+    r"^\s{2}uv run python experiments/p3_specialization/run_tier1_cell\.py",
+    re.MULTILINE,
+)
+
+
+def _count_plan_cells(stdout: str) -> int:
+    """Count cells in the pretty-printed plan block (not the bootstrap)."""
+    return len(_PLAN_LINE_RE.findall(stdout))
+
+
+# ---------------------------------------------------------------------------
+# Existence + executability
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_runbook_and_matrix_doc_exist() -> None:
+    """The companion docs must be present so the runbook references
+    resolve from the launcher's --help output."""
+    assert RUNBOOK.exists(), f"runbook missing: {RUNBOOK}"
+    assert MATRIX_DOC.exists(), f"matrix doc missing: {MATRIX_DOC}"
+
+
+# ---------------------------------------------------------------------------
+# --help / arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check that the canonical flags appear in the docstring usage
+    # examples (matches the pattern used by launch_phase_diagram_fill.sh's
+    # test_help_flag_prints_usage_and_exits_zero — only the flags actually
+    # shown in usage examples are asserted, not every parsed flag).
+    for flag in (
+        "--host",
+        "--trainers",
+        "--scenarios",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(
+        ["--host", "x", "--not-a-flag", "y", "--trainers", "mappo", "--dry-run"]
+    )
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+def test_unknown_trainer_exits_with_clear_error() -> None:
+    """An unknown trainer name must abort BEFORE consuming any compute."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "definitely-not-a-trainer",
+            "--dry-run",
+            "--skip-connectivity-check",
+        ]
+    )
+    assert result.returncode == 5, (
+        f"expected exit 5 (unknown trainer), got {result.returncode}: {result.stderr}"
+    )
+    assert "unknown trainer" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Host resolution
+# ---------------------------------------------------------------------------
+
+
+def test_missing_host_with_no_env_errors_cleanly() -> None:
+    """Without --host and without a .env, the script must fail with exit 3."""
+    env_path = REPO_ROOT / ".env"
+    backup = None
+    if env_path.exists():
+        backup = env_path.read_bytes()
+        env_path.unlink()
+    try:
+        result = _run(["--trainers", "mappo", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+
+    assert result.returncode == 3, (
+        f"expected exit 3 (no host), got {result.returncode}: {result.stderr}"
+    )
+    assert "no host specified" in result.stderr.lower()
+
+
+def test_dry_run_resolves_host_from_env() -> None:
+    """When --host is omitted, the script must pick the first non-empty
+    COMPUTE_HOST_* from .env using the documented priority (PRIMARY first)."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    try:
+        env_path.write_text(
+            textwrap.dedent(
+                """\
+                COMPUTE_HOST_PRIMARY=resolved-primary
+                COMPUTE_HOST_CLUSTER=resolved-cluster
+                """
+            )
+        )
+        result = _run(["--trainers", "mappo", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+        elif env_path.exists():
+            env_path.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved-primary" in result.stdout
+    # CLUSTER should NOT win when PRIMARY is set.
+    assert "resolved-cluster" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Per-cell driver command synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_with_single_trainer_emits_one_driver_command() -> None:
+    """A single-trainer dry-run must emit exactly one run_tier1_cell.py
+    invocation with the requested flags."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "mappo",
+            "--num-iterations",
+            "25",
+            "--rollout-steps",
+            "512",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # The header echoes the resolved trainer + iteration values.
+    assert "mappo" in out
+    assert "Num iterations: 25" in out
+    assert "Rollout steps:  512" in out
+    # Exactly one cell command + aggregator. The pretty-printed block has
+    # one driver line per cell:
+    assert _count_plan_cells(out) == 1
+    assert "--trainer 'mappo'" in out
+    assert "--scenario 'minimal_specialization'" in out
+    assert "--seeds 42 43 44" in out
+    assert "--num-iterations 25" in out
+    assert "--rollout-steps 512" in out
+    # Aggregator runs by default.
+    assert "aggregate_tier1.py" in out
+    # Dry-run banner so an operator never confuses it with a real launch.
+    assert "dry-run" in out.lower()
+
+
+def test_dry_run_multi_trainer_emits_one_command_per_trainer() -> None:
+    """A comma-separated trainer list must produce one driver command per
+    trainer (× per scenario)."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "mappo,high_lambda,reinforce",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert _count_plan_cells(out) == 3
+    for tr in ("mappo", "high_lambda", "reinforce"):
+        assert f"--trainer '{tr}'" in out
+
+
+def test_dry_run_multi_scenario_expands_cartesian_product() -> None:
+    """trainers × scenarios is a Cartesian product, not a zip."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "mappo,high_lambda",
+            "--scenarios",
+            "minimal_specialization,default",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # 2 trainers × 2 scenarios = 4 cells.
+    assert _count_plan_cells(out) == 4
+    for tr in ("mappo", "high_lambda"):
+        for sc in ("minimal_specialization", "default"):
+            assert f"--trainer '{tr}'" in out
+            assert f"--scenario '{sc}'" in out
+
+
+def test_default_launch_set_has_twelve_cells() -> None:
+    """Running with no --trainers must produce the 12-cell default launch
+    set documented in TIER1_SWEEP_MATRIX.md."""
+    result = _run(["--host", "fake-host", "--dry-run", "--skip-connectivity-check"])
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # 12 trainers × 1 scenario = 12 cells.
+    assert _count_plan_cells(out) == 12, (
+        f"expected 12 default cells, got {_count_plan_cells(out)}"
+    )
+    # ippo and coma must be excluded by default per the matrix doc.
+    assert "--trainer 'ippo'" not in out
+    assert "--trainer 'coma'" not in out
+
+
+def test_skip_aggregate_omits_aggregator_call() -> None:
+    """--skip-aggregate must drop the aggregate_tier1.py invocation so
+    sharded multi-host runs don't race on the verdict file."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "mappo",
+            "--skip-aggregate",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "aggregate_tier1.py" not in out
+    # The header should also confirm aggregation is off.
+    assert re.search(r"Aggregate:\s+no", out)
+
+
+def test_session_name_includes_trainer_count_and_first_trainer() -> None:
+    """Session-name compaction must include trainer count + first trainer
+    so concurrent launches on the same host don't collide."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--trainers",
+            "lola,hca,influence",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    # Expect "tier1-sweep-n3-lola".
+    assert "tier1-sweep-n3-lola" in result.stdout, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Canonical runbook invocations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "args,expected_cells,must_contain",
+    [
+        # Plan A — default Tier-1 launch (12 cells)
+        (
+            [],
+            12,
+            ["--trainer 'mappo'", "--trainer 'pbt'", "aggregate_tier1.py"],
+        ),
+        # Plan B shard 1 — cheap PPO-family arms (3 cells, --skip-aggregate)
+        (
+            ["--trainers", "mappo,high_lambda,reinforce", "--skip-aggregate"],
+            3,
+            ["--trainer 'mappo'", "--trainer 'high_lambda'", "--trainer 'reinforce'"],
+        ),
+        # Plan B shard 2 — credit-assignment family (4 cells, --skip-aggregate,
+        # includes coma which is normally excluded)
+        (
+            ["--trainers", "lola,hca,influence,coma", "--skip-aggregate"],
+            4,
+            ["--trainer 'lola'", "--trainer 'coma'"],
+        ),
+        # Plan C — robustness recheck on a single trainer across 3 scenarios
+        (
+            [
+                "--trainers",
+                "bc_init_continuation",
+                "--scenarios",
+                "minimal_specialization,default,chain_reaction",
+            ],
+            3,
+            [
+                "--trainer 'bc_init_continuation'",
+                "--scenario 'default'",
+                "--scenario 'chain_reaction'",
+            ],
+        ),
+    ],
+    ids=[
+        "plan_A_default",
+        "plan_B_ppo_shard",
+        "plan_B_credit_shard",
+        "plan_C_robustness",
+    ],
+)
+def test_runbook_canonical_invocations(
+    args: list[str], expected_cells: int, must_contain: list[str]
+) -> None:
+    """Lock in the runbook commands so a refactor to the script cannot
+    silently break the documented operator instructions."""
+    result = _run(["--host", "fake-host", *args, "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    actual = _count_plan_cells(out)
+    assert actual == expected_cells, (
+        f"expected {expected_cells} cells for {args}, got {actual}:\n{out}"
+    )
+    for fragment in must_contain:
+        assert fragment in out, f"missing expected fragment '{fragment}' in:\n{out}"
+
+
+# ---------------------------------------------------------------------------
+# Drift check: launcher's KNOWN_TRAINERS == driver's TRAINERS keys
+# ---------------------------------------------------------------------------
+
+
+def _launcher_known_trainers() -> set[str]:
+    """Parse the KNOWN_TRAINERS bash array out of the launch script.
+
+    We do this with a regex rather than execing bash because the value is
+    a small literal list and we want a hermetic test that doesn't depend
+    on the bash version.
+    """
+    text = SCRIPT.read_text()
+    m = re.search(r"KNOWN_TRAINERS=\(\s*([^)]+)\s*\)", text, re.DOTALL)
+    assert m is not None, "could not find KNOWN_TRAINERS array in launcher"
+    block = m.group(1)
+    # Strip comments and whitespace, split into tokens.
+    tokens = [
+        line.split("#", 1)[0].strip()
+        for line in block.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    # Each non-empty token is one trainer name.
+    return {t for t in tokens if t}
+
+
+def _driver_trainers() -> set[str]:
+    """Import the driver's TRAINERS dict via a subprocess so we don't need
+    numpy / torch in the test interpreter."""
+    out = subprocess.run(
+        [
+            "python",
+            "-c",
+            (
+                "import sys; sys.path.insert(0, '.'); "
+                "from experiments.p3_specialization.run_tier1_cell import TRAINERS; "
+                "print('\\n'.join(sorted(TRAINERS)))"
+            ),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        pytest.skip(
+            f"cannot import run_tier1_cell.TRAINERS in test env "
+            f"(stderr: {out.stderr.strip()}); skipping drift check"
+        )
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def test_launcher_known_trainers_matches_driver_trainers() -> None:
+    """The launcher's KNOWN_TRAINERS validation list must match the
+    driver's TRAINERS dict exactly. Drift means either a typo in the
+    launcher silently rejects a real trainer, or accepts a fake one."""
+    launcher = _launcher_known_trainers()
+    driver = _driver_trainers()
+    assert launcher == driver, (
+        f"KNOWN_TRAINERS drift detected:\n"
+        f"  in launcher but not driver: {launcher - driver}\n"
+        f"  in driver but not launcher: {driver - launcher}"
+    )


### PR DESCRIPTION
## Summary

Operator tooling for the Tier-1 row of the #343 trainer matrix. Wraps the per-cell driver from PR #346 (`run_tier1_cell.py`) into a single launch command that bootstraps a remote tmux session, runs the 12-cell default launch set sequentially, and finishes with `aggregate_tier1.py` to produce the verdict table.

This PR is **tooling, not results**. Per CLAUDE.md, multi-hour cluster work is operator-driven, not safe for an autonomous Builder session to spawn and walk away from. The operator runs the script when ready; the cells fill over ~6 h on `COMPUTE_HOST_PRIMARY` (or ~2 h sharded across three hosts).

Follows the Option-A pattern established by PR #393 (Nash phase-diagram gap-fill).

## What is in the PR

- **`experiments/scripts/launch_tier1_sweep.sh`** (~300 lines, executable)
  - Resolves remote host from `.env` (`COMPUTE_HOST_PRIMARY` -> `_CLUSTER` -> `_LAMBDA` -> `_GCP`, first non-empty wins), or accepts `--host`.
  - Verifies SSH reachability with `BatchMode=yes -o ConnectTimeout=5` before consuming any compute.
  - Remote bootstrap fixes the two CLAUDE.md gotchas (bare PATH under non-interactive ssh on macOS; missing pip in uv-created venvs).
  - Validates `--trainers` against an explicit `KNOWN_TRAINERS` list (kept in sync with `run_tier1_cell.TRAINERS` via a drift test) so typos fail fast (exit 5) before launching.
  - Plumbs `--trainers` (comma-separated), `--scenarios` (Cartesian-product expansion), `--seeds`, `--num-iterations`, `--rollout-steps`, and `--output-root` through to per-cell invocations of `run_tier1_cell.py`.
  - Compact tmux session-name tag (`tier1-sweep-n<count>-<first>`) so two concurrent shards on the same host do not collide.
  - `--skip-aggregate` for sharded multi-host runs (the operator aggregates locally after rsync, not on each host).
  - `--dry-run` prints the full ssh + per-cell driver commands without executing.
  - Inter-cell separator is `;` (not `&&`) so one failing cell does not abort the remaining sweep; the failed cell still gets a `cell_summary.json` with `verdict_tier = no_data`, which the aggregator surfaces.

- **`experiments/p3_specialization/TIER1_LAUNCH_RUNBOOK.md`** (~250 lines)
  - Three operator plans: A (single-host default, 12 cells / ~6 h), B (sharded across alc-2 / alc-6 / alc-9), C (cross-scenario robustness recheck on a Tier-1 winner).
  - Host reliability ranking from cluster operations (prefer alc-2 / alc-6 / alc-9; avoid alc-5 12.5%-reliable, avoid alc-10 offline).
  - Post-run rsync-merge + aggregate steps, with the verdict-tier interpretation table and a comment template for reporting back to #343.

- **`experiments/p3_specialization/TIER1_SWEEP_MATRIX.md`** (~140 lines)
  - Per-axis decisions: why 12 of 14 trainers (ippo is the baseline; coma is author-deprioritized per #271), why only `minimal_specialization` for Tier-1, why `42 43 44`, why 50 iters, why default `--rollout-steps 2048`.
  - Excluded-combo policy: what to do if Tier-1 surfaces no `>= 0.49` cells (escalate to Tier-2 env-mode screens), what to do if all in `[0.20, 0.49)` (escalate to Tier-3 cross-product), what to do if one >= 0.49 (declare "PPO gap closed-by-trainer" and close the issue).

- **`tests/test_launch_tier1_sweep.py`** (18 tests, all passing)
  - `--help`, `--dry-run`, unknown-flag, unknown-trainer exit-code contracts.
  - `.env` auto-resolution picks `_PRIMARY` over `_CLUSTER`.
  - Per-cell driver-command synthesis: single-trainer, multi-trainer, multi-scenario Cartesian product.
  - Default launch set is exactly 12 cells (ippo + coma excluded).
  - `--skip-aggregate` drops the aggregator call.
  - Session-name compaction includes trainer count + first trainer.
  - Parametrized canonical-invocation tests lock in Plans A, B shard 1, B shard 2, and C from the runbook.
  - Drift check: launcher's `KNOWN_TRAINERS` array is asserted equal to the driver's `TRAINERS` dict keys via a subprocess import (the test gracefully skips if the test env can't import the driver, which happens when bucket-brigade-core is not built).

## Acceptance criteria verification (parent issue #343 test plan)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| #345 (Tier-1 driver) landed | ok | PR #346 merged |
| Sub-issues filed for each Tier-1 sweep cell | operator-next | Curator pass after this PR merges; this PR provides the matrix doc + runbook template to file them from |
| At least one sub-issue has run and produced a verdict | operator-next | requires `COMPUTE_HOST_PRIMARY` run (~30 min/cell) |
| Matrix table updated with at least one "ran" status | operator-next | same |
| If any Tier-1 trainer reaches `gap_closed >= 0.49`, close with verdict | operator-next | runbook documents the comment template |

The PR closes #343 **operationally** — the per-trainer sub-issue cycle is the next decomposition step (Curator), the launches are the operator's, and the verdict comments tied to those launches are what ultimately resolve the meta-tracker.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/test_launch_tier1_sweep.py -v` -> 18 passed
- [x] `uv run --with pytest python -m pytest tests/test_launch_tier1_sweep.py tests/test_launch_phase_diagram_fill.py tests/test_tier1_driver.py -q` -> 52 passed (no regression in adjacent suites)
- [x] `uv run --with ruff ruff check tests/test_launch_tier1_sweep.py` -> clean
- [x] `uv run --with ruff ruff format --check tests/test_launch_tier1_sweep.py` -> clean
- [x] `bash -n experiments/scripts/launch_tier1_sweep.sh` -> syntax OK
- [x] `./experiments/scripts/launch_tier1_sweep.sh --host fake-host --trainers mappo,reinforce --dry-run --skip-connectivity-check` -> emits expected per-cell driver commands + aggregator call, exit 0
- [x] `./experiments/scripts/launch_tier1_sweep.sh --trainers definitely-not-a-trainer --dry-run --skip-connectivity-check --host fake` -> exits 5 with "unknown trainer" error before connecting
- [x] `./experiments/scripts/launch_tier1_sweep.sh --trainers mappo --dry-run` with empty .env -> exits 3 with documented "no host specified" error
- [ ] (operator-only) end-to-end launch on `COMPUTE_HOST_PRIMARY`

## Notes / caveats

- The 9 pre-existing collection errors in adjacent test files (`test_heterogeneous_oracle_*`, `test_p3_*`, `test_joint_trainer`, etc.) are all `ModuleNotFoundError: No module named 'bucket_brigade_core'` — they require the Rust extension to be built in the test venv. Not caused by this PR; confirmed by running them on `main` HEAD without my changes.
- The launcher's `KNOWN_TRAINERS` array is duplicated from the driver's `TRAINERS` dict. The drift test (`test_launcher_known_trainers_matches_driver_trainers`) catches any divergence; if the driver gains a trainer, both the launcher list and the matrix doc need an update.

Closes #343