### PR TITLE
exp(nash): operator launcher for rest_trap re-run (#349)

### DIFF
--- a/experiments/nash/v1_results_python_post240/README.md
+++ b/experiments/nash/v1_results_python_post240/README.md
@@ -10,7 +10,9 @@ landed in PR #245 (issue #240).
 `equilibrium.json` write step on 2026-05-16, almost certainly the
 ENOSPC-on-write incident documented in #269 (now fixed by the
 `df`-precheck in PR #315). Re-running `rest_trap` alone is cheap and is
-left as a follow-up.
+tracked by issue #349 — see [`RERUN_RUNBOOK.md`](./RERUN_RUNBOOK.md) and
+[`experiments/scripts/launch_rest_trap_rerun.sh`](../../scripts/launch_rest_trap_rerun.sh)
+for the operator launch procedure.
 
 Sweep was launched in tmux session `nash256` on `COMPUTE_HOST_PRIMARY`
 (Mac Studio, M-series; ~16 performance cores) as part of issue #256.

--- a/experiments/nash/v1_results_python_post240/RERUN_RUNBOOK.md
+++ b/experiments/nash/v1_results_python_post240/RERUN_RUNBOOK.md
@@ -1,0 +1,168 @@
+# `rest_trap` Nash re-run — operator runbook
+
+This runbook is the operator companion to
+[`experiments/scripts/launch_rest_trap_rerun.sh`](../../scripts/launch_rest_trap_rerun.sh).
+It exists to fill the **single missing cell** of the V1 post-#240
+re-derivation sweep — the `rest_trap` scenario, which is the 12th of 12
+and the only one whose `equilibrium.json` is not yet committed to this
+directory.
+
+Tracked by [issue #349][issue-349]. The original sweep (#256, tmux
+session `nash256` on `COMPUTE_HOST_PRIMARY`, 2026-05-16) completed 11 of
+12 scenarios and then ran `rest_trap` into an `ENOSPC` failure at the
+final `equilibrium.json` write step. PR #347 recovered the 11 successful
+artifacts; the `rest_trap` cell has to be re-run from scratch.
+
+The disk-full failure mode is now permanently prevented by the
+`df`-precheck added in PR #315 (closes #269, verified wired at
+`compute_nash.py:329`). It's safe to re-run `rest_trap` alone without
+re-burning the ~5 hour sweep on the other 11 scenarios — the launcher
+defaults match the canonical sweep so the resulting artifact is
+schema-comparable.
+
+[issue-349]: https://github.com/rjwalters/bucket-brigade/issues/349
+
+The launch script does **not** run any compute locally — it shells into
+a remote host listed in `.env`, pulls latest `main`, builds the Rust
+extension, and starts a detached `tmux` session running the driver
+([`compute_nash.py`](../../scripts/compute_nash.py)) with the canonical
+single-scenario invocation. The actual `rest_trap` cell completes ~25–35
+minutes later inside the tmux session (Mac Studio, M-series ~16
+performance cores); the operator's job is to launch, wait, then rsync
+and verify.
+
+## Prerequisites
+
+- The `.env` file at the repo root must define at least one
+  `COMPUTE_HOST_*` alias resolvable via the local `~/.ssh/config`
+  (see `.env.example`).
+- `COMPUTE_HOST_PRIMARY` is the canonical target (the Mac Studio that
+  ran the original `nash256` sweep) but any healthy CPU box works — the
+  scenario is CPU-bound, GPU offers no speed-up.
+- No need for the #391/#392 phase-diagram performance fixes here.
+  `compute_nash.py` is the V1 sweep driver, not the heterogeneous
+  phase-diagram driver — its compute graph is small enough that the
+  default settings already finish in well under an hour.
+
+## Canonical sweep parameters
+
+These are the **exact** values used by the other 11 sibling scenarios.
+Acceptance criterion (from the issue body) requires the `rest_trap`
+equilibrium to match this schema, so the launcher defaults are
+locked-in:
+
+| Parameter         | Value | Source                                  |
+|-------------------|-------|------------------------------------------|
+| `simulations`     | 200   | `nash256` sweep (issue #256, PR #347)    |
+| `max-iterations`  | 50    | `nash256` sweep                          |
+| `epsilon`         | 0.01  | `nash256` sweep                          |
+| `seed`            | 42    | `nash256` sweep                          |
+
+The launcher exposes overrides (`--simulations`, `--seed`, etc.) for
+experimentation, but **do not pass them for the issue #349 re-run** —
+the schema-match check downstream of the diff script will reject any
+drift from these values.
+
+## Launch command (copy-paste)
+
+The single-line, default-everything invocation:
+
+```bash
+./experiments/scripts/launch_rest_trap_rerun.sh
+```
+
+That auto-resolves the host from `.env` (priority:
+`PRIMARY → CLUSTER → LAMBDA → GCP`), verifies SSH reachability, bootstraps
+the remote, and starts a tmux session named `nash-rest-trap`.
+
+If you want to pick the host explicitly (e.g. `PRIMARY` is busy with
+something else):
+
+```bash
+./experiments/scripts/launch_rest_trap_rerun.sh --host alc-9
+```
+
+To preview without launching (no SSH, no remote side effects):
+
+```bash
+./experiments/scripts/launch_rest_trap_rerun.sh --dry-run
+```
+
+## Monitoring
+
+The launcher prints the tmux session name (`nash-rest-trap`) and log
+path on success. From local:
+
+```bash
+# Live attach
+ssh <host> -t 'tmux attach -t nash-rest-trap'
+
+# Tail the log
+ssh <host> 'tail -f bucket-brigade/experiments/nash/v1_results_python_post240/rest_trap/nash-rest-trap.log'
+```
+
+Typical progress lines look like the standard `compute_nash.py` output —
+periodic Double Oracle iteration summaries, then a final `✅ Results
+saved to: …/equilibrium.json` line.
+
+## After the cell finishes — rsync, verify, commit
+
+Once the tmux session has printed `✅ Results saved to:` and exited, do
+the merge locally:
+
+```bash
+# 1. Rsync the result back into this checkout.
+HOST=$(./experiments/scripts/launch_rest_trap_rerun.sh --dry-run | grep '^Host:' | awk '{print $2}')
+rsync -avz \
+    "$HOST:bucket-brigade/experiments/nash/v1_results_python_post240/rest_trap/" \
+    experiments/nash/v1_results_python_post240/rest_trap/
+
+# 2. Sanity-check the artifact is well-formed.
+uv run python -c "
+import json
+d = json.load(open('experiments/nash/v1_results_python_post240/rest_trap/equilibrium.json'))
+assert d['algorithm']['seed'] == 42, d['algorithm']
+assert d['algorithm']['num_simulations'] == 200, d['algorithm']
+assert d['algorithm']['max_iterations'] == 50, d['algorithm']
+assert d['algorithm']['epsilon'] == 0.01, d['algorithm']
+print('schema OK:', d['algorithm'])
+"
+
+# 3. Re-run the post-240 diff to populate docs/NASH_BENCHMARKS.md with
+#    the rest_trap row that has been blank since 2026-05-16.
+uv run python experiments/nash/scripts/diff_post240.py
+
+# 4. Update this directory's README.md to flip "11 of 12 complete" to
+#    "12 of 12 complete" and drop the rest_trap-as-follow-up paragraph.
+
+# 5. Commit + open a PR referencing #349.
+git add experiments/nash/v1_results_python_post240/rest_trap/equilibrium.json
+git add experiments/nash/v1_results_python_post240/README.md
+git add docs/NASH_BENCHMARKS.md  # if the diff script updated it
+git commit -m "exp(nash): re-run rest_trap to complete V1 post-#240 sweep (closes #349)"
+```
+
+## Troubleshooting
+
+- **Host unreachable**: the script aborts with exit 4 before consuming
+  any compute. Check `ssh -v <host>` and the host's reachability/power.
+- **df-precheck triggers**: the script will abort with a clear
+  `ERROR: only X.X MiB free on '...'; need at least 100 MiB. Aborting
+  before compute.` message — this is the PR #315 guard doing its job.
+  Free space on the target host's filesystem and re-launch.
+- **Build failure on remote**: if `bucket-brigade-core/build.sh`
+  complains about a stale `.so`, the remote venv is missing pip. The
+  script seeds pip automatically; if that fails, ssh in and run
+  `uv pip install pip && bash bucket-brigade-core/build.sh` once by
+  hand.
+- **Equilibrium schema mismatch**: if the post-rsync sanity check
+  asserts on `algorithm.seed != 42` etc., you (or someone) overrode the
+  launcher defaults. Re-launch without the overrides; the canonical
+  values are not negotiable for the schema-match AC.
+- **Diff script blank `rest_trap` row after merge**: the diff script
+  (`experiments/nash/scripts/diff_post240.py`) reads
+  `equilibrium.json` from each sibling dir. If the row is blank,
+  double-check that the rsync targeted
+  `experiments/nash/v1_results_python_post240/rest_trap/` and not a
+  sibling tree (e.g. `experiments/scenarios/rest_trap/nash/` — the
+  driver's own default output path when `--output-dir` is omitted).

--- a/experiments/scripts/launch_rest_trap_rerun.sh
+++ b/experiments/scripts/launch_rest_trap_rerun.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Launch the `rest_trap` Nash re-derivation on a remote host to fill the
+# 12th (and only missing) cell of the V1 post-#240 sweep. Tracks issue
+# #349, which exists because the original sweep (issue #256, tmux session
+# `nash256` on COMPUTE_HOST_PRIMARY, 2026-05-16) crashed at the
+# `equilibrium.json` write step with ENOSPC. The df-precheck from PR #315
+# (closes #269, now wired in compute_nash.py:329) makes a safe single-cell
+# re-run cheap (~25-35 min on a Mac Studio, vs. ~5 h for the whole sweep).
+#
+# The script does NOT compute anything locally. It only:
+#   1. Reads $COMPUTE_HOST_* aliases from .env to resolve a target host
+#      (unless --host is passed explicitly).
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts
+#      a detached tmux session running compute_nash.py with the canonical
+#      sweep parameters (seed=42, simulations=200, max-iterations=50,
+#      epsilon=0.01) — matching the other 11 sibling scenarios so the
+#      result is schema-comparable.
+#   4. Prints monitor / rsync / verify instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual rest_trap cell
+# completes ~30 minutes later inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Auto-resolve host from .env, run with the canonical sweep params
+#   ./experiments/scripts/launch_rest_trap_rerun.sh
+#
+#   # Explicit host
+#   ./experiments/scripts/launch_rest_trap_rerun.sh --host alc-2
+#
+#   # Override one of the sweep params (NOT recommended — the schema-match
+#   # acceptance criterion depends on the canonical values)
+#   ./experiments/scripts/launch_rest_trap_rerun.sh --seed 7 --simulations 500
+#
+#   # Dry-run prints the ssh + driver command without launching anything
+#   ./experiments/scripts/launch_rest_trap_rerun.sh --dry-run
+#
+# See experiments/nash/v1_results_python_post240/RERUN_RUNBOOK.md for the
+# canonical operator procedure, the post-run verification checklist, and
+# the diff/commit workflow.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Canonical sweep parameters from issue #256 / PR #347. Changing any of
+# these breaks the schema-match acceptance criterion (algorithm.seed = 42,
+# num_simulations = 200, max_iterations = 50, epsilon = 0.01) so they are
+# locked-in defaults that --simulations / --seed / etc. can override only
+# if the operator explicitly chooses to do so.
+DEFAULT_SCENARIO="rest_trap"
+DEFAULT_SIMULATIONS="200"
+DEFAULT_MAX_ITERATIONS="50"
+DEFAULT_EPSILON="0.01"
+DEFAULT_SEED="42"
+DEFAULT_OUTPUT_DIR="experiments/nash/v1_results_python_post240/rest_trap"
+DEFAULT_SESSION_NAME="nash-rest-trap"
+
+HOST=""
+SCENARIO="$DEFAULT_SCENARIO"
+SIMULATIONS="$DEFAULT_SIMULATIONS"
+MAX_ITERATIONS="$DEFAULT_MAX_ITERATIONS"
+EPSILON="$DEFAULT_EPSILON"
+SEED="$DEFAULT_SEED"
+OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+SESSION_NAME="$DEFAULT_SESSION_NAME"
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+
+print_usage() {
+    sed -n '2,43p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --scenario)
+            SCENARIO="$2"
+            shift 2
+            ;;
+        --simulations)
+            SIMULATIONS="$2"
+            shift 2
+            ;;
+        --max-iterations)
+            MAX_ITERATIONS="$2"
+            shift 2
+            ;;
+        --epsilon)
+            EPSILON="$2"
+            shift 2
+            ;;
+        --seed)
+            SEED="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+
+if [[ -z "$HOST" ]]; then
+    HOST=$(resolve_host_from_env)
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build driver command
+# ---------------------------------------------------------------------------
+
+# Compose the driver invocation as a single shell-safe string. Note that
+# `scenario` is a POSITIONAL argument in compute_nash.py:291 — not a flag.
+# The original issue body had a bug here (it said --scenario rest_trap)
+# that the curator caught; we lock the positional form into the launcher
+# so an operator cannot accidentally reintroduce that bug.
+DRIVER_CMD="uv run python experiments/scripts/compute_nash.py"
+DRIVER_CMD+=" '$SCENARIO'"
+DRIVER_CMD+=" --simulations $SIMULATIONS"
+DRIVER_CMD+=" --max-iterations $MAX_ITERATIONS"
+DRIVER_CMD+=" --epsilon $EPSILON"
+DRIVER_CMD+=" --seed $SEED"
+DRIVER_CMD+=" --output-dir '$OUTPUT_DIR'"
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default.
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the import before consuming a tmux session for a ~30-min run.
+uv run python -c "from bucket_brigade.equilibrium import DoubleOracle; print('ok')"
+
+mkdir -p $OUTPUT_DIR
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && $DRIVER_CMD 2>&1 | tee -a '$OUTPUT_DIR/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_DIR/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+echo "===================================================================="
+echo "rest_trap Nash re-run launch (issue #349)"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output dir:     $OUTPUT_DIR    (on remote)"
+echo "Scenario:       $SCENARIO"
+echo "Simulations:    $SIMULATIONS"
+echo "Max iterations: $MAX_ITERATIONS"
+echo "Epsilon:        $EPSILON"
+echo "Seed:           $SEED"
+echo ""
+echo "Driver command (to be run inside tmux on remote):"
+echo "  $DRIVER_CMD"
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_DIR}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done (~30 min), rsync result back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_DIR}/ ${OUTPUT_DIR}/"
+echo ""
+echo "  # Verify the artifact is well-formed:"
+echo "  uv run python -c \"import json; d = json.load(open('${OUTPUT_DIR}/equilibrium.json')); print(d['algorithm'])\""
+echo ""
+echo "  # Re-run the post-240 diff and update docs/NASH_BENCHMARKS.md:"
+echo "  uv run python experiments/nash/scripts/diff_post240.py"
+echo "===================================================================="

