### PR TITLE
fix(p3): add het_ppo to launcher KNOWN_TRAINERS

### DIFF
--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -198,6 +198,7 @@ KNOWN_TRAINERS=(
     macro_actions
     reinforce
     pbt
+    het_ppo
 )
 
 is_known_trainer() {


### PR DESCRIPTION
## Summary

One-line fix for a drift introduced when PR #394 (tier-1 launcher) and PR #395 (asymmetry-aware PPO arm with new `het_ppo` trainer) both landed today.

PR #394 added a `test_launcher_known_trainers_matches_driver_trainers` drift-check test that verifies the launcher's `KNOWN_TRAINERS` array matches the driver's `TRAINERS` dispatch dict. PR #395 added `het_ppo` to `TRAINERS` without updating `KNOWN_TRAINERS`. The drift-check test caught this — exactly its purpose. This PR closes the gap.

## Diff

```diff
     reinforce
     pbt
+    het_ppo
 )
```

## Test plan

- [x] `uv run pytest tests/test_launch_tier1_sweep.py -v` → 18/18 pass (was 17/18 with the drift-check failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)