### PR TITLE
feat(env): MacroActionEnv x two_phase composition (Option 2a) for #344

### DIFF
--- a/bucket_brigade/envs/macro_action_env.py
+++ b/bucket_brigade/envs/macro_action_env.py
@@ -109,26 +109,19 @@ class MacroActionEnv:
                 f"discount_gamma must be None or in (0, 1]; got {discount_gamma}"
             )
 
-        # Issue #252: MacroActionEnv x two-phase commitment is out of
-        # scope for the v1 pilot. The macro-option translation already
-        # emits primitive ``[house, mode, signal]`` actions per base
-        # step; under two-phase the wrapper would need to also emit a
-        # deterministic round-1 signal per base step (e.g. always
-        # Uncommitted) and feed it through ``base_env.step_two_phase``.
-        # This is documented as a follow-up in the issue body; for now
-        # we gate with a clear NotImplementedError.
+        # Issue #344: MacroActionEnv x two-phase commitment is supported
+        # via :meth:`step_two_phase`, which loops the base env's
+        # ``step_two_phase`` for each of the ``commit_steps`` base steps
+        # inside the macro window. Caller passes per-base-step round-1
+        # signals (Option 2a from the architect's #344 ratification) so
+        # the deception channel survives at native per-night rate rather
+        # than throttling to 1/N (Option 1 / 2b). The single-phase
+        # :meth:`step` path is unchanged and raises a clear error on
+        # two-phase scenarios (caller must use ``step_two_phase``).
         base_commitment = getattr(
             getattr(base_env, "scenario", None), "commitment_mode", "simultaneous"
         )
-        if base_commitment == "two_phase":
-            raise NotImplementedError(
-                f"MacroActionEnv does not support commitment_mode="
-                f"{base_commitment!r} (issue #252). The macro-option "
-                f"translation needs to emit a round-1 signal per base "
-                f"step; this is deferred to a follow-up issue. Use the "
-                f"raw BucketBrigadeEnv with JointPPOTrainer's two-phase "
-                f"rollout path instead."
-            )
+        self._is_two_phase = base_commitment == "two_phase"
 
         self.base_env = base_env
         self.commit_steps = int(commit_steps)
@@ -188,23 +181,21 @@ class MacroActionEnv:
             number of base steps executed within the macro-step (``<=
             commit_steps``); ``info["primitive_actions"]`` is a list of
             the ``[N, 3]`` primitive arrays emitted (for tests/debug).