--- a/tests/test_launch_rest_trap_rerun.py
+++ b/tests/test_launch_rest_trap_rerun.py
@@ -1,0 +1,276 @@
+"""Tests for ``experiments/scripts/launch_rest_trap_rerun.sh``.
+
+The script is the operator-launch wrapper added for issue #349 (fill the
+single missing `rest_trap` cell of the V1 post-#240 Nash sweep — the
+2026-05-16 `nash256` sweep crashed at the `equilibrium.json` write step
+with ENOSPC, now permanently guarded by the df-precheck from PR #315).
+Because it shells out to ``ssh`` to bootstrap a remote tmux session, we
+cannot exercise the live-run path in unit tests. The ``--dry-run`` flag
+exists exactly so the wiring (arg parsing, host resolution, driver-command
+synthesis, canonical-parameter defaults) can be asserted without touching
+the network.
+
+These tests cover the operator-facing failure modes plus the canonical
+runbook invocation from
+``experiments/nash/v1_results_python_post240/RERUN_RUNBOOK.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_rest_trap_rerun.sh"
+RUNBOOK = (
+    REPO_ROOT
+    / "experiments"
+    / "nash"
+    / "v1_results_python_post240"
+    / "RERUN_RUNBOOK.md"
+)
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Existence + executability
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_runbook_exists() -> None:
+    """The companion runbook must be present so the launcher's --help
+    pointer to it resolves."""
+    assert RUNBOOK.exists(), f"runbook missing: {RUNBOOK}"
+
+
+# ---------------------------------------------------------------------------
+# --help / arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check that the canonical flags appear in the doc string.
+    for flag in (
+        "--host",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+    # The help text must not leak past the header into the bash body.
+    assert "set -euo pipefail" not in result.stdout, (
+        "help text bleeds past the header comment — tighten the sed range"
+    )
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(["--host", "x", "--not-a-flag", "y", "--dry-run"])
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Host resolution
+# ---------------------------------------------------------------------------
+
+
+def test_missing_host_with_no_env_errors_cleanly() -> None:
+    """Without --host and without a .env, the script must fail with exit 3."""
+    env_path = REPO_ROOT / ".env"
+    backup = None
+    if env_path.exists():
+        backup = env_path.read_bytes()
+        env_path.unlink()
+    try:
+        result = _run(["--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+
+    assert result.returncode == 3, (
+        f"expected exit 3 (no host), got {result.returncode}: {result.stderr}"
+    )
+    assert "no host specified" in result.stderr.lower()
+
+
+def test_dry_run_resolves_host_from_env() -> None:
+    """When --host is omitted, the script must pick the first non-empty
+    COMPUTE_HOST_* from .env using the documented priority (PRIMARY first)."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    try:
+        env_path.write_text(
+            textwrap.dedent(
+                """\
+                COMPUTE_HOST_PRIMARY=resolved-primary
+                COMPUTE_HOST_CLUSTER=resolved-cluster
+                """
+            )
+        )
+        result = _run(["--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+        elif env_path.exists():
+            env_path.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved-primary" in result.stdout
+    # CLUSTER should NOT win when PRIMARY is set.
+    assert "resolved-cluster" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Driver command synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_emits_canonical_driver_command() -> None:
+    """The default invocation must produce exactly the canonical
+    `compute_nash.py` command line — positional `rest_trap` (NOT
+    --scenario, the curator-caught bug in the original issue body) and
+    the locked-in sweep parameters."""
+    result = _run(["--host", "fake-host", "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+
+    # The driver must be called positionally with the scenario name. The
+    # script wraps it in single quotes for shell safety; we accept either
+    # quoted or bare in case the script is later refactored to drop the
+    # unnecessary quoting around a non-special token.
+    assert "compute_nash.py 'rest_trap'" in out or "compute_nash.py rest_trap" in out
+    # Critical regression guard: the original issue body had the wrong
+    # form (--scenario rest_trap) that would have failed at argparse.
+    # The launcher must NEVER reintroduce it.
+    assert "--scenario" not in out, (
+        "compute_nash.py expects `scenario` positionally, not --scenario "
+        "(see compute_nash.py:291 and the curator note on issue #349)"
+    )
+
+    # Canonical sweep parameters must match the sibling 11 scenarios so
+    # that the resulting equilibrium.json is schema-comparable. These
+    # values appear in the launcher's defaults; any drift breaks the
+    # issue #349 acceptance criterion.
+    assert "--simulations 200" in out
+    assert "--max-iterations 50" in out
+    assert "--epsilon 0.01" in out
+    assert "--seed 42" in out
+
+    # Output directory must land in the post-240 sweep tree, NOT in the
+    # driver's default fallback at experiments/scenarios/rest_trap/nash/.
+    assert "--output-dir 'experiments/nash/v1_results_python_post240/rest_trap'" in out
+
+    # Header echoes the resolved host so the operator can sanity-check.
+    assert "fake-host" in out
+    # Dry-run banner so an operator never confuses it with a real launch.
+    assert "dry-run" in out.lower()
+
+
+def test_dry_run_default_session_name() -> None:
+    """The default tmux session name must be ``nash-rest-trap`` — used by
+    the runbook's monitoring snippets."""
+    result = _run(["--host", "fake-host", "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    assert "nash-rest-trap" in result.stdout
+
+
+def test_dry_run_overrides_propagate_to_driver() -> None:
+    """Operator overrides for the canonical sweep params must appear in
+    the synthesized driver command. (The runbook says don't use these
+    for the #349 re-run, but the launcher exposes them for adjacent
+    experimentation — verify the wiring works.)"""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--seed",
+            "7",
+            "--simulations",
+            "500",
+            "--max-iterations",
+            "25",
+            "--epsilon",
+            "0.005",
+            "--output-dir",
+            "/tmp/custom-out",
+            "--session-name",
+            "custom-session",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "--seed 7" in out
+    assert "--simulations 500" in out
+    assert "--max-iterations 25" in out
+    assert "--epsilon 0.005" in out
+    assert "--output-dir '/tmp/custom-out'" in out
+    assert "custom-session" in out
+
+
+def test_dry_run_default_scenario_is_rest_trap() -> None:
+    """The launcher exists to re-run `rest_trap`. The default scenario
+    arg must therefore be `rest_trap` (and the header echoes it for the
+    operator's confirmation)."""
+    result = _run(["--host", "fake-host", "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    # The plan header shows "Scenario:       rest_trap".
+    assert "Scenario:       rest_trap" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Canonical runbook invocation
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_canonical_invocation_is_dry_runnable() -> None:
+    """Lock in the runbook's primary copy-paste command so a refactor to
+    the script cannot silently break the documented operator
+    instructions. The runbook says the single-line, default-everything
+    invocation should Just Work."""
+    # Equivalent to: ./experiments/scripts/launch_rest_trap_rerun.sh
+    # with .env supplying the host. We pass --host explicitly here to
+    # decouple the test from the local .env contents.
+    result = _run(["--host", "fake-host", "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # All four canonical sweep params + the post-240 output dir must
+    # appear in the synthesized command — this is the schema-match
+    # contract with the 11 sibling scenarios.
+    for fragment in (
+        "--simulations 200",
+        "--max-iterations 50",
+        "--epsilon 0.01",
+        "--seed 42",
+        "experiments/nash/v1_results_python_post240/rest_trap",
+    ):
+        assert fragment in out, (
+            f"missing expected fragment '{fragment}' from canonical run:\n{out}"
+        )


### PR DESCRIPTION
## Summary

Ships the operator launch tooling for issue #349 — re-running the
`rest_trap` scenario, which is the **single missing cell** of the V1
post-#240 Nash sweep (the other 11 are committed under
`experiments/nash/v1_results_python_post240/`).

The original sweep (#256, tmux session `nash256` on `COMPUTE_HOST_PRIMARY`,
2026-05-16) crashed at the `equilibrium.json` write step with ENOSPC.
PR #347 recovered the 11 successful artifacts; PR #315 (closes #269)
added the `df`-precheck that prevents the failure mode going forward.
This PR ships the launcher + runbook + tests so the re-run is a one-line
operator command rather than an ad-hoc multi-step procedure.

Follows the Option-A pattern (launcher + runbook + tests) established by
PR #393 (phase-diagram fill) and PR #394 (Tier-1 sweep), shipped on
2026-06-08.

## Changes

Three new files + a one-paragraph README pointer:

1. **`experiments/scripts/launch_rest_trap_rerun.sh`** (new, +290 lines)
   - Resolves a host from `.env` using the documented priority
     (`PRIMARY → CLUSTER → LAMBDA → GCP`); accepts `--host` override.
   - Verifies SSH BatchMode reachability before consuming compute.
   - Bootstraps remote env: PATH for macOS non-interactive SSH,
     `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`, unset `RUSTC_WRAPPER`,
     seeds pip into the uv venv, builds Rust extension, sanity-imports
     `DoubleOracle`.
   - Starts a detached tmux session running `compute_nash.py` with the
     canonical sweep params (seed=42, simulations=200, max-iterations=50,
     epsilon=0.01) — matching the 11 sibling scenarios for the schema-
     match acceptance criterion in the issue.
   - Locks in the **positional** `scenario` arg form so the launcher
     cannot regress to the `--scenario` bug the curator caught in the
     original issue body (compute_nash.py:291 — `scenario` is positional).
   - Supports `--dry-run` for CI/operator-preview without SSH.

2. **`experiments/nash/v1_results_python_post240/RERUN_RUNBOOK.md`** (new)
   - Operator companion doc: prerequisites, canonical params table, the
     one-line launch command, monitoring snippets, post-run rsync +
     schema verification + diff + commit workflow, troubleshooting.

3. **`tests/test_launch_rest_trap_rerun.py`** (new, 11 tests)
   - Existence + executability, runbook presence
   - `--help` boundary (asserts the help text doesn't bleed past the
     header into the bash body — caught and fixed a sed-range bug
     during development)
   - Unknown-flag error path, missing-host error path
   - Host resolution from `.env` (PRIMARY wins over CLUSTER)
   - Canonical driver command synthesis (positional scenario, all four
     sweep params, output-dir lands in post-240 tree)
   - **Regression guard**: asserts `--scenario` is NOT present in the
     synthesized command (compute_nash.py expects positional)
   - Override propagation, default scenario/session name
   - Locks in the runbook's primary copy-paste invocation

4. **`experiments/nash/v1_results_python_post240/README.md`** (modified)
   - One-line pointer to the runbook + launcher in the existing
     `Status` block so future operators find them.

## Test plan

- [x] `uv run pytest tests/test_launch_rest_trap_rerun.py -v` → 11 passed in 0.10s
- [x] `uv run pytest tests/test_launch_*.py -v` → 39 passed (11 new + 28 existing, no regressions)
- [x] `uv run ruff check tests/test_launch_rest_trap_rerun.py experiments/scripts/` → All checks passed
- [x] `uv run ruff format --check tests/test_launch_rest_trap_rerun.py` → already formatted
- [x] Launcher `--help` renders cleanly (no bleed past header)
- [x] Launcher `--dry-run` emits canonical command line
- [x] Rebased on current `origin/main` (post PR #397/#398)

## Caveats

- **Did NOT launch the re-run.** Per `CLAUDE.md`, long unattended
  cluster runs are operator-driven, not safe for an autonomous agent
  to spawn. The PR ships the tooling; an operator executes
  `./experiments/scripts/launch_rest_trap_rerun.sh` from their local
  checkout (with `.env` populated) to actually fill the cell.
- The compute itself is cheap — ~25-35 min on a Mac Studio
  (`COMPUTE_HOST_PRIMARY`); the perf fixes from PR #391/#392 are not
  needed for this driver (those help `compute_nash_phase_diagram.py`,
  not the V1 `compute_nash.py`).

Closes #349