### PR TITLE
feat(p3): asymmetry-aware PPO arm + sweep launcher (#386)

### DIFF
--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -289,6 +289,29 @@ class JointPPOTrainer:
             estimate the counterfactual marginal
             ``E_{a'_i ~ pi_i} [pi_j(. | obs_j_cf(a'_i))]``. Default 4
             matches the Jaques paper. Ignored when ``influence_coef == 0``.
+        per_agent_init_seed_offset: Issue #386 — asymmetry-aware ("HetGPPO"
+            style) init. When ``None`` (default), the legacy code path is
+            preserved bit-for-bit: ``torch.manual_seed(seed)`` is called once
+            and all N :class:`PolicyNetwork` instances are constructed off
+            the same RNG stream — they end up with *different* parameter
+            tensors (each ``nn.Linear`` consumes RNG state in order) but
+            their starting points are correlated through that shared stream.
+            When set to a positive integer ``K``, each agent ``i`` is
+            initialized under its own seed ``seed + i * K`` so per-position
+            policies start from maximally-distinct random inits. This is the
+            architectural commitment to per-position parameter heterogeneity
+            that HetGPPO (Bettini et al. AAMAS 2023, arXiv:2301.07137)
+            recommends as the simplest "drop parameter sharing" baseline:
+            the trainer *already* maintains N independent policies + N
+            independent optimizers (see ``self.policies`` and
+            ``self.optimizers`` below), but a shared RNG stream at init can
+            still bias the basin found by SGD. ``per_agent_init_seed_offset``
+            forces the basin choice to be position-dependent from step 0 by
+            removing the shared-stream coupling. Requires ``seed is not None``
+            — raises ``ValueError`` otherwise (offsetting a non-deterministic
+            seed produces a non-reproducible trainer). Recommended value:
+            ``1000`` (large enough that the per-agent RNG streams do not
+            overlap for any reasonable ``num_agents``).
     """
 
     def __init__(
@@ -320,6 +343,7 @@ class JointPPOTrainer:
         hindsight_ratio_clip: float = 10.0,
         influence_coef: float = 0.0,
         influence_mc_samples: int = 4,
+        per_agent_init_seed_offset: Optional[int] = None,
         obs_auditor: Optional[ObsAuditor] = None,
     ):
         self.env_fn = env_fn
@@ -455,20 +479,68 @@ class JointPPOTrainer:
 
         self.device = torch.device(device)
 
+        # Issue #386 — asymmetry-aware ("HetGPPO") init. Validate the
+        # offset knob before consuming RNG state so a misconfigured cell
+        # fails fast (rather than silently producing a non-reproducible
+        # trainer that happens to "work" on the first seed). Stored on
+        # ``self`` so downstream code paths (e.g. tests, save/load) can
+        # surface the configuration.
+        if per_agent_init_seed_offset is not None:
+            if seed is None:
+                raise ValueError(
+                    "per_agent_init_seed_offset requires seed to be set: "
+                    "offsetting a non-deterministic seed produces a "
+                    "non-reproducible trainer. Pass seed=<int> alongside."
+                )
+            if not isinstance(per_agent_init_seed_offset, int):
+                raise TypeError(
+                    "per_agent_init_seed_offset must be an int, got "
+                    f"{type(per_agent_init_seed_offset).__name__}"
+                )
+            if per_agent_init_seed_offset <= 0:
+                raise ValueError(
+                    "per_agent_init_seed_offset must be > 0, got "
+                    f"{per_agent_init_seed_offset!r}. Use None to disable."
+                )
+        self.per_agent_init_seed_offset = per_agent_init_seed_offset
+
         if seed is not None:
             torch.manual_seed(seed)
             np.random.seed(seed)
 
-        self.policies = nn.ModuleList(
-            [
-                PolicyNetwork(
-                    obs_dim=obs_dim,
-                    action_dims=action_dims,
-                    hidden_size=hidden_size,
+        # Issue #386: when ``per_agent_init_seed_offset`` is set, reseed the
+        # global torch RNG to ``seed + i * offset`` *before* each policy is
+        # constructed so the per-position parameter draws are independent.
+        # When ``None`` (default), this loop preserves the legacy single-
+        # stream behavior bit-for-bit (one shared RNG state across all N
+        # PolicyNetwork constructions).
+        if per_agent_init_seed_offset is None:
+            self.policies = nn.ModuleList(
+                [
+                    PolicyNetwork(
+                        obs_dim=obs_dim,
+                        action_dims=action_dims,
+                        hidden_size=hidden_size,
+                    )
+                    for _ in range(num_agents)
+                ]
+            ).to(self.device)
+        else:
+            policy_list: List[PolicyNetwork] = []
+            for i in range(num_agents):
+                agent_seed = int(seed) + i * int(per_agent_init_seed_offset)
+                torch.manual_seed(agent_seed)
+                policy_list.append(
+                    PolicyNetwork(
+                        obs_dim=obs_dim,
+                        action_dims=action_dims,
+                        hidden_size=hidden_size,
+                    )
                 )
-                for _ in range(num_agents)
-            ]
-        ).to(self.device)
+            self.policies = nn.ModuleList(policy_list).to(self.device)
+            # Restore the global RNG to the original seed-derived stream so
+            # downstream init (centralized critic, HCA, etc.) is unaffected.
+            torch.manual_seed(int(seed))
 
         # Per-agent optimizers. Each only updates its own params, but
         # ``total_loss.backward()`` is called once across all of them so the

--- a/experiments/p3_specialization/het_ppo_runbook.md
+++ b/experiments/p3_specialization/het_ppo_runbook.md
@@ -1,0 +1,190 @@
+# het_ppo runbook (issue #386)
+
+Operator-driven launch + retrieve guide for the asymmetry-aware PPO arm.
+
+This runbook is the companion to:
+
+- `experiments/scripts/launch_het_ppo_sweep.sh` — the launcher
+- `bucket_brigade/training/joint_trainer.py` — the `per_agent_init_seed_offset` kwarg
+- `experiments/p3_specialization/run_tier1_cell.py` — the `het_ppo` entry in `TRAINERS`
+- `tests/test_joint_trainer.py::TestAsymmetryAwareInit` — the trainer-side tests
+- `tests/test_tier1_driver.py::test_het_ppo_*` — the dispatch tests
+- `tests/test_launch_het_ppo_sweep.py` — the launcher contract tests
+
+## What `het_ppo` is
+
+`het_ppo` is the HetGPPO-style (Bettini et al. AAMAS 2023, arXiv:2301.07137)
+positive baseline for `asymmetric_only` phase-diagram cells. The architectural
+contribution is small: the existing `JointPPOTrainer` already maintains
+`num_agents` independent `PolicyNetwork` instances with `num_agents`
+independent Adam optimizers (see `joint_trainer.py` line 462). What changed
+in issue #386:
+
+- A new `per_agent_init_seed_offset` kwarg on `JointPPOTrainer`. When set
+  (recommended: `1000`), each policy `i` is initialized under its own seed
+  `seed + i * offset` so the per-position parameter draws come from disjoint
+  RNG streams. Default (`None`) preserves bit-identical legacy single-stream
+  init.
+- A new `het_ppo` entry in `run_tier1_cell.py::TRAINERS` that dispatches to
+  `train.py --algorithm ppo --per-agent-init-seed-offset 1000`.
+
+**Why the offset matters.** The legacy path constructs all `N` policies off a
+single `torch.manual_seed(seed)` stream. The per-agent parameter tensors end
+up *different* (each `nn.Linear` consumes RNG state in order) but their
+starting points are correlated. On `asymmetric_only` cells (where the Nash
+equilibrium is per-position-distinct), that shared-stream coupling can bias
+SGD into a symmetric basin. Forcing disjoint init streams completes the
+symmetry break at step 0.
+
+## Acceptance criteria (per issue #386)
+
+### Phase 1: rest_trap anchor
+
+- 20 seeds × default budget (50 iter × 2048 rollout)
+- Target: `gap_closed_mean >= 0.49` (`partial_upper` tier or better)
+
+Tier-1 baselines (IPPO, MAPPO, COMA, HCA, social-influence, etc.) fail by
+construction on `rest_trap` (#356); the asymmetric variant is expected to
+beat them clearly. If `het_ppo` returns `insufficient` on `rest_trap`, the
+asymmetry-aware story collapses and needs reframing.
+
+### Phase 2: phase-diagram `asymmetric_only` cells
+
+From `experiments/nash/phase_diagram/phase_diagram_table.md` (commit 1de2d557):
+
+| β | κ | c | verdict | NE team reward |
+|---|---|---|---------|----------------|
+| 0.5 | 0.5 | 0.9 | `asymmetric_only` | 72.01 |
+| 0.5 | 0.9 | 0.9 | `asymmetric_only` | 72.01 |
+
+These are the only `asymmetric_only` cells in the current preview slice (3
+β-values × 3 κ-values × 3 c-values). Scenario file names for these cells live
+under `experiments/scenarios/` once the cell-to-scenario mapping driver from
+#358 has emitted them. As of this writing, only `rest_trap` is committed as a
+standalone scenario; the Phase 2 cells require the #358 follow-up to
+materialize.
+
+### Phase 3 (optional): `symmetric_only` sanity check
+
+Per the issue:
+
+> sanity check: does dropping parameter sharing hurt on `symmetric_only`
+> cells where the symmetric NE is optimal? Expected: yes, mildly
+> (sample-efficiency loss without equilibrium-structure gain).
+
+Run `het_ppo` on `minimal_specialization` (the canonical `symmetric_only`
+anchor — see #354) and compare to IPPO. Useful framing for the paper but not
+strictly required by the issue's acceptance criteria.
+
+## Launch commands
+
+All launches go through `launch_het_ppo_sweep.sh`. The script reads
+`COMPUTE_HOST_PRIMARY` from `.env` and falls back to `_CLUSTER` / `_LAMBDA` /
+`_GCP`. Pass `--host <alias>` to override.
+
+### Plan A — Phase 1 anchor (smallest viable launch)
+
+```bash
+./experiments/scripts/launch_het_ppo_sweep.sh \
+    --scenarios rest_trap
+```
+
+- 20 seeds (the default) × 50 iter × 2048 rollout × 1 cell
+- Expected wall-clock: 30 min – 2 h per seed on a CPU host, ~20 h total at
+  16-way parallelism (depends on host). The trainer is single-process per
+  seed; parallelism comes from running multiple seeds concurrently, which
+  this launcher does NOT do — each seed runs sequentially inside one tmux
+  session. For multi-host parallelism, launch this command on each host with
+  a disjoint seed slice (`--seeds 42,43,44,45,46`) and rsync results into a
+  shared directory.
+
+### Plan B — Phase 1 fast turnaround (debug / positive-control rerun)
+
+```bash
+./experiments/scripts/launch_het_ppo_sweep.sh \
+    --scenarios rest_trap \
+    --seeds 42,43,44 \
+    --num-iterations 25
+```
+
+- 3 seeds × 25 iter — finishes in 1–3 h on most hosts
+- Use this to confirm the trainer is wired correctly on a new host before
+  burning compute on the full 20-seed sweep
+
+### Plan C — Phase 2 (after #358 emits asymmetric_only scenarios)
+
+```bash
+./experiments/scripts/launch_het_ppo_sweep.sh \
+    --scenarios rest_trap,asym_b05_k05_c09,asym_b05_k09_c09
+```
+
+Each cell appends a fresh `het_ppo_<scenario>/cell_summary.json` under
+`experiments/p3_specialization/tier1_runs/`. The launcher loops over
+scenarios serially inside one tmux session.
+
+## Host assignments
+
+Per `~/.claude/.../reference_cluster_host_reliability.md`:
+
+- **Prefer**: `alc-2`, `alc-6`, `alc-9` (high reliability)
+- **Avoid**: `alc-5` (12.5% reliable, confirmed flaky)
+- **Personal CPU**: `COMPUTE_HOST_PRIMARY` (Mac Studio) — default for
+  evolution / Nash / P3 sweeps. The env is CPU-bound; parallelism wins, not
+  GPU.
+
+## Retrieving results
+
+```bash
+# After the tmux session reports "cell complete" for every scenario:
+rsync -avz <host>:bucket-brigade/experiments/p3_specialization/tier1_runs/ \
+    experiments/p3_specialization/tier1_runs/
+
+# Regenerate the tier-1 aggregate table (this picks up het_ppo automatically
+# as long as the cell_summary.json files are under tier1_runs/):
+uv run python experiments/p3_specialization/aggregate_tier1.py \
+    --root experiments/p3_specialization/tier1_runs/
+
+# Commit results to a feature branch (do NOT push to main without review):
+git checkout -b results/het-ppo-issue-386
+git add experiments/p3_specialization/tier1_runs/het_ppo_*
+git commit -m "exp(p3): het_ppo sweep results — issue #386"
+```
+
+## What the launcher does NOT do
+
+- It does **not** launch automatically. The operator runs it once and the
+  remote tmux session does the work over hours.
+- It does **not** parallelize seeds across multiple hosts. For an asymmetric
+  N-host launch, run the script N times with `--seeds <slice>` on each host
+  and rsync results into a shared directory.
+- It does **not** auto-merge results. The operator pulls results back,
+  inspects the per-cell `cell_summary.json`, and commits/PRs.
+
+## Smoke test (local, safe)
+
+```bash
+# 1 seed × 1 iter × 32 rollout on rest_trap; finishes in seconds.
+uv run python experiments/p3_specialization/run_tier1_cell.py \
+    --trainer het_ppo \
+    --scenario rest_trap \
+    --seeds 42 \
+    --num-iterations 1 \
+    --rollout-steps 32 \
+    --output-root /tmp/het_ppo_smoke \
+    --skip-precheck
+```
+
+Expected: `== cell het_ppo_rest_trap complete: verdict=<some-tier>
+gap_closed_mean=<some-float>`. The verdict on a 1-iteration smoke run is
+meaningless — this only checks the dispatch + trainer + env wiring.
+
+## See also
+
+- `experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md` — sibling runbook for
+  the phase-diagram fill operation (the #358/#390/#393 workflow this one
+  follows).
+- `bucket_brigade/training/joint_trainer.py` (lines ~290, 458–520) — kwarg
+  docstring + init logic.
+- `experiments/p3_specialization/tier1_runs/tier1_verdict.md` — the existing
+  tier-1 verdict table. `het_ppo` results will land alongside the 14 trainers
+  already there.

--- a/experiments/p3_specialization/run_tier1_cell.py
+++ b/experiments/p3_specialization/run_tier1_cell.py
@@ -203,6 +203,18 @@ TRAINERS: dict[str, TrainerSpec] = {
         description="Independent PPO baseline (--algorithm ppo, no extras).",
         train_extra=("--algorithm", "ppo"),
     ),
+    "het_ppo": TrainerSpec(
+        name="het_ppo",
+        description=(
+            "HetGPPO-style asymmetry-aware PPO (issue #386): IPPO with "
+            "--per-agent-init-seed-offset 1000 so each per-position policy "
+            "is initialized from a maximally-distinct RNG stream. Designed "
+            "for asymmetric_only phase-diagram cells (e.g. rest_trap) where "
+            "the Nash equilibrium is per-position-distinct and shared-stream "
+            "init can trap SGD in a symmetric basin."
+        ),
+        train_extra=("--algorithm", "ppo", "--per-agent-init-seed-offset", "1000"),
+    ),
     "mappo": TrainerSpec(
         name="mappo",
         description="MAPPO: centralized critic, decentralized actors.",

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -233,6 +233,20 @@ class CellConfig:
     # — the diagnostic's interpretation depends on running clean vanilla
     # PG. ``"ppo"`` (default) preserves bit-identical pre-#273 behavior.
     algorithm: str = "ppo"
+    # Issue #386: asymmetry-aware ("HetGPPO") per-agent init seed offset.
+    # When ``None`` (default), the legacy single-stream init is preserved
+    # bit-for-bit (every per-agent ``PolicyNetwork`` is drawn off the same
+    # RNG state derived from ``seed``). When set to a positive integer ``K``,
+    # each agent ``i`` is initialized with seed ``seed + i * K`` so per-
+    # position policies start from maximally-distinct random inits. This is
+    # the architectural commitment to per-position parameter heterogeneity
+    # that HetGPPO (Bettini et al. AAMAS 2023) calls out as the simplest
+    # "drop parameter sharing" baseline. The trainer *already* maintains
+    # N independent policies + optimizers; this flag completes the
+    # symmetry break at init so SGD cannot fall into a basin that depends
+    # on shared-stream coupling. Recommended value: ``1000``. Wired to
+    # ``--per-agent-init-seed-offset`` on the CLI.
+    per_agent_init_seed_offset: Optional[int] = None
 
 
 # Default number of day bins for the state-summary conditioner. Episodes in
@@ -1070,6 +1084,7 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
             hindsight_ratio_clip=cfg.hindsight_ratio_clip,
             influence_coef=cfg.influence_coef,
             influence_mc_samples=cfg.influence_mc_samples,
+            per_agent_init_seed_offset=cfg.per_agent_init_seed_offset,
             device=cfg.device,
             seed=cfg.seed,
             obs_auditor=obs_auditor,
@@ -1569,6 +1584,23 @@ def main() -> None:
             "--lola-dice."
         ),
     )
+    p.add_argument(
+        "--per-agent-init-seed-offset",
+        type=int,
+        default=None,
+        help=(
+            "Issue #386: asymmetry-aware (HetGPPO-style) per-agent init "
+            "seed offset. When unset (default), the legacy single-stream "
+            "init is preserved bit-for-bit: every PolicyNetwork is drawn "
+            "off the same RNG state derived from --seed. When set to a "
+            "positive integer K, each agent i is seeded with seed + i * K "
+            "before its policy is constructed, producing maximally-distinct "
+            "starting points across positions. This completes the symmetry "
+            "break at init for the per-position-distinct equilibria that "
+            "asymmetric_only phase-diagram cells require (e.g. rest_trap). "
+            "Recommended value: 1000."
+        ),
+    )
     p.add_argument("--device", default="cpu")
     p.add_argument(
         "--audit-obs",
@@ -1648,6 +1680,7 @@ def main() -> None:
         lola_eta=args.lola_eta,
         lola_lookahead_steps=args.lola_lookahead_steps,
         algorithm=args.algorithm,
+        per_agent_init_seed_offset=args.per_agent_init_seed_offset,
         device=args.device,
         audit_obs=args.audit_obs,
         audit_obs_path=args.audit_obs_path,

--- a/experiments/scripts/launch_het_ppo_sweep.sh
+++ b/experiments/scripts/launch_het_ppo_sweep.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# Launch the issue #386 asymmetry-aware ("het_ppo") sweep on a remote host.
+# The het_ppo trainer arm (see experiments/p3_specialization/run_tier1_cell.py
+# TRAINERS dict and bucket_brigade/training/joint_trainer.py
+# per_agent_init_seed_offset kwarg) is the HetGPPO-style positive baseline
+# for asymmetric_only phase-diagram cells (Bettini et al. AAMAS 2023,
+# arXiv:2301.07137): each per-position policy is initialized from a
+# maximally-distinct RNG stream so SGD cannot trap into a symmetric basin.
+#
+# The script does NOT compute anything locally. It only:
+#   1. Reads $COMPUTE_HOST_* aliases from .env to resolve a target host
+#      (unless --host is passed explicitly).
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts
+#      a detached tmux session running run_tier1_cell.py with
+#      --trainer het_ppo over the requested scenarios × seeds.
+#   4. Prints monitor / rsync follow-up instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual cells fill over
+# hours inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Phase 1: anchor on rest_trap (20 seeds, default budget)
+#   ./experiments/scripts/launch_het_ppo_sweep.sh --scenarios rest_trap
+#
+#   # Phase 2: every asymmetric_only cell from the phase diagram
+#   ./experiments/scripts/launch_het_ppo_sweep.sh \
+#       --scenarios rest_trap,asym_b05_k05_c09,asym_b05_k09_c09
+#
+#   # Explicit host, smaller seed set for a fast positive-control rerun
+#   ./experiments/scripts/launch_het_ppo_sweep.sh \
+#       --host alc-2 --scenarios rest_trap --seeds 42,43,44 \
+#       --num-iterations 25 --rollout-steps 1024
+#
+#   # Dry-run prints the ssh + driver command without launching anything
+#   ./experiments/scripts/launch_het_ppo_sweep.sh --scenarios rest_trap --dry-run
+#
+# Flags:
+#   --host HOST                     SSH alias (or auto-resolved from .env)
+#   --scenarios LIST                Comma-separated scenario names (required)
+#   --seeds LIST                    Comma-separated seeds (default: 20 seeds)
+#   --num-iterations N              PPO iterations per seed (default: 50)
+#   --rollout-steps N               Rollout buffer size (default: 2048)
+#   --output-dir PATH               Remote output root (default: tier1_runs)
+#   --session-name NAME             tmux session name (auto-synthesized)
+#   --dry-run                       Print plan; do not ssh anywhere
+#   --skip-connectivity-check       For CI / smoke tests
+#
+# See experiments/p3_specialization/het_ppo_runbook.md for the canonical
+# scenario list, host assignments, and the per-cell expected wall-clock.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Defaults that the operator usually does not need to override.
+DEFAULT_SESSION_PREFIX="het-ppo"
+DEFAULT_SEEDS="42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61"
+DEFAULT_NUM_ITERATIONS=50
+DEFAULT_ROLLOUT_STEPS=2048
+DEFAULT_OUTPUT_DIR="experiments/p3_specialization/tier1_runs"
+
+HOST=""
+SCENARIOS=""
+SEEDS="$DEFAULT_SEEDS"
+NUM_ITERATIONS="$DEFAULT_NUM_ITERATIONS"
+ROLLOUT_STEPS="$DEFAULT_ROLLOUT_STEPS"
+OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+SESSION_NAME=""
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+
+print_usage() {
+    sed -n '2,64p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --scenarios)
+            SCENARIOS="$2"
+            shift 2
+            ;;
+        --seeds)
+            SEEDS="$2"
+            shift 2
+            ;;
+        --num-iterations)
+            NUM_ITERATIONS="$2"
+            shift 2
+            ;;
+        --rollout-steps)
+            ROLLOUT_STEPS="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Required: --scenarios
+if [[ -z "$SCENARIOS" ]]; then
+    echo "ERROR: --scenarios is required (comma-separated scenario names)" >&2
+    echo "       e.g. --scenarios rest_trap" >&2
+    echo "       See experiments/p3_specialization/het_ppo_runbook.md for the canonical list." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+
+if [[ -z "$HOST" ]]; then
+    HOST=$(resolve_host_from_env)
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build driver command + tmux session name
+# ---------------------------------------------------------------------------
+
+# Convert comma-separated scenarios/seeds into space-separated for the driver.
+SEEDS_SPACED="${SEEDS//,/ }"
+
+if [[ -z "$SESSION_NAME" ]]; then
+    # Compact tag so two concurrent launches on the same host don't collide.
+    # Use the first scenario as the tag; if multiple, append count.
+    first_scenario="${SCENARIOS%%,*}"
+    n_scenarios=$(echo "$SCENARIOS" | tr ',' '\n' | wc -l | tr -d ' ')
+    if [[ "$n_scenarios" -gt 1 ]]; then
+        SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${first_scenario}-and${n_scenarios}more"
+    else
+        SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${first_scenario}"
+    fi
+fi
+
+# Compose the driver invocation as a loop over scenarios so a single tmux
+# session covers the whole sweep. Each scenario is one run_tier1_cell.py
+# invocation (which itself loops over seeds and writes its own
+# cell_summary.json under <OUTPUT_DIR>/het_ppo_<scenario>/).
+DRIVER_CMD="set -e"
+IFS=',' read -ra SCENARIO_LIST <<< "$SCENARIOS"
+for scen in "${SCENARIO_LIST[@]}"; do
+    DRIVER_CMD+=" && echo '=== het_ppo on $scen ===' && uv run python experiments/p3_specialization/run_tier1_cell.py --trainer het_ppo --scenario '$scen' --seeds $SEEDS_SPACED --num-iterations $NUM_ITERATIONS --rollout-steps $ROLLOUT_STEPS --output-root '$OUTPUT_DIR'"
+done
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default.
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync --extra rl
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the trainer import + het_ppo dispatch before consuming a tmux
+# session for a multi-hour run.
+uv run python -c "from experiments.p3_specialization.run_tier1_cell import TRAINERS; assert 'het_ppo' in TRAINERS, 'het_ppo missing from dispatch — run from a main checkout that has issue #386 merged'; print('het_ppo dispatch OK')"
+
+mkdir -p $OUTPUT_DIR
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && ($DRIVER_CMD) 2>&1 | tee -a '$OUTPUT_DIR/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_DIR/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+echo "===================================================================="
+echo "Issue #386 — het_ppo sweep launch"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output dir:     $OUTPUT_DIR    (on remote)"
+echo "Scenarios:      $SCENARIOS"
+echo "Seeds:          $SEEDS"
+echo "Num iterations: $NUM_ITERATIONS"
+echo "Rollout steps:  $ROLLOUT_STEPS"
+echo ""
+echo "Driver command (to be run inside tmux on remote):"
+echo "  $DRIVER_CMD"
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_DIR}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done, rsync results back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_DIR}/ ${OUTPUT_DIR}/"
+echo ""
+echo "  # Aggregate verdicts across scenarios once results are back:"
+echo "  uv run python experiments/p3_specialization/aggregate_tier1.py \\"
+echo "      --root ${OUTPUT_DIR}   # writes tier1_verdict.{json,md}"
+echo "===================================================================="

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -1365,3 +1365,167 @@ class TestCommitmentModeTwoPhase:
             include_round1_signals=False,
         ).shape[0]
         assert with_r1 == without_r1 + NUM_AGENTS
+
+
+class TestAsymmetryAwareInit:
+    """Issue #386: per-agent init seed offset (HetGPPO-style symmetry break).
+
+    The trainer's ``per_agent_init_seed_offset`` knob reseeds the global
+    torch RNG to ``seed + i * offset`` before each :class:`PolicyNetwork`
+    is constructed. This produces maximally-distinct per-position parameter
+    inits — the symmetry-break that asymmetric_only phase-diagram cells
+    (e.g. rest_trap) need to converge to per-position-distinct equilibria.
+
+    Default (``None``) preserves bit-identical legacy single-stream init.
+    """
+
+    def _trainer(
+        self, *, seed: int = 0, per_agent_init_seed_offset=None
+    ) -> JointPPOTrainer:
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        return JointPPOTrainer(
+            env_fn=_env_fn,
+            num_agents=NUM_AGENTS,
+            obs_dim=obs_dim,
+            action_dims=ACTION_DIMS,
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=1,
+            seed=seed,
+            per_agent_init_seed_offset=per_agent_init_seed_offset,
+        )
+
+    @staticmethod
+    def _param_signature(policy) -> torch.Tensor:
+        """Concatenate all flattened policy params into a single 1-D tensor."""
+        return torch.cat([p.detach().flatten() for p in policy.parameters()])
+
+    def test_default_none_preserves_legacy_init(self):
+        """``per_agent_init_seed_offset=None`` (default) is bit-identical
+        to constructing without the kwarg at all — the legacy single-stream
+        init path is unchanged."""
+        t_default = self._trainer(seed=42)
+        t_explicit_none = self._trainer(seed=42, per_agent_init_seed_offset=None)
+        for i in range(NUM_AGENTS):
+            sig_a = self._param_signature(t_default.policies[i])
+            sig_b = self._param_signature(t_explicit_none.policies[i])
+            assert torch.allclose(sig_a, sig_b, atol=0.0), (
+                f"agent {i}: explicit None changed init — the default-None "
+                "path must be a true no-op"
+            )
+
+    def test_offset_produces_distinct_per_agent_params(self):
+        """With the offset on, every pair of agents has visibly different
+        parameter tensors (not just different identity tails in obs)."""
+        trainer = self._trainer(seed=42, per_agent_init_seed_offset=1000)
+        sigs = [self._param_signature(p) for p in trainer.policies]
+        for i in range(NUM_AGENTS):
+            for j in range(i + 1, NUM_AGENTS):
+                # L2 distance over flattened params; with disjoint RNG
+                # streams these should be O(1) units apart, well above
+                # any floating-point tolerance.
+                dist = float((sigs[i] - sigs[j]).norm().item())
+                assert dist > 1.0, (
+                    f"agents {i} and {j} have param distance {dist:.6f} — "
+                    "per-agent seed offset did not break init symmetry "
+                    "(expected at least ~1.0 between disjoint RNG streams)"
+                )
+
+    def test_offset_init_is_reproducible(self):
+        """Two trainers built with the same (seed, offset) pair must
+        produce bit-identical per-agent params. Reproducibility is the
+        whole point of the knob — it must not depend on hidden RNG state."""
+        t1 = self._trainer(seed=7, per_agent_init_seed_offset=1000)
+        t2 = self._trainer(seed=7, per_agent_init_seed_offset=1000)
+        for i in range(NUM_AGENTS):
+            sig_a = self._param_signature(t1.policies[i])
+            sig_b = self._param_signature(t2.policies[i])
+            assert torch.allclose(sig_a, sig_b, atol=0.0), (
+                f"agent {i}: same (seed, offset) produced different params — "
+                "the offset path is not reproducible"
+            )
+
+    def test_offset_changes_init_vs_default(self):
+        """Same ``seed`` with offset on vs off produces at least one agent
+        whose params differ. (Legacy single-stream still produces distinct
+        per-agent params via sequential RNG consumption, but the *first*
+        agent always reads the same prefix of the stream, so it is the
+        agents with i > 0 that are guaranteed to shift.)"""
+        t_off = self._trainer(seed=99, per_agent_init_seed_offset=None)
+        t_on = self._trainer(seed=99, per_agent_init_seed_offset=1000)
+        any_diff = False
+        for i in range(NUM_AGENTS):
+            sig_off = self._param_signature(t_off.policies[i])
+            sig_on = self._param_signature(t_on.policies[i])
+            if not torch.allclose(sig_off, sig_on, atol=0.0):
+                any_diff = True
+                break
+        assert any_diff, (
+            "no agent's init changed between offset=None and offset=1000 — "
+            "the offset path is silently a no-op"
+        )
+
+    def test_offset_requires_seed(self):
+        """``per_agent_init_seed_offset`` without an explicit ``seed`` is
+        a misconfiguration: offsetting a non-deterministic seed yields a
+        non-reproducible trainer. Surface the error at construction."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        with pytest.raises(ValueError, match="seed"):
+            JointPPOTrainer(
+                env_fn=_env_fn,
+                num_agents=NUM_AGENTS,
+                obs_dim=obs_dim,
+                action_dims=ACTION_DIMS,
+                hidden_size=16,
+                seed=None,
+                per_agent_init_seed_offset=1000,
+            )
+
+    def test_offset_rejects_non_positive(self):
+        """Offset must be a positive integer. Zero or negative values are
+        misconfigurations (zero gives all agents the same seed; negative
+        is meaningless)."""
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        for bad in (0, -1, -1000):
+            with pytest.raises(ValueError, match="must be > 0"):
+                JointPPOTrainer(
+                    env_fn=_env_fn,
+                    num_agents=NUM_AGENTS,
+                    obs_dim=obs_dim,
+                    action_dims=ACTION_DIMS,
+                    hidden_size=16,
+                    seed=0,
+                    per_agent_init_seed_offset=bad,
+                )
+
+    def test_offset_rejects_non_int(self):
+        env = _env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        with pytest.raises(TypeError, match="must be an int"):
+            JointPPOTrainer(
+                env_fn=_env_fn,
+                num_agents=NUM_AGENTS,
+                obs_dim=obs_dim,
+                action_dims=ACTION_DIMS,
+                hidden_size=16,
+                seed=0,
+                per_agent_init_seed_offset=1.5,  # type: ignore[arg-type]
+            )
+
+    def test_offset_trainer_runs_one_update(self):
+        """Smoke test: a trainer with the offset on still completes a full
+        collect_rollout + update cycle with finite losses. Catches any
+        subtle wiring break (e.g. accidentally re-initializing the
+        optimizers off the wrong policy params)."""
+        trainer = self._trainer(seed=11, per_agent_init_seed_offset=1000)
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        stats = trainer.update(rollout)
+        for k, v in stats.items():
+            assert np.isfinite(v), f"non-finite stat {k}={v} under het_ppo init"

