### PR TITLE
docs(release): ENV.md + PAPER_RESULTS.md + README quick-start (#372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ pnpm install
 pnpm run dev   # http://localhost:5173
 ```
 
+### Five-minute "try it" — Gymnasium env
+
+The library ships a Gymnasium-compatible `make()` keyed on **versioned
+scenario IDs** (e.g. `minimal_specialization-v1`) so every paper result
+is reproducible by ID:
+
+```python
+import bucket_brigade
+
+print(bucket_brigade.list_envs())
+# ['chain_reaction-v1', 'default-v1', 'minimal_specialization-v1', ...]
+
+env = bucket_brigade.make("minimal_specialization-v1")
+obs, info = env.reset(seed=0)
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+
+# Batched / vectorized:
+vec = bucket_brigade.make_vec("minimal_specialization-v1", num_envs=8)
+```
+
+Full env API reference (observation/action layout, registry policy,
+vectorized wrapper): [docs/ENV.md](docs/ENV.md). Formal mathematical
+spec from the paper: [paper/anvil_memo.env_spec.1/env_spec.md](paper/anvil_memo.env_spec.1/env_spec.md).
+
 Run a game, a batch, or Nash analysis:
 
 ```bash
@@ -58,6 +82,12 @@ uv run python -m experiments.p3_specialization.train --num-iterations 100 --roll
 ```
 
 See [docs/TRAINING_GUIDE.md](docs/TRAINING_GUIDE.md) for the full training workflow.
+
+### Paper artifacts
+
+For one-line reproduction commands per paper figure, ship-ready artifact
+paths, and the heterogeneous-Nash + phase-diagram + specialist
+exploitability writeups: [docs/PAPER_RESULTS.md](docs/PAPER_RESULTS.md).
 
 ## Repo layout
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,187 @@
+# Bucket Brigade — Environment API
+
+Reference for the public `bucket_brigade` Python entry points: `make()`,
+`make_vec()`, `list_envs()`, and the versioned scenario registry. This is
+the *programming surface*. The *mathematical contract* lives in
+[`paper/anvil_memo.env_spec.1/env_spec.md`](../paper/anvil_memo.env_spec.1/env_spec.md)
+(paper §2) — read that for the formal definition of states, dynamics,
+and rewards. This document covers only what you need to wire the env
+into a training pipeline or evaluation harness.
+
+## Quick reference
+
+```python
+import bucket_brigade
+
+# 1. Pick a scenario.
+print(bucket_brigade.list_envs())
+# ['chain_reaction-v1', 'deceptive_calm-v1', 'default-v1', ...]
+
+# 2. Make a single env.
+env = bucket_brigade.make("minimal_specialization-v1")
+obs, info = env.reset(seed=0)
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+
+# 3. Or a synchronous batched vector env (issue #370).
+vec = bucket_brigade.make_vec("minimal_specialization-v1", num_envs=8)
+obs, info = vec.reset(seed=0)  # obs.shape == (8, obs_dim)
+```
+
+Both `make()` and `make_vec()` accept an optional `num_agents` override.
+Overriding produces an env that is **not covered by the frozen scenario
+ID's reproducibility guarantee**; record the override in your experiment
+metadata if you use it.
+
+## Versioned scenario registry
+
+Frozen scenario IDs are the **reproducibility surface**. Every paper
+result is keyed on an ID like `minimal_specialization-v1`, and the
+registry is **append-only in the version direction**: once shipped, a
+`-vN` ID never changes its meaning. If a scenario's parameters, obs/action
+shape, or RNG sequence change, the new behavior gets a new `-vN+1` ID
+and the old one stays frozen.
+
+See [`bucket_brigade/envs/registry.py`](../bucket_brigade/envs/registry.py)
+for the full version-bump policy and the live registry table.
+
+| Scenario ID | Brief |
+|---|---|
+| `default-v1` | 10 houses, 4 agents, mid-difficulty baseline |
+| `hard-v1` | High-pressure variant of `default` |
+| `trivial_cooperation-v1` | Sanity-check scenario — cooperation is trivially optimal |
+| `early_containment-v1` | Tests early fire suppression |
+| `greedy_neighbor-v1` | Owner-only reward — encourages neighbor neglect |
+| `sparse_heroics-v1` | Rare high-payoff cooperative moments |
+| `rest_trap-v1` | Asymmetric Nash — three free-riders + one firefighter ([see PAPER_RESULTS.md](PAPER_RESULTS.md#3-heterogeneous-nash-equilibria)) |
+| `chain_reaction-v1` | Tests fire-spread containment |
+| `deceptive_calm-v1` | Tests handling of misleading low-fire periods |
+| `overcrowding-v1` | Many agents competing for few targets |
+| `mixed_motivation-v1` | Mixed individual + team incentives |
+| `minimal_specialization-v1` | P3 specialization diagnostic — symmetric all-Hero NE ([see PAPER_RESULTS.md](PAPER_RESULTS.md#3-heterogeneous-nash-equilibria)) |
+| `v2_minimal-v1` | 2-house topology, PPO learnability diagnostic (#254) |
+
+`bucket_brigade.list_envs()` returns the live sorted list. The default
+number of agents for every frozen ID is **4**
+(`bucket_brigade.DEFAULT_NUM_AGENTS`).
+
+## Observation space
+
+`env.observation_space` is a `gymnasium.spaces.Box` of dtype `float32`.
+At the default parameterization (`num_agents=4`, ring size depends on
+scenario), the flat observation vector — per agent, concatenated along
+the joint-controller view — packs the following channels in order:
+
+| Channel | Shape | Source |
+|---|---|---|
+| `houses` | `(H,)` | House status one-hot/encoding per house |
+| `signals` | `(N,)` | Previous-night signals broadcast by each agent |
+| `locations` | `(N,)` | Previous-night agent locations |
+| `last_actions` | `(2N,)` | Previous-night `(house, mode)` per agent |
+| `scenario_info` | varies | Static scenario parameters (work cost, etc.) |
+| `identity` | `(N,)` | One-hot identity tail (per-agent in the multi-agent flattener) |
+
+The joint-controller wrapper (used by `make()` / `make_vec()`)
+concatenates `num_agents` of these per-agent vectors into a single flat
+observation. The shape is published on `env.observation_space.shape`
+— do not hard-code it; the layout is stable per frozen ID but the exact
+dimension depends on `(H, N)`.
+
+For the formal observation tuple $o_t = (h_t, \ell_{t-1}, \zeta_{t-1},
+\alpha_{t-1}, t)$ and the underlying state, see
+[paper/anvil_memo.env_spec.1/env_spec.md §2.3](../paper/anvil_memo.env_spec.1/env_spec.md).
+
+## Action space
+
+`env.action_space` is a `gymnasium.spaces.MultiDiscrete`. Per-agent
+action layout is `[house, mode, signal]` (length 3):
+
+| Component | Range | Meaning |
+|---|---|---|
+| `house` | `[0, H)` | Target house index |
+| `mode` | `{0, 1}` | `0` = REST, `1` = WORK |
+| `signal` | `{0, 1}` | Broadcast bit (observable next night) |
+
+The joint action layout for `N` agents is
+`[house_0, mode_0, signal_0, house_1, mode_1, signal_1, ...]`
+(length `3N`). At `num_agents=4`, `num_houses=10` (the default), this is
+`MultiDiscrete([10, 2, 2, 10, 2, 2, 10, 2, 2, 10, 2, 2])`.
+
+The signal bit is **strictly informational** — it does not constrain the
+agent's `mode` or `house` choice, and other agents cannot reject it.
+Signals support cheap-talk equilibria; their interpretation is not part
+of the game spec
+([env_spec §2.2](../paper/anvil_memo.env_spec.1/env_spec.md)).
+
+## Reward
+
+`env.step()` returns a scalar `reward` — the **team-summed reward**
+across all agents for the night. Per-agent rewards are surfaced
+losslessly via `info["per_agent_rewards"]`, a length-`N` `numpy.ndarray`,
+so multi-agent consumers retain the full decomposition.
+
+The per-agent reward decomposes into a private work/rest cost, a
+per-house ownership term, and a team-welfare term; the formal
+specification is in
+[env_spec §4](../paper/anvil_memo.env_spec.1/env_spec.md).
+
+## Episode lifecycle
+
+- `reset(seed=int) -> (obs, info)` — standard Gymnasium contract; `info`
+  on reset contains at minimum `scenario_id`.
+- `step(action) -> (obs, reward, terminated, truncated, info)` —
+  `truncated` is always `False` (the env signals end-of-episode via
+  `terminated` only; episodes are bounded by `min_nights` + natural
+  termination, not a fixed time cap).
+- `info["scenario_id"]` is set on every `reset` and `step` for
+  traceability of downstream artifacts.
+
+Episode-termination conditions and the `T_min` clamp are documented in
+[env_spec §5.1](../paper/anvil_memo.env_spec.1/env_spec.md).
+
+## Vectorized env (`make_vec`)
+
+`bucket_brigade.make_vec(id, num_envs)` returns a
+`bucket_brigade.envs.vector.SyncVectorEnv` — a synchronous batched
+wrapper around `num_envs` independent `BucketBrigadeGymEnv` instances
+built from the same versioned scenario ID. The vectorized API follows
+Gymnasium's batched conventions with auto-reset semantics: terminal
+observations surface via `info["final_observation"]` and
+`info["final_info"]`. See
+[`bucket_brigade/envs/vector.py`](../bucket_brigade/envs/vector.py) for
+implementation details and the issue #370 motivation.
+
+```python
+vec = bucket_brigade.make_vec("default-v1", num_envs=8)
+obs, info = vec.reset(seed=42)
+# obs.shape == (8, obs_dim); per-sub-env actions are stacked the same way
+actions = np.stack([vec.action_space.sample() for _ in range(8)])
+obs, rewards, terminated, truncated, info = vec.step(actions)
+```
+
+## Compatibility notes
+
+- The adapter is a `gymnasium.Env`. Stable-Baselines3, CleanRL, Tianshou,
+  and similar **single-agent** pipelines consume it directly.
+- The adapter is a **joint-controller** single-agent view. External
+  multi-agent researchers who want per-agent reward streams should read
+  `info["per_agent_rewards"]` (preserved verbatim).
+- A PettingZoo Parallel surface is **not** shipped in this slice (see
+  issue #369 scope notes). The native multi-agent surface remains
+  available via `bucket_brigade.envs.bucket_brigade_env.BucketBrigadeEnv`
+  for in-repo research; the Gym adapter is intentionally minimal so
+  external pipelines work without Rust extension builds.
+- The Gym adapter does **not** require the Rust `bucket_brigade_core`
+  extension. Pure-Python users get a fully functional env from
+  `pip install bucket-brigade` alone. The Rust extension stays optional
+  and gives ~100× throughput for evolution/Nash workloads (see
+  [README.md Quickstart](../README.md#quickstart)).
+
+## See also
+
+- **Formal spec (paper §2)**: [`paper/anvil_memo.env_spec.1/env_spec.md`](../paper/anvil_memo.env_spec.1/env_spec.md)
+- **Game-mechanics walkthrough**: [`docs/game_mechanics.md`](game_mechanics.md)
+- **Design philosophy**: [`docs/game_description.md`](game_description.md)
+- **Paper results**: [`docs/PAPER_RESULTS.md`](PAPER_RESULTS.md)
+- **Registry implementation**: [`bucket_brigade/envs/registry.py`](../bucket_brigade/envs/registry.py)
+- **Gym adapter**: [`bucket_brigade/envs/gym_adapter.py`](../bucket_brigade/envs/gym_adapter.py)
+- **Vector env**: [`bucket_brigade/envs/vector.py`](../bucket_brigade/envs/vector.py)

--- a/docs/PAPER_RESULTS.md
+++ b/docs/PAPER_RESULTS.md
@@ -1,0 +1,246 @@
+# Bucket Brigade — Paper Results
+
+Reproduction guide for the figures and tables that ship with the
+Bucket Brigade workshop paper. Each section lists the in-repo artifact
+paths, the one-line command to regenerate the result, and any compute
+caveats. All commands assume:
+
+- The repo is cloned and `uv sync --extra rl` has been run.
+- The Rust extension is built (`bash bucket-brigade-core/build.sh`) —
+  Nash and evolution runs need the ~100× speedup or the wall-clock
+  budgets explode.
+- Commands marked **`[remote]`** are designed for a multi-core remote
+  host. See [`experiments/REMOTE_EXECUTION.md`](../experiments/REMOTE_EXECUTION.md)
+  and [`CLAUDE.md`](../CLAUDE.md) for the cluster workflow.
+
+## Index
+
+1. [Environment specification (paper §2)](#1-environment-specification-paper-2)
+2. [Benchmark comparison (paper §1)](#2-benchmark-comparison-paper-1)
+3. [Heterogeneous Nash equilibria (paper §3)](#3-heterogeneous-nash-equilibria)
+4. [Nash phase diagram across (β, κ, c)](#4-nash-phase-diagram-across-β-κ-c)
+5. [Specialist exploitability harness](#5-specialist-exploitability-harness)
+
+---
+
+## 1. Environment specification (paper §2)
+
+**Result**: The formal mathematical contract for the Bucket Brigade
+environment — player set, parameter family, state/action/observation
+spaces with exact cardinalities, seven-phase night dynamics, reward
+structure, and the relationship to canonical game-theory templates
+(Volunteer's Dilemma, N-player Public Goods, Stag Hunt, stochastic
+games). Self-contained: a reader unfamiliar with the codebase can
+reimplement the env from this document alone.
+
+**Artifact**: [`paper/anvil_memo.env_spec.1/env_spec.md`](../paper/anvil_memo.env_spec.1/env_spec.md)
+
+**How to verify**: The cardinalities cited in the spec
+(2304 states and 4096 joint actions at `H=2, N=4`) can be checked
+directly:
+
+```bash
+uv run python -c "
+import bucket_brigade
+env = bucket_brigade.make('v2_minimal-v1')
+print('obs space:', env.observation_space)
+print('action space:', env.action_space)
+print('joint action cardinality:', int(env.action_space.nvec.prod()))
+"
+```
+
+For the Python-side env API reference, see [`docs/ENV.md`](ENV.md).
+
+**Source**: PR #375 / issue #362.
+
+---
+
+## 2. Benchmark comparison (paper §1)
+
+**Result**: Positioning of Bucket Brigade against the canonical
+cooperative-MARL benchmarks (Overcooked, Hanabi, SMAC, Melting Pot,
+MAgent, PettingZoo MPE). The two distinguishing properties are
+(a) state and joint-action spaces small enough to enumerate at minimal
+parameterizations, so Nash equilibria can be computed exactly rather
+than approximated, and (b) load-bearing parameters $(\beta, \kappa, c)$
+that move equilibrium structure continuously between cooperative-dominant
+and free-rider-dominant regimes.
+
+**Artifact**: [`paper/anvil_report.benchmark_comparison.1/`](../paper/anvil_report.benchmark_comparison.1/)
+
+**How to verify**: Read the report — no computation to rerun.
+
+---
+
+## 3. Heterogeneous Nash equilibria
+
+**Result**: Heterogeneous Double-Oracle Nash analysis on two
+canonical scenarios resolves the symmetric-vs-asymmetric question
+that symmetric DO was failing on.
+
+| Scenario | Verdict | Best converged NE | Pattern |
+|---|---|---|---|
+| `minimal_specialization-v1` | `symmetric_ne_superior` | **−756** (sym Hero) | 4/5 converged restarts are pure all-Hero |
+| `rest_trap-v1` | `asymmetric_only` | **+2984** (asym FR/FF) | 8/13 converged restarts are `FR × 3 + FF × 1` |
+
+Role-differentiated specialization is **not** a Nash equilibrium on
+`minimal_specialization`; the symmetric all-Hero strategy dominates any
+asymmetric deviation. `rest_trap` admits **zero** symmetric NE — the
+free-rider equilibrium (three free-riders plus one firefighter) is the
+only stable profile.
+
+**Artifacts**:
+- Headline writeup: [`experiments/nash/heterogeneous/RESULTS.md`](../experiments/nash/heterogeneous/RESULTS.md)
+- Per-scenario summaries: [`experiments/nash/heterogeneous/minimal_specialization/summary.md`](../experiments/nash/heterogeneous/minimal_specialization/summary.md), [`experiments/nash/heterogeneous/rest_trap/summary.md`](../experiments/nash/heterogeneous/rest_trap/summary.md)
+- Raw equilibrium results: `experiments/nash/heterogeneous/{minimal_specialization,rest_trap}/results.json`
+
+**Reproduce** **`[remote]`** — full sweep is ~5–7h per scenario on a
+32-thread CPU box:
+
+```bash
+uv run python experiments/scripts/compute_nash_heterogeneous.py minimal_specialization \
+    --restarts 20 --simulations 1000 --opt-simulations 300 \
+    --max-iterations 25 --epsilon 50 --seed 42
+
+uv run python experiments/scripts/compute_nash_heterogeneous.py rest_trap \
+    --restarts 20 --simulations 1000 --opt-simulations 300 \
+    --max-iterations 25 --epsilon 50 --seed 42
+```
+
+**Regenerate verdict tables from existing `results.json`** (no compute):
+
+```bash
+uv run python experiments/nash/heterogeneous/regen_summaries.py
+```
+
+**Source**: PRs #354 / #355 (sweep + verdict-logic fix).
+
+---
+
+## 4. Nash phase diagram across (β, κ, c)
+
+**Result**: Verdict map of heterogeneous Nash structure across the
+$(\beta, \kappa, c)$ grid. The $c=0.5$ plane shows a clean κ-driven
+phase pattern: low κ collapses to `no_convergence` (negative equilibrium
+payoff, no one extinguishes), mid κ admits `symmetric_only` NE, and high
+κ pushes the system into `asymmetric_only` free-rider territory.
+β does not move the regime within the partial slice that has been
+filled — the phase boundary at $c=0.5$ is one-dimensional in κ.
+
+Partial preview (7 of 18 design cells at $c=0.5$):
+
+| β\κ  | 0.10 | 0.50 | 0.90 |
+|------|------|------|------|
+| 0.10 | `no_convergence` | (missing) | (missing) |
+| 0.50 | `no_convergence` | `symmetric_only` | `asymmetric_only` |
+| 0.90 | `no_convergence` | `symmetric_only` | `asymmetric_only` |
+
+The frequency-cap validation rerun (alc-5 at 4.5 GHz) returned
+bit-identical verdicts, payoffs, and convergence rates to the
+unconstrained alc-2 host — confirming the solver is deterministic given
+the seed and that the cap is a correctness-preserving stability
+workaround for the Raptor Lake degradation crashes observed during the
+preview run.
+
+**Artifacts**:
+- Figures: `experiments/nash/phase_diagram/phase_diagram.png`, `experiments/nash/phase_diagram/phase_diagram_freqtest.png`
+- Tables: [`experiments/nash/phase_diagram/phase_diagram_table.md`](../experiments/nash/phase_diagram/phase_diagram_table.md), `experiments/nash/phase_diagram/phase_diagram_table_freqtest.md`
+- Recovery writeup: [`experiments/nash/phase_diagram/RECOVERY_NOTES.md`](../experiments/nash/phase_diagram/RECOVERY_NOTES.md)
+- Per-cell raw outputs: `experiments/nash/phase_diagram/preview/<host>/cells/*/summary.json`
+- Aggregate inputs: `experiments/nash/phase_diagram/results.json`, `results_freqtest.json`
+
+**Reproduce a single cell** **`[remote]`** — ~5.5h per cell at design
+budgets, ~25–30 min for a non-converging restart:
+
+```bash
+uv run python experiments/scripts/compute_nash_phase_diagram.py \
+    --beta-values 0.5 --kappa-values 0.9 --c-values 0.5 \
+    --restarts 20 --simulations 1000 --opt-simulations 300 \
+    --max-iterations 25 --epsilon 50 --seed 42 \
+    --num-workers $(nproc)
+```
+
+**Regenerate figures and tables from `results.json`** (no compute):
+
+```bash
+uv run python experiments/scripts/plot_phase_diagram.py \
+    experiments/nash/phase_diagram/results.json
+```
+
+**Fill gaps using the runbook script** **`[remote, multi-host]`** —
+see [`experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md`](../experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md)
+for the three-plan operator workflow:
+
+```bash
+./experiments/scripts/launch_phase_diagram_fill.sh \
+    --beta-values 0.1 --kappa-values 0.5,0.9 --c-values 0.5 \
+    --num-workers 32
+```
+
+**Source**: PRs #387 (preview results + recovery notes), #391
+(per-restart checkpointing), #392 (parallel Pool fix that gets cluster
+hosts saturating), #393 (launch runbook + script).
+
+---
+
+## 5. Specialist exploitability harness
+
+**Result**: Per-position best-response check that verifies a 4-player
+heterogeneous Nash profile is exploitation-robust. For each position,
+the harness holds the other three positions fixed at the equilibrium
+strategy, runs a 5-archetype grid scan plus L-BFGS-B refinement on the
+10-d parameter vector, and flags a position as exploitable iff
+`BR_payoff − equilibrium_payoff > ε`.
+
+The harness is shipped as a *script* (commit-merged); the full
+verdict-producing sweep is a remote-only multi-hour job that operators
+launch manually per scenario.
+
+**Artifact**: [`experiments/scripts/test_specialist_exploitability.py`](../experiments/scripts/test_specialist_exploitability.py)
+
+**Reproduce** **`[remote]`** — ~1.5h per scenario on a 32-thread box,
+writes `experiments/nash/heterogeneous/<scenario>/exploitability.json`
+with per-position `{equilibrium_payoff, best_response_payoff, gap,
+exploitable_flag, best_response_closest_archetype}` plus an aggregate
+`any_exploitable` flag (and non-zero exit if any flag is true):
+
+```bash
+uv run python experiments/scripts/test_specialist_exploitability.py rest_trap
+uv run python experiments/scripts/test_specialist_exploitability.py minimal_specialization
+```
+
+**Validate the harness wires correctly without paying the full cost**:
+
+```bash
+uv run python experiments/scripts/test_specialist_exploitability.py rest_trap \
+    --smoke --simulations 20 --opt-simulations 10 --positions 0
+```
+
+A companion symmetric-NE verification harness lives at
+[`experiments/scripts/test_specialist_nash.py`](../experiments/scripts/test_specialist_nash.py)
+(PR #378). It does a best-response chain in heuristic-parameter space
+against the `minimal_specialization` specialist baseline.
+
+**Source**: PRs #376 (per-position exploitability harness), #378
+(symmetric specialist Nash chain).
+
+---
+
+## Repro environment
+
+A clean reproduction sequence on a fresh machine:
+
+```bash
+git clone https://github.com/rjwalters/bucket-brigade.git
+cd bucket-brigade
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync --extra rl
+bash bucket-brigade-core/build.sh   # ~100x speedup for Nash/evolution
+uv run pytest tests/                 # sanity check the install
+```
+
+For the Python env API, see [`docs/ENV.md`](ENV.md). For training, see
+[`docs/TRAINING_GUIDE.md`](TRAINING_GUIDE.md). For Nash benchmarking
+provenance, see [`docs/NASH_BENCHMARKS.md`](NASH_BENCHMARKS.md). For the
+formal env spec referenced from §2 of the paper, see
+[`paper/anvil_memo.env_spec.1/env_spec.md`](../paper/anvil_memo.env_spec.1/env_spec.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ This documentation directory contains detailed guides, specifications, and resea
 
 ## Quick Start
 
+- **[Env API (`ENV.md`)](ENV.md)** - Python `make()` / `make_vec()` reference + versioned scenario registry
+- **[Paper Results (`PAPER_RESULTS.md`)](PAPER_RESULTS.md)** - One-line reproduction commands per paper figure
 - **[Game Mechanics](game_mechanics.md)** - Complete rules and game mechanics
 - **[Agent Roster](AGENT_ROSTER.md)** - Available AI agents (Firefighter, Hero, Free Rider, etc.)
 - **[API Reference](archive/API.md)** - Technical API and data structures (archived — aspirational, see SIMPLIFIED_ARCHITECTURE.md for current)


### PR DESCRIPTION
Closes #372.

Slice 4/5 of the M4 release-infra epic (#365).

## Summary

Three release docs that let a fresh reader install, reproduce a paper figure, and look up the env API without diving into the codebase.

- **`docs/ENV.md`** (~140 lines) — Python entry-point reference for `bucket_brigade.make()` / `make_vec()` / `list_envs()` plus the versioned scenario registry table. Documents the observation/action/reward layout and the Gymnasium-compat notes (joint-controller view, `info["per_agent_rewards"]`, optional Rust core). Defers the formal mathematical contract to `paper/anvil_memo.env_spec.1/env_spec.md` (paper §2 / PR #375) rather than duplicating it — every section that needs formality cites the env-spec memo by anchor.

- **`docs/PAPER_RESULTS.md`** (~180 lines) — one-line reproduction commands per paper artifact, organized by paper section:
  1. Environment specification (paper §2) — `paper/anvil_memo.env_spec.1/env_spec.md`
  2. Benchmark comparison report
  3. Heterogeneous Nash (#354 / #355) — `minimal_specialization-v1` = `symmetric_ne_superior`, `rest_trap-v1` = `asymmetric_only`
  4. (β, κ, c) phase diagram (PRs #387 / #391 / #392 / #393) — partial preview + freq-cap validation table, plus the `launch_phase_diagram_fill.sh` runbook
  5. Specialist exploitability harness (PRs #376 / #378)

  Compute-heavy commands are tagged `[remote]`. Cheap regeneration paths (`regen_summaries.py`, `plot_phase_diagram.py`) are also called out so a reviewer can spot-check tables/figures without paying the multi-hour cost.

- **`README.md`** — adds a "Five-minute try-it" snippet (`bucket_brigade.make("minimal_specialization-v1")`) plus a "Paper artifacts" pointer to the two new docs. Existing CLI examples preserved.

- **`docs/README.md`** — surfaces `ENV.md` and `PAPER_RESULTS.md` at the top of the Quick Start section so the doc index points at them.

## Test plan

- [x] `bucket_brigade.make("minimal_specialization-v1")` returns a working `gym.Env` with `obs.shape == (168,)` and `action_space == MultiDiscrete([10,2,2]*4)`, matching the doc.
- [x] `bucket_brigade.list_envs()` returns the 13 scenario IDs listed in the registry table.
- [x] Pre-commit hooks pass on the four touched files (`trim trailing whitespace`, `fix end of files`, etc. all green; ruff/bandit skip markdown by design).
- [x] All relative links in the new docs resolve to existing files in the repo (env_spec.md, RESULTS.md, RECOVERY_NOTES.md, LAUNCH_RUNBOOK.md, registry.py, gym_adapter.py, vector.py, etc.).
- [x] Rebased onto latest `origin/main` (8a2f7f9c).
- [x] Diff is docs-only — no Python / Rust / TS code touched.

## Out of scope

- pip wheel / HuggingFace distribution — slice 5/5, separate issue (#373).
- New paper figures or rerunning any experiments — uses only artifacts already on `main` per issue instructions.
- A docs-CI lint workflow — not requested in the issue body.