### PR TITLE
ops(release): PPO baseline training launcher for #371 frozen baselines

### DIFF
--- a/experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md
+++ b/experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md
@@ -1,0 +1,208 @@
+# PPO baselines runbook (issue #384 → feeds #371)
+
+Operator-driven launch + retrieve guide for the PPO baseline training
+sweep that produces the frozen checkpoints shipped with the M4 release
+(parent: [#371][issue-371], grandparent: [#365][issue-365] / [#357][issue-357]).
+
+This runbook is the companion to:
+
+- [`experiments/scripts/launch_ppo_baselines.sh`](../scripts/launch_ppo_baselines.sh) — the launcher
+- [`experiments/p3_specialization/run_tier1_cell.py`](run_tier1_cell.py) — the `ippo` entry in `TRAINERS` (line 201)
+- [`bucket_brigade/envs/scenarios_generated.py`](../../bucket_brigade/envs/scenarios_generated.py) — `SCENARIO_REGISTRY` (line 649)
+- [`tests/test_launch_ppo_baselines.py`](../../tests/test_launch_ppo_baselines.py) — launcher contract tests
+
+[issue-371]: https://github.com/rjwalters/bucket-brigade/issues/371
+[issue-365]: https://github.com/rjwalters/bucket-brigade/issues/365
+[issue-357]: https://github.com/rjwalters/bucket-brigade/issues/357
+
+## What `ippo` is (and why it is the "baseline PPO")
+
+`ippo` (Independent PPO) is the simplest PPO arm in `run_tier1_cell.py`'s
+`TRAINERS` dispatch:
+
+```python
+"ippo": TrainerSpec(
+    name="ippo",
+    description="Independent PPO baseline (--algorithm ppo, no extras).",
+    train_extra=("--algorithm", "ppo"),
+),
+```
+
+No centralized critic (MAPPO), no opponent shaping (LOLA), no asymmetric
+init (HetGPPO / #386), no value-loss tricks. Each agent runs its own PPO
+update against its own GAE. This is the headline "PPO baseline" the paper
+reports against and the artifact `#371` packages into
+`bucket_brigade/baselines/release/ppo/`.
+
+## Scope — what gets launched
+
+By default the launcher runs the release scenario set defined in #384:
+
+| Scenario                  | Source                                            | Why included                              |
+|---------------------------|---------------------------------------------------|-------------------------------------------|
+| `minimal_specialization`  | `minimal_specialization_scenario` (#199-family)   | Canonical P3 substrate                    |
+| `default`                 | `default_scenario`                                | Vanilla 10-house environment              |
+| `positional_default`      | `positional_default_scenario`                     | Positional variant of default             |
+| `chain_reaction`          | `chain_reaction_scenario`                         | Cascade dynamics                          |
+| `trivial_cooperation`     | `trivial_cooperation_scenario`                    | Simplest cooperation diagnostic           |
+| `v2_minimal`              | `v2_minimal_scenario` (#254)                      | 2-house × 4-agent PPO learnability diagnostic |
+
+All six names are keys of `SCENARIO_REGISTRY`. The launcher passes them
+through to `run_tier1_cell.py --scenario <name>` verbatim. The versioned
+release IDs (e.g. `minimal_specialization-v1`) are #371's concern when it
+packages — at training time we use the bare names because that is what
+the dispatcher consumes.
+
+**Caveat**: `positional_default` is in `SCENARIO_REGISTRY` (the legacy
+name-keyed registry) but does NOT have an entry in `SCENARIO_VERSIONS`
+(`bucket_brigade/envs/registry.py`) as of this writing. Training works
+fine. If #371 needs the versioned ID for its loader, the scenario needs
+a `positional_default-v1` entry added to `SCENARIO_VERSIONS` — that is a
+small follow-up and not in scope here.
+
+### Compute estimate
+
+Per the #384 budget:
+
+| Path                                    | Cells | Wall-clock @ COMPUTE_HOST_CLUSTER |
+|-----------------------------------------|-------|-----------------------------------|
+| Default release set (6 scenarios × 3 seeds) | 6 | ~18 GPU-hours total              |
+| Single scenario, 3 seeds                | 1     | ~1–2 h                            |
+| Smoke (1 seed × 1 iter × 32 rollout)    | 1     | < 1 minute                        |
+
+The bucket-brigade env is CPU-bound (see CLAUDE.md), so "GPU-hours" is
+shorthand for wall-clock on the chosen host — the actual compute is CPU
+even on a GPU box. `COMPUTE_HOST_CLUSTER` (alcubierre) and
+`COMPUTE_HOST_PRIMARY` (Mac Studio) are both reasonable.
+
+## Launch commands
+
+All launches go through `launch_ppo_baselines.sh`. The script reads
+`COMPUTE_HOST_PRIMARY` from `.env` and falls back to `_CLUSTER` /
+`_LAMBDA` / `_GCP`. Pass `--host <alias>` to override.
+
+### Plan A — Full release sweep (the canonical #384 launch)
+
+```bash
+./experiments/scripts/launch_ppo_baselines.sh
+```
+
+- 6 scenarios × 3 seeds × 50 iter × 2048 rollout
+- Expected wall-clock: ~18 h total (one tmux session, scenarios run
+  serially; seeds within a scenario also run serially inside
+  `run_tier1_cell.py`)
+- Outputs land under
+  `experiments/p3_specialization/baselines/ippo_<scenario>/` on the
+  remote host
+
+### Plan B — Single scenario sanity (debug / positive-control rerun)
+
+```bash
+./experiments/scripts/launch_ppo_baselines.sh \
+    --scenarios minimal_specialization \
+    --seeds 42,43,44 \
+    --num-iterations 25
+```
+
+- 1 scenario × 3 seeds × 25 iter — finishes in 1–2 h on most hosts
+- Use this to confirm the trainer is wired correctly on a new host
+  before burning compute on the full 6-scenario sweep
+
+### Plan C — Shard across hosts (multi-host parallelism)
+
+The launcher runs scenarios serially in one tmux session. To shard
+across multiple hosts, launch the script once per host with a disjoint
+scenario slice:
+
+```bash
+# Host 1: cheap scenarios
+./experiments/scripts/launch_ppo_baselines.sh \
+    --host alc-2 \
+    --scenarios minimal_specialization,trivial_cooperation,v2_minimal
+
+# Host 2: expensive scenarios
+./experiments/scripts/launch_ppo_baselines.sh \
+    --host alc-6 \
+    --scenarios default,positional_default,chain_reaction
+```
+
+Each invocation creates an independent tmux session
+(`ppo-baselines-<first_scenario>-and<N>more`) so concurrent launches on
+the same host do not collide either.
+
+### Plan D — Smoke test (local, safe)
+
+```bash
+# 1 seed × 1 iter × 32 rollout on minimal_specialization; finishes in seconds.
+uv run python experiments/p3_specialization/run_tier1_cell.py \
+    --trainer ippo \
+    --scenario minimal_specialization \
+    --seeds 42 \
+    --num-iterations 1 \
+    --rollout-steps 32 \
+    --output-root /tmp/ppo_baseline_smoke \
+    --skip-precheck
+```
+
+Expected: `== cell ippo_minimal_specialization complete: verdict=<some-tier>
+gap_closed_mean=<some-float>`. The verdict on a 1-iteration smoke run is
+meaningless — this only checks the dispatch + trainer + env wiring.
+
+## Host assignments
+
+Per `~/.claude/.../reference_cluster_host_reliability.md`:
+
+- **Prefer**: `alc-2`, `alc-6`, `alc-9` (high reliability)
+- **Avoid**: `alc-5` (12.5% reliable, confirmed flaky)
+- **Personal CPU**: `COMPUTE_HOST_PRIMARY` (Mac Studio) — the env is
+  CPU-bound, so the Mac Studio is competitive with GPU cluster nodes
+  for this workload
+
+## Retrieving results
+
+```bash
+# After the tmux session reports "cell complete" for every scenario:
+rsync -avz <host>:bucket-brigade/experiments/p3_specialization/baselines/ \
+    experiments/p3_specialization/baselines/
+
+# Each cell writes:
+#   ippo_<scenario>/cell_summary.json     -- gap_closed + verdict per seed
+#   ippo_<scenario>/seed_<N>/             -- per-seed train.py output dir
+#                                            (checkpoints, metrics.jsonl, config)
+```
+
+## Handoff to issue #371
+
+This issue produces raw artifacts only. Issue #371 owns:
+
+1. Selecting the best checkpoint per scenario from the per-seed sweep
+2. Copying it to `bucket_brigade/baselines/release/ppo/<scenario>/checkpoint.pt`
+3. Writing the sibling `config.json` (training hyperparameters + gap_closed)
+4. Authoring `bucket_brigade/baselines/release/ppo/scores.json` with
+   `{seed, gap_closed, config_hash}` per scenario
+5. Adding the loader API (`bucket_brigade.baselines.load_ppo(scenario_id)`)
+6. Smoke-testing the loader deserializes and runs
+
+The handoff contract: as long as
+`experiments/p3_specialization/baselines/ippo_<scenario>/` exists with a
+non-empty `cell_summary.json` and at least one `seed_<N>/` subdirectory
+containing a checkpoint, #371 can package it.
+
+## What the launcher does NOT do
+
+- It does **not** launch automatically. The operator runs it once and
+  the remote tmux session does the work over hours.
+- It does **not** package checkpoints into the release directory — that
+  is #371's job.
+- It does **not** parallelize seeds across hosts. For sharded
+  multi-host launches, see Plan C above.
+- It does **not** auto-merge results. The operator pulls results back,
+  inspects the per-cell `cell_summary.json`, and PRs the artifacts.
+
+## See also
+
+- [`experiments/p3_specialization/het_ppo_runbook.md`](het_ppo_runbook.md) — sibling runbook for the asymmetry-aware PPO arm (#386)
+- [`experiments/p3_specialization/TIER1_LAUNCH_RUNBOOK.md`](TIER1_LAUNCH_RUNBOOK.md) — sibling runbook for the full Tier-1 trainer matrix (#343)
+- [`experiments/nash/phase_diagram/LAUNCH_RUNBOOK.md`](../nash/phase_diagram/LAUNCH_RUNBOOK.md) — sibling runbook for phase-diagram gap-fill (#390)
+- [`bucket_brigade/envs/scenarios_generated.py`](../../bucket_brigade/envs/scenarios_generated.py) — `SCENARIO_REGISTRY`
+- [`bucket_brigade/envs/registry.py`](../../bucket_brigade/envs/registry.py) — `SCENARIO_VERSIONS` (versioned IDs for #371's loader)

--- a/experiments/scripts/launch_ppo_baselines.sh
+++ b/experiments/scripts/launch_ppo_baselines.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# Launch the issue #384 PPO baseline training sweep on a remote host. This
+# is the operator-launch wrapper for the "actually run PPO on the canonical
+# scenario set" task that feeds the frozen-baseline release tracked by
+# issue #371 (slice 3/5 of #365) and ultimately the M4 release infra in
+# #357.
+#
+# The trained checkpoints written by this sweep land under
+# ``experiments/p3_specialization/baselines/<scenario>/`` on the remote
+# host. Issue #371 owns the downstream step of packaging them into
+# ``bucket_brigade/baselines/release/ppo/`` with a loader API and
+# ``scores.json``; this script only produces the raw artifacts.
+#
+# The dispatcher is the same ``run_tier1_cell.py --trainer ippo`` used by
+# the Tier-1 sweep — the "ippo" entry in TRAINERS is Independent PPO with
+# no extras (see run_tier1_cell.py:201–205), which is exactly the
+# "baseline PPO checkpoint" #371 / #365 want to ship.
+#
+# The script does NOT compute anything locally. It only:
+#   1. Reads $COMPUTE_HOST_* aliases from .env to resolve a target host
+#      (unless --host is passed explicitly). Per CLAUDE.md the env is
+#      CPU-bound, so COMPUTE_HOST_PRIMARY (Mac Studio) and
+#      COMPUTE_HOST_CLUSTER (alc-*) are both reasonable.
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts
+#      a detached tmux session running run_tier1_cell.py with
+#      --trainer ippo over the requested scenarios × seeds.
+#   4. Prints monitor / rsync / handoff-to-#371 instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual cells fill over
+# hours inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Auto-resolve host from .env, train the full release scenario set
+#   # (6 scenarios × 3 seeds, ~18 GPU-hours per #384 estimate).
+#   ./experiments/scripts/launch_ppo_baselines.sh
+#
+#   # Subset for a fast turnaround (e.g. just minimal_specialization).
+#   ./experiments/scripts/launch_ppo_baselines.sh \
+#       --scenarios minimal_specialization \
+#       --seeds 42,43,44 \
+#       --num-iterations 25
+#
+#   # Explicit host, smaller seed set for a single-scenario sanity rerun.
+#   ./experiments/scripts/launch_ppo_baselines.sh \
+#       --host alc-2 --scenarios minimal_specialization --seeds 42
+#
+#   # Dry-run prints the ssh + driver command without launching anything.
+#   ./experiments/scripts/launch_ppo_baselines.sh --dry-run
+#
+# Flags:
+#   --host HOST                     SSH alias (or auto-resolved from .env)
+#   --scenarios LIST                Comma-separated scenario names
+#                                    (default: the #384 release scenario set)
+#   --seeds LIST                    Comma-separated seeds (default: 42,43,44)
+#   --num-iterations N              PPO iterations per seed (default: 50)
+#   --rollout-steps N               Rollout buffer size (default: 2048)
+#   --output-dir PATH               Remote output root
+#                                    (default: experiments/p3_specialization/baselines)
+#   --session-name NAME             tmux session name (auto-synthesized)
+#   --dry-run                       Print plan; do not ssh anywhere
+#   --skip-connectivity-check       For CI / smoke tests
+#
+# See experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md for the
+# canonical scenario list, host assignments, per-cell wall-clock, and the
+# handoff procedure to issue #371.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Default scenario set per issue #384 acceptance criteria. These are the
+# scenarios the paper references in headline numbers, all backed by the
+# scenario registry shipped in #369 (see
+# bucket_brigade/envs/scenarios_generated.py::SCENARIO_REGISTRY and
+# bucket_brigade/envs/registry.py::SCENARIO_VERSIONS — the bare names below
+# are the registry keys consumed by get_scenario_by_name, which is what
+# run_tier1_cell.py dispatches to).
+#
+# Sources:
+#   - minimal_specialization: canonical P3 substrate (#199-family)
+#   - default: vanilla 10-house environment
+#   - positional_default: positional variant of default (no -v1 yet)
+#   - chain_reaction: cascade dynamics scenario
+#   - trivial_cooperation: simplest cooperation diagnostic
+#   - v2_minimal: 2-house x 4-agent PPO learnability diagnostic (#254)
+DEFAULT_SCENARIOS="minimal_specialization,default,positional_default,chain_reaction,trivial_cooperation,v2_minimal"
+DEFAULT_SEEDS="42,43,44"
+DEFAULT_NUM_ITERATIONS=50
+DEFAULT_ROLLOUT_STEPS=2048
+DEFAULT_OUTPUT_DIR="experiments/p3_specialization/baselines"
+DEFAULT_SESSION_PREFIX="ppo-baselines"
+
+HOST=""
+SCENARIOS="$DEFAULT_SCENARIOS"
+SEEDS="$DEFAULT_SEEDS"
+NUM_ITERATIONS="$DEFAULT_NUM_ITERATIONS"
+ROLLOUT_STEPS="$DEFAULT_ROLLOUT_STEPS"
+OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+SESSION_NAME=""
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+
+print_usage() {
+    sed -n '2,72p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --scenarios)
+            SCENARIOS="$2"
+            shift 2
+            ;;
+        --seeds)
+            SEEDS="$2"
+            shift 2
+            ;;
+        --num-iterations)
+            NUM_ITERATIONS="$2"
+            shift 2
+            ;;
+        --rollout-steps)
+            ROLLOUT_STEPS="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Scenarios must be non-empty (the operator can override the default but
+# cannot launch a sweep with zero cells).
+if [[ -z "$SCENARIOS" ]]; then
+    echo "ERROR: --scenarios cannot be empty" >&2
+    echo "       Pass --scenarios <comma-separated-list> or omit the flag" >&2
+    echo "       to use the default release set." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+
+if [[ -z "$HOST" ]]; then
+    HOST=$(resolve_host_from_env)
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build driver command + tmux session name
+# ---------------------------------------------------------------------------
+
+# Convert comma-separated seeds into space-separated for the driver.
+SEEDS_SPACED="${SEEDS//,/ }"
+
+if [[ -z "$SESSION_NAME" ]]; then
+    # Compact tag so two concurrent launches on the same host don't collide.
+    # Use the first scenario as the tag; if multiple, append count.
+    first_scenario="${SCENARIOS%%,*}"
+    n_scenarios=$(echo "$SCENARIOS" | tr ',' '\n' | wc -l | tr -d ' ')
+    if [[ "$n_scenarios" -gt 1 ]]; then
+        SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${first_scenario}-and${n_scenarios}more"
+    else
+        SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${first_scenario}"
+    fi
+fi
+
+# Compose the driver invocation as a loop over scenarios so a single tmux
+# session covers the whole sweep. Each scenario is one run_tier1_cell.py
+# invocation (which itself loops over seeds and writes its own
+# cell_summary.json + per-seed checkpoint under <OUTPUT_DIR>/ippo_<scenario>/).
+#
+# We use `;` not `&&` so one failing scenario doesn't abort the rest — the
+# driver writes cell_summary.json with verdict=no_data on failure and #371's
+# packager can still pick up whichever scenarios succeeded.
+DRIVER_CMD=""
+IFS=',' read -ra SCENARIO_LIST <<< "$SCENARIOS"
+for scen in "${SCENARIO_LIST[@]}"; do
+    cell_cmd="echo '=== ippo on $scen ===' && uv run python experiments/p3_specialization/run_tier1_cell.py --trainer ippo --scenario '$scen' --seeds $SEEDS_SPACED --num-iterations $NUM_ITERATIONS --rollout-steps $ROLLOUT_STEPS --output-root '$OUTPUT_DIR'"
+    if [[ -z "$DRIVER_CMD" ]]; then
+        DRIVER_CMD="$cell_cmd"
+    else
+        DRIVER_CMD+=" ; $cell_cmd"
+    fi
+done
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default.
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync --extra rl
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the ippo trainer dispatch before consuming a tmux session
+# for a multi-hour run. If 'ippo' is missing from TRAINERS the launcher
+# has no business burning compute.
+uv run python -c "from experiments.p3_specialization.run_tier1_cell import TRAINERS; assert 'ippo' in TRAINERS, 'ippo missing from dispatch — run from a main checkout'; print('ippo dispatch OK')"
+
+mkdir -p $OUTPUT_DIR
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && ( $DRIVER_CMD ) 2>&1 | tee -a '$OUTPUT_DIR/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_DIR/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+echo "===================================================================="
+echo "Issue #384 — PPO baseline training launch (feeds #371)"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output dir:     $OUTPUT_DIR    (on remote)"
+echo "Scenarios:      $SCENARIOS"
+echo "Seeds:          $SEEDS"
+echo "Num iterations: $NUM_ITERATIONS"
+echo "Rollout steps:  $ROLLOUT_STEPS"
+echo ""
+echo "Per-scenario driver commands (one run_tier1_cell.py invocation each,"
+echo "chained with ';' so one failure doesn't abort the sweep):"
+echo "$DRIVER_CMD" | tr ';' '\n' | sed 's/^ *//; s/^/  /'
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_DIR}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done, rsync results back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_DIR}/ ${OUTPUT_DIR}/"
+echo ""
+echo "  # Handoff to #371: each scenario produces a cell_summary.json +"
+echo "  # per-seed checkpoint under ${OUTPUT_DIR}/ippo_<scenario>/."
+echo "  # Issue #371 owns the packaging step into"
+echo "  # bucket_brigade/baselines/release/ppo/<scenario>/checkpoint.pt"
+echo "  # + scores.json — see experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md."
+echo "===================================================================="

--- a/tests/test_launch_ppo_baselines.py
+++ b/tests/test_launch_ppo_baselines.py
@@ -1,0 +1,480 @@
+"""Tests for ``experiments/scripts/launch_ppo_baselines.sh``.
+
+The script is the operator-launch wrapper added for issue #384 (the PPO
+baseline training sweep that produces the frozen checkpoints shipped by
+issue #371). It shells out to ``ssh`` to bootstrap a remote tmux session,
+so the live-run path is not exercisable in unit tests. The ``--dry-run``
+flag exists exactly so the wiring (arg parsing, host resolution, driver-
+command synthesis, session-name compaction) can be asserted without
+touching the network.
+
+These tests mirror the contract style established for the sibling
+launchers (``tests/test_launch_phase_diagram_fill.py``,
+``tests/test_launch_tier1_sweep.py``, ``tests/test_launch_het_ppo_sweep.py``):
+each documented operator invocation in
+``experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md`` is locked in
+here so a future refactor to the script cannot silently break the
+runbook commands.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_ppo_baselines.sh"
+RUNBOOK = REPO_ROOT / "experiments" / "p3_specialization" / "PPO_BASELINES_RUNBOOK.md"
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(  # nosec B603 B607 (cmd is list, no shell)
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Existence + executability
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_runbook_exists() -> None:
+    """The companion runbook must be present so the launcher's --help
+    output can reference it."""
+    assert RUNBOOK.exists(), f"runbook missing: {RUNBOOK}"
+
+
+# ---------------------------------------------------------------------------
+# --help / arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check that the canonical flags appear in the doc string.
+    for flag in (
+        "--host",
+        "--scenarios",
+        "--seeds",
+        "--num-iterations",
+        "--rollout-steps",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(
+        [
+            "--host",
+            "x",
+            "--not-a-flag",
+            "y",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+def test_empty_scenarios_errors_cleanly() -> None:
+    """Explicit empty --scenarios must fail (the default is non-empty,
+    but a deliberately-empty override is almost certainly a mistake)."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 (empty --scenarios), got {result.returncode}: {result.stderr}"
+    )
+    assert "--scenarios" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Host resolution
+# ---------------------------------------------------------------------------
+
+
+def test_missing_host_with_no_env_errors_cleanly() -> None:
+    """Without --host and without a .env, the script must fail with exit 3."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    if env_path.exists():
+        env_path.unlink()
+    try:
+        result = _run(["--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+
+    assert result.returncode == 3, (
+        f"expected exit 3 (no host), got {result.returncode}: {result.stderr}"
+    )
+    assert "no host specified" in result.stderr.lower()
+
+
+def test_dry_run_resolves_host_from_env() -> None:
+    """When --host is omitted, the script must pick the first non-empty
+    COMPUTE_HOST_* from .env using the documented priority (PRIMARY first)."""
+    env_path = REPO_ROOT / ".env"
+    backup = env_path.read_bytes() if env_path.exists() else None
+    try:
+        env_path.write_text(
+            textwrap.dedent(
+                """\
+                COMPUTE_HOST_PRIMARY=resolved-primary
+                COMPUTE_HOST_CLUSTER=resolved-cluster
+                """
+            )
+        )
+        result = _run(["--dry-run"])
+    finally:
+        if backup is not None:
+            env_path.write_bytes(backup)
+        elif env_path.exists():
+            env_path.unlink()
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved-primary" in result.stdout
+    # CLUSTER should NOT win when PRIMARY is set.
+    assert "resolved-cluster" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Driver command synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_with_explicit_host_emits_driver_command() -> None:
+    """``--dry-run`` must print the synthesized driver invocation."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "minimal_specialization",
+            "--seeds",
+            "42,43,44",
+            "--num-iterations",
+            "25",
+            "--rollout-steps",
+            "1024",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Argument plumbing through to the driver:
+    assert "run_tier1_cell.py" in out
+    assert "--trainer ippo" in out
+    assert "--scenario 'minimal_specialization'" in out
+    # Seeds are passed space-separated (not comma) to run_tier1_cell.py.
+    assert "--seeds 42 43 44" in out
+    assert "--num-iterations 25" in out
+    assert "--rollout-steps 1024" in out
+    # Header echoes the resolved host.
+    assert "fake-host" in out
+    # Dry-run banner must be present so an operator never confuses it
+    # with a real launch.
+    assert "dry-run" in out.lower()
+
+
+def test_dry_run_default_output_dir_is_baselines() -> None:
+    """The default --output-dir must point at the baselines tree so #371's
+    packaging step knows where to look."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "minimal_specialization",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert "experiments/p3_specialization/baselines" in result.stdout
+
+
+def test_dry_run_default_scenarios_include_release_set() -> None:
+    """With no --scenarios, the launcher must expand to the canonical
+    #384 release scenario set (all 6 names appear in the driver plan)."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    for scen in (
+        "minimal_specialization",
+        "default",
+        "positional_default",
+        "chain_reaction",
+        "trivial_cooperation",
+        "v2_minimal",
+    ):
+        assert f"--scenario '{scen}'" in out, (
+            f"default scenario set missing '{scen}':\n{out}"
+        )
+
+
+def test_dry_run_synthesizes_session_name_single_scenario() -> None:
+    """Session name must include the scenario tag so concurrent launches
+    on the same host don't collide."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "minimal_specialization",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ppo-baselines-minimal_specialization" in result.stdout, result.stdout
+
+
+def test_dry_run_session_name_with_multiple_scenarios() -> None:
+    """Multi-scenario launches must produce a distinguishable session name."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "minimal_specialization,default,chain_reaction",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    # First scenario + count marker so the operator can tell at a glance
+    # this was a multi-scenario launch.
+    assert "ppo-baselines-minimal_specialization-and3more" in result.stdout, (
+        result.stdout
+    )
+
+
+def test_dry_run_loops_over_scenarios_with_semicolon() -> None:
+    """Multi-scenario launches must produce one run_tier1_cell.py invocation
+    per scenario, chained with ';' so one failing scenario does not abort
+    the rest (vs het_ppo which uses '&&' because each scenario is an
+    indivisible Phase). For #384 we want partial success — if 5/6 scenarios
+    train and 1 fails, #371 can still package the 5."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenarios",
+            "minimal_specialization,default",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # One --scenario clause per scenario in the driver invocation.
+    assert "--scenario 'minimal_specialization'" in out
+    assert "--scenario 'default'" in out
+    # The chain uses `;` so a single-scenario failure doesn't take down the
+    # rest of the sweep. Count actual driver invocations in the plan block
+    # by counting `uv run python experiments/p3_specialization/run_tier1_cell.py`
+    # — the prose around the plan also mentions `run_tier1_cell.py` once but
+    # the literal command string is distinctive.
+    plan_section = out.split("Per-scenario driver commands")[-1].split(
+        "===================================================================="
+    )[0]
+    n_cells = plan_section.count(
+        "uv run python experiments/p3_specialization/run_tier1_cell.py"
+    )
+    assert n_cells == 2, (
+        f"expected 2 cells in plan for 2 scenarios, got {n_cells}:\n{plan_section}"
+    )
+
+
+def test_unknown_flag_does_not_silently_become_scenario() -> None:
+    """A typoed flag like `--scenrios` (note the typo) must error, not
+    fall through to the default scenarios with mysterious extra args."""
+    result = _run(
+        [
+            "--host",
+            "fake-host",
+            "--scenrios",
+            "minimal_specialization",
+            "--dry-run",
+        ]
+    )
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Canonical runbook invocations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "args,expected_in_cmd",
+    [
+        # Runbook Plan A: full release sweep (default scenario set)
+        (
+            [],
+            [
+                "--trainer ippo",
+                "--scenario 'minimal_specialization'",
+                "--scenario 'default'",
+                "--scenario 'positional_default'",
+                "--scenario 'chain_reaction'",
+                "--scenario 'trivial_cooperation'",
+                "--scenario 'v2_minimal'",
+                # Default seeds = 42 43 44
+                "--seeds 42 43 44",
+            ],
+        ),
+        # Runbook Plan B: single scenario sanity rerun
+        (
+            [
+                "--scenarios",
+                "minimal_specialization",
+                "--seeds",
+                "42,43,44",
+                "--num-iterations",
+                "25",
+            ],
+            [
+                "--trainer ippo",
+                "--scenario 'minimal_specialization'",
+                "--seeds 42 43 44",
+                "--num-iterations 25",
+            ],
+        ),
+        # Runbook Plan C shard 1: cheap scenarios
+        (
+            [
+                "--scenarios",
+                "minimal_specialization,trivial_cooperation,v2_minimal",
+            ],
+            [
+                "--scenario 'minimal_specialization'",
+                "--scenario 'trivial_cooperation'",
+                "--scenario 'v2_minimal'",
+            ],
+        ),
+        # Runbook Plan C shard 2: expensive scenarios
+        (
+            [
+                "--scenarios",
+                "default,positional_default,chain_reaction",
+            ],
+            [
+                "--scenario 'default'",
+                "--scenario 'positional_default'",
+                "--scenario 'chain_reaction'",
+            ],
+        ),
+    ],
+    ids=["plan_a_full", "plan_b_sanity", "plan_c_shard1", "plan_c_shard2"],
+)
+def test_runbook_canonical_invocations(
+    args: list[str], expected_in_cmd: list[str]
+) -> None:
+    """Lock in the runbook commands so a refactor to the script cannot
+    silently break the documented operator instructions."""
+    result = _run(["--host", "fake-host", *args, "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    for fragment in expected_in_cmd:
+        assert fragment in result.stdout, (
+            f"missing expected driver flag '{fragment}' in:\n{result.stdout}"
+        )
+
+
+def test_runbook_referenced_by_script_help() -> None:
+    """The runbook path must be discoverable from --help so an operator can
+    find it without grepping the source tree."""
+    result = _run(["--help"])
+    assert result.returncode == 0
+    assert "PPO_BASELINES_RUNBOOK.md" in result.stdout, (
+        "--help should point operators at the runbook for the canonical "
+        "scenario list and handoff procedure to #371"
+    )
+
+
+def test_handoff_to_371_documented_in_followups() -> None:
+    """A real ``ssh``-mode launch prints follow-up instructions to the
+    operator. The handoff to #371 must be referenced so the operator
+    knows the workflow does not end at "training complete".
+
+    We assert this against the help/usage text rather than running a real
+    launch (which we can't from a test)."""
+    result = _run(["--help"])
+    assert result.returncode == 0
+    # The header in the --help block mentions #371 explicitly.
+    assert "#371" in result.stdout, (
+        "--help should reference #371 as the downstream consumer of the "
+        "checkpoints this launcher produces"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift check: launcher uses 'ippo' which must be in the driver's TRAINERS
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_trainer_name_matches_driver() -> None:
+    """The launcher hardcodes ``--trainer ippo``. If the driver renames
+    or removes the ippo entry from TRAINERS, the launcher silently
+    produces a command that will error out on the remote host. Catch
+    drift here, locally, before consuming compute."""
+    out = subprocess.run(
+        [
+            "python",
+            "-c",
+            (
+                "import sys; sys.path.insert(0, '.'); "
+                "from experiments.p3_specialization.run_tier1_cell import TRAINERS; "
+                "print('ippo' if 'ippo' in TRAINERS else 'MISSING')"
+            ),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        pytest.skip(
+            f"cannot import run_tier1_cell.TRAINERS in test env "
+            f"(stderr: {out.stderr.strip()}); skipping drift check"
+        )
+    assert out.stdout.strip() == "ippo", (
+        "launcher hardcodes --trainer ippo but driver does not expose it. "
+        "Either restore the ippo entry in TRAINERS or update the launcher."
+    )


### PR DESCRIPTION
## Summary

Adds the operator-launch wrapper for the PPO baseline training sweep that produces the frozen checkpoints shipped with the M4 release. Closes #384, feeds parent #371 (slice 3/5 of #365).

This is the fourth Option-A launcher in this series (alongside #393's phase-diagram fill, #394's Tier-1 sweep, #395's het_ppo arm). Same pattern, same shape — launcher + runbook + contract tests.

### What lands

- `experiments/scripts/launch_ppo_baselines.sh` — operator-launch wrapper that SSHs into a `$COMPUTE_HOST_*` host, builds the Rust extension, and starts a detached tmux session running `run_tier1_cell.py --trainer ippo` over the canonical #384 release scenario set
- `experiments/p3_specialization/PPO_BASELINES_RUNBOOK.md` — operator runbook with 4 launch plans (full sweep / sanity / shard / smoke) and the handoff procedure to #371
- `tests/test_launch_ppo_baselines.py` — 21 contract tests (arg parsing, host resolution, driver-command synthesis, session-name compaction, runbook canonical invocations, drift check against the driver's TRAINERS dict)

### What this does NOT do

- Does not run training locally (CLAUDE.md is explicit on this)
- Does not package checkpoints into `bucket_brigade/baselines/release/ppo/` — that is #371's job
- Does not auto-launch — operator runs `./experiments/scripts/launch_ppo_baselines.sh` to kick off the remote sweep

### Default scenario set (per #384)

`minimal_specialization`, `default`, `positional_default`, `chain_reaction`, `trivial_cooperation`, `v2_minimal` × seeds 42,43,44 × 50 iter × 2048 rollout = ~18 h on `$COMPUTE_HOST_CLUSTER` per the #384 estimate.

### Caveats

- The issue body's "Reference command" calls `train.py --seeds 42 43 44`, but `train.py` takes a single `--seed`. The launcher uses `run_tier1_cell.py --trainer ippo` instead — the multi-seed wrapper that dispatches to train.py per-seed, matching the sibling launchers (#394, #395). Documented in the runbook.
- `positional_default` is in `SCENARIO_REGISTRY` (legacy name-keyed) but not in `SCENARIO_VERSIONS` (versioned IDs). Training works fine; #371's loader may need a `positional_default-v1` entry added — flagged in the runbook.

## Test plan

- [x] `uv run pytest tests/test_launch_ppo_baselines.py` — 21 passed
- [x] `uv run pytest tests/test_launch_*.py` — 63 passed (no regressions on sibling launchers)
- [x] `uv run ruff check tests/test_launch_ppo_baselines.py` — clean
- [x] `uv run ruff format --check tests/test_launch_ppo_baselines.py` — clean
- [x] `bash experiments/scripts/launch_ppo_baselines.sh --dry-run --host fake-host --skip-connectivity-check` — produces the expected 6-cell plan
- [ ] Operator smoke (out of scope for this PR): `bash launch_ppo_baselines.sh --scenarios minimal_specialization --seeds 42 --num-iterations 1` on a real host

Closes #384