--- a/tests/test_launch_het_ppo_sweep.py
+++ b/tests/test_launch_het_ppo_sweep.py
@@ -1,0 +1,304 @@
+"""Tests for ``experiments/scripts/launch_het_ppo_sweep.sh``.
+
+The script is the operator-launch wrapper added for issue #386 (the
+asymmetry-aware HetGPPO-style PPO arm sweep on ``rest_trap`` and the
+``asymmetric_only`` phase-diagram cells). It shells out to ``ssh`` to
+bootstrap a remote tmux session, so the live-run path is not exercisable in
+unit tests. The ``--dry-run`` flag exists exactly so the wiring (arg parsing,
+host resolution, driver-command synthesis, session-name compaction) can be
+asserted without touching the network.
+
+These tests mirror the contract style established for the phase-diagram
+launcher (``tests/test_launch_phase_diagram_fill.py``): each documented
+operator invocation in ``experiments/p3_specialization/het_ppo_runbook.md``
+is locked in here so a future refactor to the script cannot silently break
+the runbook commands.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_het_ppo_sweep.sh"
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(  # nosec B603 B607 (cmd is list, no shell)
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check that the canonical flags appear in the doc string.
+    for flag in (
+        "--host",
+        "--scenarios",
+        "--seeds",
+        "--num-iterations",
+        "--rollout-steps",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+
+
+def test_missing_scenarios_errors_cleanly() -> None:
+    """Without --scenarios, the script must fail with a clear message.
+
+    --scenarios is required because there is no sensible default sweep —
+    Phase 1 is rest_trap only, Phase 2 depends on #358's per-cell scenario
+    file mapping. We force the operator to be explicit.
+    """
+    result = _run(["--host", "fake-host", "--dry-run"])
+    assert result.returncode == 2, (
+        f"expected exit 2 (missing --scenarios), got {result.returncode}: "
+        f"{result.stderr}"
+    )
+    assert "--scenarios" in result.stderr
+
+
+def test_missing_host_with_no_env_errors_cleanly() -> None:
+    """Without --host and without a .env, the script must fail with exit 3."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    if env_path.exists():
+        env_path.unlink()
+    try:
+        result = _run(["--scenarios", "rest_trap", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+
+    assert result.returncode == 3, (
+        f"expected exit 3 (no host), got {result.returncode}: {result.stderr}"
+    )
+    assert "no host specified" in result.stderr.lower()
+
+
+def test_dry_run_with_explicit_host_emits_driver_command() -> None:
+    """``--dry-run`` must print the synthesized driver invocation."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "rest_trap",
+            "--seeds",
+            "42,43,44",
+            "--num-iterations",
+            "25",
+            "--rollout-steps",
+            "1024",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Argument plumbing through to the driver:
+    assert "run_tier1_cell.py" in out
+    assert "--trainer het_ppo" in out
+    assert "--scenario 'rest_trap'" in out
+    # Seeds are passed space-separated (not comma) to run_tier1_cell.py.
+    assert "--seeds 42 43 44" in out
+    assert "--num-iterations 25" in out
+    assert "--rollout-steps 1024" in out
+    # Header echoes the resolved host.
+    assert "fake-host" in out
+    # Dry-run banner must be present so an operator never confuses it
+    # with a real launch.
+    assert "dry-run" in out.lower()
+
+
+def test_dry_run_synthesizes_session_name() -> None:
+    """Session name must include the scenario tag so concurrent launches
+    on the same host don't collide."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "rest_trap",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert "het-ppo-rest_trap" in result.stdout, result.stdout
+
+
+def test_dry_run_session_name_with_multiple_scenarios() -> None:
+    """Multi-scenario launches must produce a distinguishable session name."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "rest_trap,asym_b05_k05_c09,asym_b05_k09_c09",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    # First scenario in the tag, plus a count marker so the operator can tell
+    # at a glance this was a multi-scenario launch.
+    assert "het-ppo-rest_trap-and3more" in result.stdout, result.stdout
+
+
+def test_dry_run_loops_over_scenarios() -> None:
+    """Multi-scenario launches must produce one run_tier1_cell.py invocation
+    per scenario inside the synthesized driver command."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "rest_trap,asym_b05_k05_c09",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    # One --scenario clause per scenario in the driver invocation.
+    assert "--scenario 'rest_trap'" in result.stdout
+    assert "--scenario 'asym_b05_k05_c09'" in result.stdout
+    # The loop is chained with &&; verify we have at least one chain so an
+    # early failure aborts the rest (set -e + && in the wrapper).
+    driver_section = result.stdout.split("Driver command")[-1]
+    assert " && " in driver_section, (
+        f"multi-scenario driver should chain with &&: {driver_section}"
+    )
+
+
+def test_dry_run_resolves_host_from_env() -> None:
+    """When --host is omitted, the script must pick the first non-empty
+    COMPUTE_HOST_* from .env using the documented priority (PRIMARY first)."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    try:
+        env_path.write_text(
+            textwrap.dedent(
+                """\
+                COMPUTE_HOST_PRIMARY=resolved-primary
+                COMPUTE_HOST_CLUSTER=resolved-cluster
+                """
+            )
+        )
+        result = _run(["--scenarios", "rest_trap", "--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+        elif env_path.exists():
+            env_path.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved-primary" in result.stdout
+    # CLUSTER should NOT win when PRIMARY is set.
+    assert "resolved-cluster" not in result.stdout
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(
+        [
+            "--host",
+            "x",
+            "--scenarios",
+            "rest_trap",
+            "--not-a-flag",
+            "y",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    "args,expected_in_cmd",
+    [
+        # Runbook Plan A: Phase 1 anchor (default 20 seeds × default budget)
+        (
+            ["--scenarios", "rest_trap"],
+            [
+                "--trainer het_ppo",
+                "--scenario 'rest_trap'",
+                # Default seed list expands to 20 space-separated ints.
+                "42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61",
+            ],
+        ),
+        # Runbook Plan B: fast turnaround (3 seeds × 25 iter)
+        (
+            [
+                "--scenarios",
+                "rest_trap",
+                "--seeds",
+                "42,43,44",
+                "--num-iterations",
+                "25",
+            ],
+            [
+                "--trainer het_ppo",
+                "--scenario 'rest_trap'",
+                "--seeds 42 43 44",
+                "--num-iterations 25",
+            ],
+        ),
+        # Runbook Plan C: Phase 2 multi-scenario
+        (
+            [
+                "--scenarios",
+                "rest_trap,asym_b05_k05_c09,asym_b05_k09_c09",
+            ],
+            [
+                "--scenario 'rest_trap'",
+                "--scenario 'asym_b05_k05_c09'",
+                "--scenario 'asym_b05_k09_c09'",
+            ],
+        ),
+    ],
+    ids=["plan_a_anchor", "plan_b_fast", "plan_c_phase2"],
+)
+def test_runbook_canonical_invocations(
+    args: list[str], expected_in_cmd: list[str]
+) -> None:
+    """Lock in the runbook commands so a refactor to the script cannot
+    silently break the documented operator instructions."""
+    result = _run(["--host", "fake-host", *args, "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    for fragment in expected_in_cmd:
+        assert fragment in result.stdout, (
+            f"missing expected driver flag '{fragment}' in:\n{result.stdout}"
+        )
+
+
+def test_runbook_referenced_by_script_help() -> None:
+    """The runbook path must be discoverable from --help so an operator can
+    find it without grepping the source tree."""
+    result = _run(["--help"])
+    assert result.returncode == 0
+    assert "het_ppo_runbook.md" in result.stdout, (
+        "--help should point operators at the runbook for the canonical scenario list"
+    )

--- a/tests/test_tier1_driver.py
+++ b/tests/test_tier1_driver.py
@@ -60,6 +60,11 @@ def _argv_contains_pair(argv: list[str], flag: str, value: str) -> bool:
 SINGLE_STEP_TRAINER_EXPECTATIONS = [
     # (trainer, expected_flag_substring, expected_pair_or_None)
     ("ippo", "--algorithm", ("--algorithm", "ppo")),
+    (
+        "het_ppo",
+        "--per-agent-init-seed-offset",
+        ("--per-agent-init-seed-offset", "1000"),
+    ),
     ("mappo", "--centralized-critic", None),
     ("high_lambda", "--gae-lambda", ("--gae-lambda", "0.99")),
     ("lola", "--lola-dice", None),
@@ -523,3 +528,51 @@ def test_all_required_trainers_present():
         "pbt",
     }
     assert expected.issubset(set(run_tier1_cell.TRAINERS))
+
+
+def test_het_ppo_trainer_registered():
+    """Issue #386: ``het_ppo`` is the asymmetry-aware (HetGPPO-style) PPO arm.
+
+    Dispatches via train.py with ``--algorithm ppo --per-agent-init-seed-offset
+    1000`` so each per-position policy is initialized from a maximally-distinct
+    RNG stream. Designed for ``asymmetric_only`` phase-diagram cells.
+    """
+    assert "het_ppo" in run_tier1_cell.TRAINERS
+    spec = run_tier1_cell.TRAINERS["het_ppo"]
+    assert spec.is_pbt is False, "het_ppo is a single-step train.py trainer"
+    assert spec.run_seed is None, "het_ppo uses the default per-seed dispatch"
+    assert ("--per-agent-init-seed-offset", "1000") == (
+        spec.train_extra[-2],
+        spec.train_extra[-1],
+    ), (
+        f"het_ppo train_extra must end with --per-agent-init-seed-offset 1000; "
+        f"got {spec.train_extra!r}"
+    )
+
+
+def test_het_ppo_dispatch_does_not_overlap_other_arms(tmp_path):
+    """het_ppo must not silently pull in centralized critic, COMA, HCA, LOLA,
+    macro-actions, influence, etc. — those would entangle the asymmetry-aware
+    diagnostic with a different experimental arm."""
+    argv = run_tier1_cell.build_argvs_for_seed(
+        "het_ppo",
+        scenario="rest_trap",
+        seed=42,
+        output_dir=tmp_path,
+        num_iterations=1,
+        rollout_steps=64,
+    )[0]
+    for forbidden in (
+        "--centralized-critic",
+        "--use-coma",
+        "--use-hca",
+        "--lola-dice",
+        "--macro-actions",
+        "--influence-coef",
+        "--team-welfare-lambda",
+        "--progress-shaping-coef",
+        "--bc-init-checkpoint-dir",
+    ):
+        assert not _argv_contains(argv, forbidden), (
+            f"het_ppo argv should not contain {forbidden!r}: {argv!r}"
+        )


### PR DESCRIPTION
## Summary

Adds the HetGPPO-style (Bettini et al. AAMAS 2023, arXiv:2301.07137) positive baseline for `asymmetric_only` phase-diagram cells. The trainer already maintained `num_agents` independent `PolicyNetwork` instances and `num_agents` independent Adam optimizers (see `joint_trainer.py` line 462) — the architectural delta requested by #386 is small:

- A new `per_agent_init_seed_offset` kwarg on `JointPPOTrainer`. When set (recommended: `1000`), each policy `i` is initialized under its own seed `seed + i * offset` so the per-position parameter draws come from disjoint RNG streams. Default `None` preserves bit-identical legacy single-stream init.
- A new `het_ppo` entry in `run_tier1_cell.py::TRAINERS` that dispatches to `train.py --algorithm ppo --per-agent-init-seed-offset 1000`.

Why the offset matters: the legacy path constructs all N policies off a single `torch.manual_seed(seed)` stream. The per-agent parameter tensors end up *different* (each `nn.Linear` consumes RNG state in order) but their starting points are correlated through that shared stream. On `asymmetric_only` cells (where the Nash equilibrium is per-position-distinct), that shared-stream coupling can bias SGD into a symmetric basin. Forcing disjoint init streams completes the symmetry break at step 0.

## What ships

| File | Change |
|---|---|
| `bucket_brigade/training/joint_trainer.py` | New `per_agent_init_seed_offset` kwarg + per-agent init loop (90 lines) |
| `experiments/p3_specialization/train.py` | `CellConfig` field + CLI flag `--per-agent-init-seed-offset` (33 lines) |
| `experiments/p3_specialization/run_tier1_cell.py` | `het_ppo` entry in `TRAINERS` dispatch (12 lines) |
| `experiments/scripts/launch_het_ppo_sweep.sh` | Operator-driven launcher (Option-A pattern, mirroring PR #393) |
| `experiments/p3_specialization/het_ppo_runbook.md` | Phase 1/2/3 launch plans + host assignments + retrieval flow |
| `tests/test_joint_trainer.py::TestAsymmetryAwareInit` | 8 trainer-side tests |
| `tests/test_tier1_driver.py::test_het_ppo_*` | 2 dispatch tests |
| `tests/test_launch_het_ppo_sweep.py` | 14 launcher contract tests |

## What this PR does NOT do

- Does **not** launch the Phase 1 or Phase 2 sweeps. Per CLAUDE.md, multi-hour cluster work is operator-driven, not safe for a builder session to spawn. The operator runs `./experiments/scripts/launch_het_ppo_sweep.sh ...` from a checkout that has this PR merged. The runbook walks through Plans A/B/C.
- Does **not** modify the legacy single-stream init path. The default (`per_agent_init_seed_offset=None`) is bit-identical to pre-#386 behavior (verified by `test_default_none_preserves_legacy_init` and by a direct param-equality check across all 4 agents at seed=42).

## Test plan

- [x] `uv run pytest tests/test_joint_trainer.py tests/test_tier1_driver.py tests/test_launch_het_ppo_sweep.py tests/test_launch_phase_diagram_fill.py` -> 122 passed
- [x] Broader sweep `uv run pytest tests/ --ignore=tests/test_evolution.py --ignore=tests/test_nash_trained_ppo.py --ignore=tests/test_code_generation.py` -> 671 passed, 59 skipped, 0 failed (the ignored modules have pre-existing import / env failures unrelated to this PR)
- [x] `uv run ruff check` on all touched files -> clean (30 pre-existing errors on `main`, none in files touched here)
- [x] `uv run ruff format --check` on all touched files -> clean
- [x] `bash -n experiments/scripts/launch_het_ppo_sweep.sh` -> syntax OK
- [x] CLI smoke test: `python -m experiments.p3_specialization.train --scenario minimal_specialization --lambda-red 0.0 --seed 7 --output-dir /tmp/smoke --num-iterations 1 --rollout-steps 32 --per-agent-init-seed-offset 1000` -> exit 0, one iteration logged, `config.json` records `per_agent_init_seed_offset=1000`
- [x] Tier-1 dispatch smoke test: `python experiments/p3_specialization/run_tier1_cell.py --trainer het_ppo --scenario rest_trap --seeds 42 --num-iterations 1 --rollout-steps 32 --output-root /tmp/het_ppo_tier1_smoke --skip-precheck` -> completes with verdict + `cell_summary.json`
- [x] Launcher dry-run with both auto-resolve and explicit host
- [ ] (operator-only) end-to-end Phase 1 launch on a real host with full budget

## Acceptance criteria (per #386)

- **Phase 1 (rest_trap)**: target `gap_closed_mean >= 0.49` (`partial_upper` tier or better). Awaits operator launch.
- **Phase 2 (asymmetric_only phase-diagram cells)**: per-cell `gap_closed` reported with the same protocol as #360. Awaits #358's per-cell scenario file emission + operator launch.
- **Phase 3 (optional symmetric_only sanity check)**: not required by the issue's acceptance criteria; mentioned in the runbook for completeness.

## Caveats

- The Phase 2 cells (`asym_b05_k05_c09`, `asym_b05_k09_c09`) referenced in the runbook are placeholder scenario names. They will exist as concrete scenarios once #358 ships the cell-to-scenario mapping driver. `rest_trap` is the only `asymmetric_only` scenario currently committed; Phase 1 is fully launchable today.
- The implementation is intentionally minimal — the issue body itself notes "First check whether the trainer already exposes a `share_parameters=False` (or equivalent) mode — if so this is mostly a config change". It is mostly a config change. The architectural per-position commitment is the `per_agent_init_seed_offset` knob; the larger HARL / SePS alternatives mentioned in the issue are not needed here because the trainer's per-position-distinct policies are already wired.

Closes #386 (operationally — Phase 1/2 sweep results will land via the operator running the launcher and committing the `cell_summary.json` artifacts in a follow-up PR).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>