+
+        Raises:
+            RuntimeError: if the wrapped scenario uses
+                ``commitment_mode="two_phase"``. Callers must use
+                :meth:`step_two_phase` in that case (mirrors the base
+                env's guardrail).
         """
-        macro_actions = np.asarray(macro_actions)
-        if macro_actions.ndim == 2 and macro_actions.shape[1] == 1:
-            macro_actions = macro_actions[:, 0]
-        if macro_actions.ndim != 1 or macro_actions.shape[0] != self.num_agents:
-            raise ValueError(
-                f"macro_actions must have shape ({self.num_agents},) or "
-                f"({self.num_agents}, 1); got {macro_actions.shape}"
+        if self._is_two_phase:
+            raise RuntimeError(
+                "MacroActionEnv.step requires commitment_mode='simultaneous'; "
+                "the wrapped scenario uses 'two_phase'. Use "
+                "MacroActionEnv.step_two_phase(round1_signals, macro_actions) "
+                "instead (issue #344)."
             )
-        # Validate option indices.
-        bad = (macro_actions < 0) | (macro_actions >= self.num_options)
-        if bad.any():
-            raise ValueError(
-                f"macro_actions contains out-of-range option indices "
-                f"(num_options={self.num_options}): {macro_actions.tolist()}"
-            )
-        macro_actions = macro_actions.astype(np.int64)
+        macro_actions = self._validate_macro_actions(macro_actions)
 
         # Reset per-window REST_UNTIL_FIRE state for agents holding that option.
         # (Agents that are not running REST_UNTIL_FIRE this window will not
@@ -264,6 +255,160 @@ class MacroActionEnv:
         info_out["base_steps"] = base_steps_done
         info_out["primitive_actions"] = primitive_log
         return last_obs, accumulated_rewards, last_dones, info_out
+
+    def step_two_phase(
+        self,
+        round1_signals: np.ndarray,
+        macro_actions: np.ndarray,
+    ) -> Tuple[Dict[str, np.ndarray], np.ndarray, np.ndarray, Dict]:
+        """Execute one macro-step under two-phase commitment (issue #344).
+
+        Implements **Option 2a** from the architect's #344 ratification:
+        the round-1 signal is sampled per base step inside the macro
+        window (NOT per macro window); the macro option is fixed for the
+        whole window. This preserves the deception channel at its native
+        per-night rate rather than throttling it to 1/``commit_steps``.
+
+        For each of the ``commit_steps`` base steps inside the window
+        the wrapper calls ``base_env.step_two_phase(r1_k, primitive_k)``
+        where ``r1_k`` is the caller-provided round-1 signal for base
+        step ``k`` and ``primitive_k`` is the macro option's translated
+        primitive ``[house, mode, signal]`` (same translation as the
+        single-phase path). The round-1 signal that the base env writes
+        into its observation is the CALLER-provided ``r1_k`` — the
+        macro's "honest mirror of mode" pattern only affects the round-2
+        signal column of the primitive, NOT the round-1 channel. This is
+        what keeps the deception channel open at per-night rate.
+
+        Args:
+            round1_signals: Per-base-step round-1 signals. Accepted
+                shapes:
+
+                - ``(commit_steps, num_agents)`` — Option 2a (fresh per
+                  base step). This is the trainer's default path.
+                - ``(num_agents,)`` — broadcast to all base steps inside
+                  the window (Option 2b; throttled deception channel).
+                  Accepted for direct callers / tests that don't care
+                  about within-window variation.
+
+                Dtype is coerced to ``int8``. Values must be in
+                ``{0, 1}`` (the base env clamps invalid values via
+                ``np.asarray.reshape`` so we don't re-validate here).
+            macro_actions: Integer array of shape ``(num_agents,)`` or
+                ``(num_agents, 1)``. Each entry is an option index in
+                ``[0, num_options)``.
+
+        Returns:
+            ``(obs, rewards, dones, info)`` matching :meth:`step`. The
+            ``info`` dict also carries ``info["round1_signals_used"]``,
+            a list of ``[num_agents]`` arrays of the round-1 signals
+            actually fed to the base env each base step (for tests).
+
+        Raises:
+            RuntimeError: if the wrapped scenario does NOT use
+                ``commitment_mode="two_phase"`` (callers must use
+                :meth:`step` in that case; mirrors the base env's
+                guardrail).
+            ValueError: if ``round1_signals`` has an unsupported shape
+                or ``macro_actions`` is malformed.
+        """
+        if not self._is_two_phase:
+            raise RuntimeError(
+                "MacroActionEnv.step_two_phase requires "
+                "commitment_mode='two_phase'; the wrapped scenario uses "
+                "'simultaneous'. Use MacroActionEnv.step instead."
+            )
+        macro_actions = self._validate_macro_actions(macro_actions)
+
+        # Validate / normalize round1_signals to shape (commit_steps, N).
+        r1 = np.asarray(round1_signals)
+        if r1.ndim == 1:
+            if r1.shape[0] != self.num_agents:
+                raise ValueError(
+                    f"1D round1_signals must have length num_agents="
+                    f"{self.num_agents}; got shape {r1.shape}"
+                )
+            # Broadcast a single signal vector across the commit window
+            # (Option 2b — throttled). Accepted for caller convenience.
+            r1 = np.broadcast_to(r1, (self.commit_steps, self.num_agents))
+        elif r1.ndim == 2:
+            if r1.shape != (self.commit_steps, self.num_agents):
+                raise ValueError(
+                    f"2D round1_signals must have shape "
+                    f"({self.commit_steps}, {self.num_agents}); got {r1.shape}"
+                )
+        else:
+            raise ValueError(
+                f"round1_signals must be 1D (num_agents,) or 2D "
+                f"(commit_steps, num_agents); got ndim={r1.ndim}"
+            )
+
+        # Reset per-window REST_UNTIL_FIRE state for agents holding that option.
+        self._fire_seen = np.zeros(self.num_agents, dtype=bool)
+
+        accumulated_rewards = np.zeros(self.num_agents, dtype=np.float32)
+        primitive_log: List[np.ndarray] = []
+        r1_log: List[np.ndarray] = []
+        base_steps_done = 0
+        last_obs: Optional[Dict[str, np.ndarray]] = None
+        last_dones: Optional[np.ndarray] = None
+        last_info: Dict = {}
+
+        for k in range(self.commit_steps):
+            # Mirror the single-phase REST_UNTIL_FIRE bookkeeping.
+            if np.any(self.base_env.houses == BucketBrigadeEnv.BURNING):
+                self._fire_seen[:] = True
+
+            primitive = self._build_primitive_actions(macro_actions)
+            primitive_log.append(primitive.copy())
+
+            r1_k = np.asarray(r1[k]).astype(np.int8)
+            r1_log.append(r1_k.copy())
+
+            obs, rewards, dones, info = self.base_env.step_two_phase(r1_k, primitive)
+
+            if self.discount_gamma is None:
+                accumulated_rewards += rewards.astype(np.float32)
+            else:
+                accumulated_rewards += (self.discount_gamma**k) * rewards.astype(
+                    np.float32
+                )
+
+            base_steps_done += 1
+            last_obs = obs
+            last_dones = dones
+            last_info = info
+
+            if np.any(obs["houses"] == BucketBrigadeEnv.BURNING):
+                self._fire_seen[:] = True
+
+            if bool(np.asarray(dones).any()):
+                break
+
+        assert last_obs is not None and last_dones is not None
+        info_out = dict(last_info)
+        info_out["base_steps"] = base_steps_done
+        info_out["primitive_actions"] = primitive_log
+        info_out["round1_signals_used"] = r1_log
+        return last_obs, accumulated_rewards, last_dones, info_out
+
+    def _validate_macro_actions(self, macro_actions: np.ndarray) -> np.ndarray:
+        """Normalize macro-action input to a ``(num_agents,)`` int64 array."""
+        macro_actions = np.asarray(macro_actions)
+        if macro_actions.ndim == 2 and macro_actions.shape[1] == 1:
+            macro_actions = macro_actions[:, 0]
+        if macro_actions.ndim != 1 or macro_actions.shape[0] != self.num_agents:
+            raise ValueError(
+                f"macro_actions must have shape ({self.num_agents},) or "
+                f"({self.num_agents}, 1); got {macro_actions.shape}"
+            )
+        bad = (macro_actions < 0) | (macro_actions >= self.num_options)
+        if bad.any():
+            raise ValueError(
+                f"macro_actions contains out-of-range option indices "
+                f"(num_options={self.num_options}): {macro_actions.tolist()}"
+            )
+        return macro_actions.astype(np.int64)
 
     # ------------------------------------------------------------------
     # Option -> primitive action translation
@@ -381,6 +526,31 @@ class MacroActionEnv:
     @property
     def signals(self) -> np.ndarray:
         return self.base_env.signals
+
+    def _get_observation(self) -> Dict[str, np.ndarray]:
+        """Pass-through to :meth:`BucketBrigadeEnv._get_observation`.
+
+        Issue #344: :class:`JointPPOTrainer` probes the env via
+        ``_get_observation()`` at construction time (to recover the
+        ``last_actions`` slot offsets in the flattened obs vector;
+        :mod:`joint_trainer` lines 670-690). The macro wrapper does not
+        rewrite obs, so the natural answer is the base env's obs.
+        """
+        return self.base_env._get_observation()
+
+    @property
+    def round1_signals(self) -> np.ndarray:
+        """Issue #344: two-phase round-1 signal channel pass-through.
+
+        Mirrors :attr:`BucketBrigadeEnv.round1_signals` so the trainer
+        and obs-builder code that probes the env directly work uniformly
+        across the wrapped and un-wrapped paths.
+        """
+        return self.base_env.round1_signals
+
+    @round1_signals.setter
+    def round1_signals(self, value: np.ndarray) -> None:
+        self.base_env.round1_signals = value
 
     @property
     def last_actions(self) -> np.ndarray:

--- a/bucket_brigade/training/joint_trainer.py
+++ b/bucket_brigade/training/joint_trainer.py
@@ -376,17 +376,50 @@ class JointPPOTrainer:
             else "simultaneous"
         )
         if self._commitment_mode == "two_phase":
-            # MacroActionEnv (#298) does not yet support two-phase. We
-            # gate here rather than silently producing wrong behavior.
+            # Issue #344: MacroActionEnv x two-phase is now supported via
+            # the wrapper's :meth:`step_two_phase` method, which loops
+            # the base env's two-phase step for each base step in the
+            # commit window (Option 2a). Detect that path here so the
+            # rollout loop knows whether to call ``env.step_two_phase``
+            # with primitives (raw base env) or per-base-step signal
+            # arrays (wrapper). The check is kept lightweight; we do not
+            # raise on macro+two_phase any more.
             from bucket_brigade.envs.bucket_brigade_env import BucketBrigadeEnv
+            from bucket_brigade.envs.macro_action_env import MacroActionEnv
 
-            if not isinstance(self.env, BucketBrigadeEnv):
+            if not isinstance(self.env, (BucketBrigadeEnv, MacroActionEnv)):
                 raise NotImplementedError(
                     "commitment_mode='two_phase' is currently only supported "
-                    "with a raw BucketBrigadeEnv. Wrappers like MacroActionEnv "
-                    "(#298) require a follow-up to translate options into "
-                    "round-1 signal + round-2 action."
+                    "with a raw BucketBrigadeEnv or a MacroActionEnv-wrapped "
+                    "one. Got env type: " + type(self.env).__name__
                 )
+            self._is_macro_two_phase = isinstance(self.env, MacroActionEnv)
+            if self._is_macro_two_phase:
+                # Issue #344 (Option 2a / Option 4): the macro head emits
+                # the round-2 macro option; a second head (size 2) emits
+                # the per-base-step round-1 signal. Caller must declare
+                # ``action_dims = [num_options, 2]``: head 0 = macro
+                # option (Discrete(num_options)), head 1 = round-1 signal
+                # bit (Discrete(2)). The trainer reads column 0 of the
+                # joint action for the macro step (stored for PPO update)
+                # and column 1 for the per-base-step round-1 signal
+                # (re-sampled ``commit_steps`` times per macro-step from
+                # the macro-boundary obs; not in the PPO loss, matching
+                # the raw two-phase trainer's "round-1 lp not in loss"
+                # simplification at line 933-938).
+                expected_macro_head = int(self.env.num_options)
+                if (
+                    len(action_dims) != 2
+                    or action_dims[0] != expected_macro_head
+                    or action_dims[1] != 2
+                ):
+                    raise ValueError(
+                        f"MacroActionEnv + two_phase requires "
+                        f"action_dims=[{expected_macro_head}, 2] "
+                        f"(head 0 = macro option, head 1 = round-1 signal "
+                        f"bit); got action_dims={action_dims!r}. See issue "
+                        f"#344 (Option 2a)."
+                    )
             # Issue #252 + #274 mutex: obs-audit's "what did the policy see
             # when it picked this action" invariant does not hold under
             # two-phase rollouts (round-1 obs feeds the signal forward;
@@ -394,6 +427,10 @@ class JointPPOTrainer:
             # record one per (step, agent)). Surface the conflict at
             # construction time rather than silently logging a misleading
             # record. The audit + simultaneous path is unchanged.
+            # Issue #344: the mutex extends to MacroActionEnv + two_phase
+            # for the same reason — there are now N round-1 obs per
+            # macro-step on top of the round-2 obs, none of which line
+            # up with the single audit slot.
             if obs_auditor is not None and obs_auditor.enabled:
                 raise NotImplementedError(
                     "commitment_mode='two_phase' is incompatible with "
@@ -403,6 +440,8 @@ class JointPPOTrainer:
                     "round-2 action). Run them separately or extend the "
                     "audit record to carry both phases."
                 )
+        else:
+            self._is_macro_two_phase = False
 
         self.gamma = gamma
         self.gae_lambda = gae_lambda
@@ -944,33 +983,84 @@ class JointPPOTrainer:
             # two-phase. We surface this conflict at config-validation
             # time rather than silently logging a misleading record.
             if self._commitment_mode == "two_phase":
-                # Round 1: signal-only forward pass. Reuse _act_all but
-                # discard everything except the signal column.
-                _r1_joint, _r1_lps, _r1_vs = self._act_all(obs_t)
-                round1_signals = _r1_joint[:, 2].astype(np.uint8)
-                # Stash round-1 signals into the env so the round-2 obs
-                # carries them. We mutate the env's buffer directly
-                # rather than running env.step_two_phase twice — the env
-                # exposes `round1_signals` as a public attribute (#252).
-                self.env.round1_signals = round1_signals.astype(np.int8)
-                # Rebuild the per-agent flat obs with the now-populated
-                # round1_signals so the round-2 policy forward sees them.
-                round2_dict = {
-                    "signals": self.env.signals.copy(),
-                    "locations": self.env.locations.copy(),
-                    "houses": self.env.houses.copy(),
-                    "last_actions": self.env.last_actions.copy(),
-                    "scenario_info": self.env.scenario.to_feature_vector(),
-                    "round1_signals": self.env.round1_signals.copy(),
-                }
-                self._last_obs = self._flatten_per_agent(round2_dict)
-                obs_t = torch.from_numpy(self._last_obs).to(self.device)
-                # Round 2: full-action forward pass. This is the one we
-                # store for PPO updates.
-                joint_action, lps, vs = self._act_all(obs_t)
-                next_obs_dict, rew, done_arr, _ = self.env.step_two_phase(
-                    round1_signals, joint_action
-                )
+                if self._is_macro_two_phase:
+                    # Issue #344: MacroActionEnv + two_phase (Option 2a).
+                    # The macro is committed for ``commit_steps`` base
+                    # steps; the round-1 signal is sampled fresh per
+                    # base step inside the window (NOT once per macro
+                    # window — that would silently collapse to Option
+                    # 2b / Option 1, throttling the deception channel
+                    # to 1/N). To approximate per-base-step conditioning
+                    # cheaply, we draw ``commit_steps`` independent
+                    # stochastic samples from the same macro-boundary
+                    # obs (one forward each), reading the signal head
+                    # (column 1 of action_dims=[num_options, 2]).
+                    # Each draw is a fresh sample from the round-1 signal
+                    # distribution; this is the architecturally cheapest
+                    # way to keep the native per-night lie-rate
+                    # (#234 / #344).
+                    commit_steps = int(self.env.commit_steps)
+                    round1_signals_per_step = np.zeros(
+                        (commit_steps, self.num_agents), dtype=np.int8
+                    )
+                    for k in range(commit_steps):
+                        _r1k_joint, _, _ = self._act_all(obs_t)
+                        round1_signals_per_step[k] = _r1k_joint[:, 1].astype(np.int8)
+                    # Stash the first base step's round-1 signal into the
+                    # env so the round-2 macro forward conditions on a
+                    # plausible obs. (Round 2's obs only carries one
+                    # round1_signals vector at a time; the natural choice
+                    # is "what would be active at the START of the macro
+                    # window".)
+                    self.env.round1_signals = round1_signals_per_step[0]
+                    round2_dict = {
+                        "signals": self.env.signals.copy(),
+                        "locations": self.env.locations.copy(),
+                        "houses": self.env.houses.copy(),
+                        "last_actions": self.env.last_actions.copy(),
+                        "scenario_info": self.env.scenario.to_feature_vector(),
+                        "round1_signals": self.env.round1_signals.copy(),
+                    }
+                    self._last_obs = self._flatten_per_agent(round2_dict)
+                    obs_t = torch.from_numpy(self._last_obs).to(self.device)
+                    # Round 2 (macro): one forward pass per macro-step,
+                    # stored for PPO updates (correct credit assignment).
+                    # The macro option is in column 0 of action_dims=
+                    # [num_options, 2]; the wrapper consumes that column.
+                    joint_action, lps, vs = self._act_all(obs_t)
+                    macro_action_col0 = joint_action[:, 0]
+                    next_obs_dict, rew, done_arr, _ = self.env.step_two_phase(
+                        round1_signals_per_step, macro_action_col0
+                    )
+                else:
+                    # Raw BucketBrigadeEnv two-phase rollout (pre-#344).
+                    # Round 1: signal-only forward pass. Reuse _act_all but
+                    # discard everything except the signal column.
+                    _r1_joint, _r1_lps, _r1_vs = self._act_all(obs_t)
+                    round1_signals = _r1_joint[:, 2].astype(np.uint8)
+                    # Stash round-1 signals into the env so the round-2 obs
+                    # carries them. We mutate the env's buffer directly
+                    # rather than running env.step_two_phase twice — the env
+                    # exposes `round1_signals` as a public attribute (#252).
+                    self.env.round1_signals = round1_signals.astype(np.int8)
+                    # Rebuild the per-agent flat obs with the now-populated
+                    # round1_signals so the round-2 policy forward sees them.
+                    round2_dict = {
+                        "signals": self.env.signals.copy(),
+                        "locations": self.env.locations.copy(),
+                        "houses": self.env.houses.copy(),
+                        "last_actions": self.env.last_actions.copy(),
+                        "scenario_info": self.env.scenario.to_feature_vector(),
+                        "round1_signals": self.env.round1_signals.copy(),
+                    }
+                    self._last_obs = self._flatten_per_agent(round2_dict)
+                    obs_t = torch.from_numpy(self._last_obs).to(self.device)
+                    # Round 2: full-action forward pass. This is the one we
+                    # store for PPO updates.
+                    joint_action, lps, vs = self._act_all(obs_t)
+                    next_obs_dict, rew, done_arr, _ = self.env.step_two_phase(
+                        round1_signals, joint_action
+                    )
             else:
                 joint_action, lps, vs = self._act_all(obs_t)
                 next_obs_dict, rew, done_arr, _ = self.env.step(joint_action)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1979,10 +1979,23 @@ class TestCommitmentMode:
         py_obs, _, _, _ = py_env.step_two_phase(r1_np, r2_np)
         np.testing.assert_array_equal(py_obs["round1_signals"], r1_np)
 
-    def test_macro_action_env_rejects_two_phase(self):
-        """MacroActionEnv x two-phase is gated as NotImplementedError."""
+    def test_macro_action_env_accepts_two_phase(self):
+        """Issue #344: MacroActionEnv x two-phase is now SUPPORTED via
+        :meth:`MacroActionEnv.step_two_phase` (Option 2a — round-1
+        sampled per base step, round-2 macro committed for the window).
+        The construction-time gate that previously raised
+        ``NotImplementedError`` has been removed; the wrapper's
+        :meth:`step` instead raises a clear ``RuntimeError`` directing
+        callers to :meth:`step_two_phase`. See
+        ``tests/test_macro_action_env.py::TestMacroTwoPhaseDeceptionChannel``
+        for the deception-channel PR-gate."""
         from bucket_brigade.envs.macro_action_env import MacroActionEnv
 
         env = BucketBrigadeEnv(scenario=self._make_two_phase_scenario())
-        with pytest.raises(NotImplementedError, match="two_phase"):
-            MacroActionEnv(env, commit_steps=3)
+        # Must not raise.
+        wrapped = MacroActionEnv(env, commit_steps=3)
+        wrapped.reset(seed=0)
+        # Single-phase step path is gated with a clear runtime error.
+        macro_actions = np.zeros(4, dtype=np.int64)
+        with pytest.raises(RuntimeError, match="two_phase"):
+            wrapped.step(macro_actions)

--- a/tests/test_joint_trainer.py
+++ b/tests/test_joint_trainer.py
@@ -1367,6 +1367,130 @@ class TestCommitmentModeTwoPhase:
         assert with_r1 == without_r1 + NUM_AGENTS
 
 
+class TestMacroActionEnvTwoPhase:
+    """Issue #344: trainer wiring for MacroActionEnv + two_phase.
+
+    The trainer auto-detects the composition (``MacroActionEnv`` wrapper +
+    ``commitment_mode='two_phase'``) and uses the wrapper's
+    :meth:`MacroActionEnv.step_two_phase` API, sampling
+    ``commit_steps`` round-1 signals per macro-step (Option 2a from
+    architect #344).
+    """
+
+    _COMMIT_STEPS = 3
+
+    def _env_fn(self):
+        import dataclasses
+
+        from bucket_brigade.envs.macro_action_env import MacroActionEnv
+        from bucket_brigade.envs.scenarios_generated import default_scenario
+
+        scenario = default_scenario(num_agents=NUM_AGENTS)
+        scenario = dataclasses.replace(scenario, commitment_mode="two_phase")
+        base = BucketBrigadeEnv(scenario=scenario)
+        return MacroActionEnv(base, commit_steps=self._COMMIT_STEPS)
+
+    def _make_trainer(self) -> JointPPOTrainer:
+        env = self._env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(
+            obs,
+            agent_id=0,
+            num_agents=NUM_AGENTS,
+            include_round1_signals=True,
+        ).shape[0]
+        return JointPPOTrainer(
+            env_fn=self._env_fn,
+            num_agents=NUM_AGENTS,
+            obs_dim=obs_dim,
+            # Issue #344 (Option 2a / Option 4): macro+two_phase requires
+            # a 2-head policy — head 0 = macro option (Discrete(num_options)),
+            # head 1 = round-1 signal bit (Discrete(2)). num_options =
+            # 3 + (num_agents - 1) = 6 for num_agents=4.
+            action_dims=[6, 2],
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            seed=0,
+        )
+
+    def test_trainer_construction_no_longer_raises(self):
+        """Pre-#344 the trainer raised ``NotImplementedError`` on the
+        composition; post-#344 it constructs cleanly and sets the
+        ``_is_macro_two_phase`` dispatch flag."""
+        trainer = self._make_trainer()
+        assert trainer._commitment_mode == "two_phase"
+        assert trainer._is_macro_two_phase is True
+
+    def test_rollout_finite_shapes(self):
+        """A short rollout through MacroActionEnv + two_phase produces
+        finite tensors with shapes matching the simultaneous case
+        (the rollout buffer schema is shared)."""
+        trainer = self._make_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        assert rollout.observations.shape == (
+            ROLLOUT_STEPS,
+            NUM_AGENTS,
+            trainer.obs_dim,
+        )
+        for i in range(NUM_AGENTS):
+            # 2-head action: column 0 = macro option, column 1 = round-1
+            # signal bit (issue #344 Option 2a / Option 4).
+            assert rollout.actions[i].shape == (ROLLOUT_STEPS, 2)
+            assert torch.isfinite(rollout.log_probs[i]).all()
+            assert torch.isfinite(rollout.values[i]).all()
+            assert torch.isfinite(rollout.rewards[i]).all()
+
+    def test_update_does_not_nan(self):
+        """A PPO update on a macro+two_phase rollout produces finite
+        gradients and no NaN losses."""
+        trainer = self._make_trainer()
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        metrics = trainer.update(rollout)
+        for key, value in metrics.items():
+            assert np.isfinite(value), (
+                f"metric {key}={value} is not finite in macro+two_phase update"
+            )
+
+    def test_simultaneous_macro_path_unchanged(self):
+        """Regression: when ``commitment_mode='simultaneous'`` the
+        ``_is_macro_two_phase`` flag is False and the trainer routes to
+        the legacy ``env.step()`` path — bit-identical to pre-#344
+        behavior for single-phase macro scenarios."""
+        import dataclasses
+
+        from bucket_brigade.envs.macro_action_env import MacroActionEnv
+        from bucket_brigade.envs.scenarios_generated import default_scenario
+
+        def _sim_macro_env_fn():
+            scenario = default_scenario(num_agents=NUM_AGENTS)
+            # Explicit simultaneous (the default).
+            scenario = dataclasses.replace(scenario, commitment_mode="simultaneous")
+            return MacroActionEnv(
+                BucketBrigadeEnv(scenario=scenario),
+                commit_steps=self._COMMIT_STEPS,
+            )
+
+        env = _sim_macro_env_fn()
+        obs = env.reset(seed=0)
+        obs_dim = flatten_dict_obs(obs, agent_id=0, num_agents=NUM_AGENTS).shape[0]
+        trainer = JointPPOTrainer(
+            env_fn=_sim_macro_env_fn,
+            num_agents=NUM_AGENTS,
+            obs_dim=obs_dim,
+            action_dims=[6],
+            hidden_size=16,
+            minibatch_size=32,
+            ppo_epochs=2,
+            seed=0,
+        )
+        assert trainer._commitment_mode == "simultaneous"
+        assert trainer._is_macro_two_phase is False
+        rollout = trainer.collect_rollout(ROLLOUT_STEPS)
+        for i in range(NUM_AGENTS):
+            assert torch.isfinite(rollout.rewards[i]).all()
+
+
 class TestAsymmetryAwareInit:
     """Issue #386: per-agent init seed offset (HetGPPO-style symmetry break).
 

--- a/tests/test_macro_action_env.py
+++ b/tests/test_macro_action_env.py
@@ -7,6 +7,7 @@ per-option primitive semantics, reward accumulation, and edge cases.
 """
 
 import dataclasses
+from typing import List
 
 import numpy as np
 import pytest
@@ -328,3 +329,288 @@ class TestSmokeRollout:
             assert 1 <= info["base_steps"] <= 3
             if bool(dones.any()):
                 env.reset()
+
+
+# ----------------------------------------------------------------------
+# Issue #344: MacroActionEnv + commitment_mode="two_phase" composition.
+# Architect ratified Option 2a: round-1 signal sampled per base step
+# inside the macro window, round-2 macro committed for the whole window.
+# ----------------------------------------------------------------------
+
+
+def _make_two_phase_env(num_agents: int = 4, commit_steps: int = 3) -> MacroActionEnv:
+    scenario = minimal_specialization_scenario(num_agents=num_agents)
+    scenario = dataclasses.replace(scenario, commitment_mode="two_phase")
+    base = BucketBrigadeEnv(scenario=scenario)
+    return MacroActionEnv(base, commit_steps=commit_steps)
+
+
+def _make_two_phase_env_no_fire(
+    num_agents: int = 4, commit_steps: int = 3
+) -> MacroActionEnv:
+    scenario = minimal_specialization_scenario(num_agents=num_agents)
+    scenario = dataclasses.replace(
+        scenario,
+        commitment_mode="two_phase",
+        prob_house_catches_fire=0.0,
+    )
+    base = BucketBrigadeEnv(scenario=scenario)
+    return MacroActionEnv(base, commit_steps=commit_steps)
+
+
+class TestMacroTwoPhaseComposition:
+    """Issue #344: smoke + contract tests for MacroActionEnv x two_phase."""
+
+    def test_construction_no_longer_raises_on_two_phase(self):
+        """Pre-#344 the wrapper gated two-phase with NotImplementedError;
+        post-#344 the constructor accepts two-phase scenarios."""
+        scenario = minimal_specialization_scenario(num_agents=4)
+        scenario = dataclasses.replace(scenario, commitment_mode="two_phase")
+        base = BucketBrigadeEnv(scenario=scenario)
+        # Must not raise.
+        env = MacroActionEnv(base, commit_steps=3)
+        assert env.num_options == 6  # 3 + (4 - 1)
+
+    def test_step_raises_on_two_phase_scenario(self):
+        """The simultaneous :meth:`step` path now raises on two-phase
+        scenarios — callers must use :meth:`step_two_phase` instead.
+        Mirrors the base env's :meth:`BucketBrigadeEnv.step` guardrail."""
+        env = _make_two_phase_env(num_agents=4, commit_steps=3)
+        env.reset(seed=42)
+        macro_actions = np.zeros(4, dtype=np.int64)
+        with pytest.raises(RuntimeError, match="two_phase"):
+            env.step(macro_actions)
+
+    def test_step_two_phase_raises_on_simultaneous_scenario(self):
+        """Conversely, :meth:`step_two_phase` requires two-phase mode."""
+        env = _make_env(num_agents=4, commit_steps=3)
+        env.reset(seed=42)
+        r1 = np.zeros((3, 4), dtype=np.int8)
+        macro_actions = np.zeros(4, dtype=np.int64)
+        with pytest.raises(RuntimeError, match="two_phase"):
+            env.step_two_phase(r1, macro_actions)
+
+    def test_smoke_step_two_phase_executes_full_window(self):
+        """Composition smoke: wrapper + two_phase constructs and steps
+        cleanly through one macro window."""
+        env = _make_two_phase_env(num_agents=4, commit_steps=3)
+        obs = env.reset(seed=42)
+        assert obs is not None
+
+        # Round-1 signals: shape (commit_steps, num_agents). All zeros
+        # (Uncommitted/Rest signals) — should not interfere with macro.
+        r1 = np.zeros((3, 4), dtype=np.int8)
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        obs2, rewards, dones, info = env.step_two_phase(r1, macro_actions)
+        assert rewards.shape == (4,)
+        assert dones.shape == (4,)
+        assert info["base_steps"] <= 3
+        # Wrapper records the round-1 signals it actually fed to the env.
+        assert "round1_signals_used" in info
+        assert len(info["round1_signals_used"]) == info["base_steps"]
+        for r in info["round1_signals_used"]:
+            np.testing.assert_array_equal(r, np.zeros(4, dtype=np.int8))
+
+    def test_step_two_phase_accepts_1d_round1_broadcast(self):
+        """A 1D round-1 vector is broadcast to all base steps (Option 2b
+        convenience — the deception channel is throttled to 1/N but the
+        signature is convenient for tests / direct callers)."""
+        env = _make_two_phase_env(num_agents=4, commit_steps=3)
+        env.reset(seed=7)
+        r1 = np.array([1, 0, 1, 0], dtype=np.int8)
+        macro_actions = np.full(4, OPT_PATROL, dtype=np.int64)
+        _, _, _, info = env.step_two_phase(r1, macro_actions)
+        # All recorded r1 vectors should equal the broadcast input.
+        for r in info["round1_signals_used"]:
+            np.testing.assert_array_equal(r, r1)
+
+    def test_round1_signals_property_passthrough(self):
+        """The wrapper exposes a ``round1_signals`` pass-through so the
+        trainer's existing two-phase rollout code (which mutates
+        ``env.round1_signals`` directly) keeps working uniformly."""
+        env = _make_two_phase_env(num_agents=4, commit_steps=3)
+        env.reset(seed=0)
+        np.testing.assert_array_equal(env.round1_signals, np.zeros(4, dtype=np.int8))
+        env.round1_signals = np.array([1, 0, 1, 0], dtype=np.int8)
+        np.testing.assert_array_equal(
+            env.base_env.round1_signals, np.array([1, 0, 1, 0], dtype=np.int8)
+        )
+
+
+class TestMacroTwoPhaseDeceptionChannel:
+    """**PR-GATE**: deception-channel preservation under composition.
+
+    The composition's analog of
+    ``tests/test_environment.py::TestCommitmentMode::test_can_still_lie``.
+    Under Option 2a the round-1 signal is sampled per base step; under
+    Option 1 or Option 2b it would be throttled to 1/commit_steps. This
+    test asserts the per-base-step rate is preserved — if a hardcoded
+    Liar policy emits round-1=WORK on every base step and chooses a
+    REST_UNTIL_FIRE macro (whose round-2 mode is REST until first fire),
+    the lie-rate stays at 100% per base step, not 100%/commit_steps.
+
+    Architect-flagged as the PR-gate (issue #344). If this fails the
+    composition has silently collapsed to Option 1's deception profile
+    and the PR must NOT merge.
+    """
+
+    def test_can_still_lie_under_macro_per_base_step(self):
+        """Per-base-step lie-rate >= 50% with a hardcoded liar (the
+        threshold discriminates Option 2a from Option 2b: a 1/N=20%
+        cap would fail the >= 50% gate even in the worst case)."""
+        env = _make_two_phase_env_no_fire(num_agents=4, commit_steps=5)
+        env.reset(seed=42)
+
+        # Hardcoded liar: round-1 signal=WORK (1) on every base step.
+        # Macro = REST_UNTIL_FIRE → round-2 mode=REST (0) while no fire
+        # has been observed (and the env is constructed with
+        # prob_house_catches_fire=0 so no fire ever ignites).
+        r1_lie = np.ones((5, 4), dtype=np.int8)  # WORK on every base step
+        macro_actions = np.full(4, OPT_REST_UNTIL_FIRE, dtype=np.int64)
+
+        lying_count = 0
+        total_count = 0
+        # Drive several macro-steps (each = commit_steps base steps).
+        for _ in range(4):
+            if env.done:
+                env.reset()
+            obs, _, _, info = env.step_two_phase(r1_lie, macro_actions)
+            # Inspect every (round-1 signal, round-2 mode) pair from the
+            # primitives the wrapper emitted across the commit window.
+            r1_used = info["round1_signals_used"]
+            primitives = info["primitive_actions"]
+            assert len(r1_used) == len(primitives)
+            for r1_k, prim_k in zip(r1_used, primitives):
+                for i in range(env.num_agents):
+                    total_count += 1
+                    r2_mode_i = int(prim_k[i, 1])
+                    r1_i = int(r1_k[i])
+                    if r1_i != r2_mode_i:
+                        lying_count += 1
+
+        assert total_count > 0
+        lie_rate = lying_count / total_count
+        # The hardcoded liar lies on every base step (rate == 1.0).
+        # PR-gate threshold: >= 50% (much higher than 1/N=20%) to
+        # discriminate Option 2a from Option 2b.
+        assert lie_rate >= 0.5, (
+            f"PR-GATE (#344): expected per-base-step lie-rate >= 50% with "
+            f"a hardcoded liar + REST_UNTIL_FIRE macro; got {lie_rate:.4f} "
+            f"({lying_count}/{total_count} pairs inconsistent). If this "
+            f"rate is throttled to ~1/commit_steps the composition has "
+            f"silently collapsed to Option 1's deception profile and the "
+            f"deception channel has been destroyed. DO NOT MERGE."
+        )
+
+    def test_per_base_step_signals_not_broadcast(self):
+        """Discriminator between Option 2a and Option 2b: each base step
+        inside the macro window must consume the r1 row at its position
+        in the [commit_steps, N] input — NOT a single broadcast value.
+
+        If the wrapper silently broadcast a single r1 vector to all base
+        steps (Option 2b), the recorded ``round1_signals_used`` would
+        be identical across all base steps. This test sends a strictly
+        varying matrix and asserts row k is used at base step k."""
+        env = _make_two_phase_env_no_fire(num_agents=4, commit_steps=3)
+        env.reset(seed=0)
+        # Distinct rows so 2b broadcast would fail the assertion.
+        r1 = np.array(
+            [
+                [1, 1, 1, 1],
+                [1, 0, 1, 0],
+                [0, 1, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        _, _, _, info = env.step_two_phase(r1, macro_actions)
+        r1_used = info["round1_signals_used"]
+        assert len(r1_used) == info["base_steps"]
+        for k in range(info["base_steps"]):
+            (
+                np.testing.assert_array_equal(r1_used[k], r1[k]),
+                (
+                    f"base step {k} used r1={r1_used[k]} but input row "
+                    f"{k} was {r1[k]}; the wrapper has silently broadcast a "
+                    f"single r1 vector (Option 2b), throttling the deception "
+                    f"channel to 1/commit_steps"
+                ),
+            )
+
+    def test_round1_signals_visible_in_obs(self):
+        """The base env's ``round1_signals`` slot reflects the LAST base
+        step's round-1 signal after the macro window closes (matches the
+        per-step ``base_env.step_two_phase`` contract)."""
+        env = _make_two_phase_env_no_fire(num_agents=4, commit_steps=3)
+        env.reset(seed=0)
+        # Last base step's signal: [0, 1, 0, 1].
+        r1 = np.array(
+            [
+                [1, 1, 1, 1],
+                [1, 0, 1, 0],
+                [0, 1, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        macro_actions = np.full(4, OPT_DEFEND_OWN, dtype=np.int64)
+        obs, _, _, info = env.step_two_phase(r1, macro_actions)
+        if info["base_steps"] == 3:
+            np.testing.assert_array_equal(
+                obs["round1_signals"], np.array([0, 1, 0, 1], dtype=np.int8)
+            )
+
+
+class TestMacroSinglePhaseRegression:
+    """Issue #344: single-phase regression — the wrapper's behavior on
+    ``commitment_mode="simultaneous"`` scenarios must be bit-identical
+    to the pre-#344 path. The new construction logic and the new
+    ``step_two_phase`` method must not perturb anything on the
+    single-phase path."""
+
+    def test_single_phase_step_bit_identical(self):
+        """Wrapper-driven single-phase rollout produces the same
+        (rewards, locations, houses) as a direct re-play of the wrapper-
+        emitted primitives against a fresh base env. This is the same
+        invariant as :class:`TestRewardAggregation` but exercised across
+        several macro-steps + random options to maximize the chance of
+        catching a regression."""
+        env_w = _make_env(num_agents=4, commit_steps=3)
+        env_w.reset(seed=42)
+        rng = np.random.RandomState(0)
+        all_primitives: List[np.ndarray] = []
+        all_macro_rewards: List[np.ndarray] = []
+        # Save the n_steps actually executed each macro-step.
+        all_n_steps: List[int] = []
+        for _ in range(5):
+            macro_actions = rng.randint(0, env_w.num_options, size=4).astype(np.int64)
+            _, macro_rewards, dones, info = env_w.step(macro_actions)
+            all_primitives.extend(info["primitive_actions"])
+            all_macro_rewards.append(macro_rewards.copy())
+            all_n_steps.append(int(info["base_steps"]))
+            if bool(dones.any()):
+                env_w.reset()
+
+        # Replay all primitives directly against a fresh base env (with
+        # the same seed + auto-reset pattern). Compare per-macro-step
+        # accumulated rewards.
+        scenario = minimal_specialization_scenario(num_agents=4)
+        base = BucketBrigadeEnv(scenario=scenario)
+        base.reset(seed=42)
+        primitive_idx = 0
+        for macro_idx, n_steps in enumerate(all_n_steps):
+            sum_rew = np.zeros(4, dtype=np.float32)
+            for _ in range(n_steps):
+                _, rewards, dones, _ = base.step(all_primitives[primitive_idx])
+                sum_rew += rewards.astype(np.float32)
+                primitive_idx += 1
+                if bool(dones.any()):
+                    base.reset()
+                    break
+            np.testing.assert_allclose(all_macro_rewards[macro_idx], sum_rew, atol=1e-5)
+
+    def test_single_phase_construction_still_works(self):
+        """Constructing the wrapper on a default (simultaneous) scenario
+        does not raise after the #344 gate removal."""
+        env = _make_env(num_agents=4, commit_steps=3)
+        assert env.num_options == 6
+        assert env._is_two_phase is False


### PR DESCRIPTION
Closes #344

## Summary

Resolves the previously-gated `NotImplementedError` for the cross-product of macro-actions (#298) and two-phase commitment (#321). Implements the **architect-ratified Option 2a**: round-1 signal is sampled per base step inside the macro window; the macro option is committed for the whole window. Preserves the deception channel at its native per-night rate (#234) — avoids the 1/`commit_steps` throttling of Options 1 and 2b.

The composition follows the architect's plan with one refinement: under macro+two_phase the policy uses a 2-head `action_dims=[num_options, 2]` layout (head 0 = macro option, head 1 = round-1 signal bit). This is the natural multi-head plumbing for Option 2a / Option 4 — the trainer's existing "extract column k as signal" pattern cleanly maps to "column 0 = macro, column 1 = signal". The architect's text implies a single-head policy could be reused; in practice that requires a 2nd output head because the raw env's `[house, mode, signal]` semantics differ from the macro env's `[option]` semantics.

## Changes

**`bucket_brigade/envs/macro_action_env.py`** (gate removal + new API)
- Remove the construction-time `NotImplementedError` gate at L120-131.
- Add `MacroActionEnv.step_two_phase(round1_signals, macro_actions)`: loops `base_env.step_two_phase` per base step in the commit window with caller-provided per-base-step round-1 signals. Accepts `[commit_steps, N]` (Option 2a) or `[N]` (Option 2b convenience for direct callers/tests).
- `step()` now raises `RuntimeError` on two-phase scenarios, mirroring `BucketBrigadeEnv.step`'s guardrail.
- Add `round1_signals` property pass-through and `_get_observation` pass-through (the trainer probes both at construction time).

**`bucket_brigade/training/joint_trainer.py`** (mutex removal + dispatch)
- Detect MacroActionEnv + two_phase composition; set `_is_macro_two_phase` dispatch flag.
- Validate `action_dims=[num_options, 2]` for the macro+two_phase path.
- Rollout dispatch: pre-sample `commit_steps` round-1 signals from the macro-boundary obs (one forward each from the signal head, column 1), do one round-2 macro forward (stored for PPO update; macro option in column 0), call `env.step_two_phase(r1_per_step, macro_col0)`.

**Tests** (the 3 architect-flagged regressions plus trainer wiring)
- `tests/test_macro_action_env.py::TestMacroTwoPhaseComposition` — smoke + contract tests (5 tests).
- `tests/test_macro_action_env.py::TestMacroTwoPhaseDeceptionChannel` — the **PR-gate** analog of #321's `test_can_still_lie`: per-base-step lie-rate >= 50% with a hardcoded liar + `REST_UNTIL_FIRE` macro + `commit_steps=5`. Plus a discriminator test (`test_per_base_step_signals_not_broadcast`) that proves the wrapper uses row `k` of the input matrix at base step `k` (not a single broadcast value).
- `tests/test_macro_action_env.py::TestMacroSinglePhaseRegression` — bit-identical regression vs the existing single-phase macro path.
- `tests/test_joint_trainer.py::TestMacroActionEnvTwoPhase` — trainer construction, rollout finite-shape, PPO update no-NaN, and a `commitment_mode='simultaneous'` regression to verify the dispatch flag is False on the legacy path.
- `tests/test_environment.py` — replace the obsolete `test_macro_action_env_rejects_two_phase` with `test_macro_action_env_accepts_two_phase` reflecting the unblocked path.

## Test plan

- [x] `tests/test_macro_action_env.py`: 27/27 pass (16 pre-existing + 11 new).
- [x] `tests/test_joint_trainer.py`: 75/75 pass (71 pre-existing + 4 new).
- [x] `tests/test_environment.py`: 87 pass, 6 skip (no regressions; updated 1 obsolete test).
- [x] **Deception PR-gate**: `TestMacroTwoPhaseDeceptionChannel::test_can_still_lie_under_macro_per_base_step` passes — proves Option 2a, not Option 1 / 2b.
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [x] Wider sweep: 735 pass / 61 skip across `tests/` (ignoring pre-existing failures `test_launch_tier1_sweep.py::test_launcher_known_trainers_matches_driver_trainers`, `test_launch_ppo_baselines.py::test_launcher_trainer_name_matches_driver` — both fail with `FileNotFoundError: 'python'` from subprocess; confirmed pre-existing by git stash).

## Caveats for reviewer

1. **Multi-head policy required**: macro+two_phase now requires the user to declare `action_dims=[num_options, 2]` (raises `ValueError` otherwise). This is a small ergonomic cost vs the single-head `[num_options]` of pure macro, but it cleanly maps the round-1 signal head into the existing PPO network. Documented in the trainer's construction validator.

2. **Round-1 signal conditioning**: the architect's Option 2a description implies the round-1 signal should condition on within-window obs evolution. The implementation here pre-samples all `commit_steps` round-1 signals from the macro-boundary obs (independent stochastic draws from the same conditioning input). This preserves the per-base-step lie-rate (verified by the deception PR-gate test) but the signals can't react to within-window state changes. A follow-up could add a callback-based wrapper API that drives the inner loop step-by-step, but that would diverge from the architect's literal `step_two_phase(round1_signals, macro_actions)` signature.

3. **Mutex with obs_auditor preserved**: the existing `obs_auditor + two_phase` `NotImplementedError` is retained and now explicitly covers macro+two_phase too (the audit invariant captures one obs per step; macro+two_phase has N round-1 obs + 1 round-2 obs per macro-step, none of which line up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)