### PR TITLE
feat(env): add positional_default-v1 to SCENARIO_VERSIONS

### DIFF
--- a/bucket_brigade/envs/registry.py
+++ b/bucket_brigade/envs/registry.py
@@ -76,6 +76,7 @@ from .scenarios_generated import (
     minimal_specialization_scenario,
     mixed_motivation_scenario,
     overcrowding_scenario,
+    positional_default_scenario,
     rest_trap_scenario,
     sparse_heroics_scenario,
     trivial_cooperation_scenario,
@@ -137,6 +138,9 @@ SCENARIO_VERSIONS: Dict[str, _ScenarioFactory] = {
     "minimal_specialization-v1": minimal_specialization_scenario,
     # 2-house topology for PPO learnability diagnostics (#254).
     "v2_minimal-v1": v2_minimal_scenario,
+    # Positional-reward variant of default — frozen baseline for PPO
+    # training (#384) and frozen-baseline release manifest (#371). See #403.
+    "positional_default-v1": positional_default_scenario,
 }
 
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -59,6 +59,7 @@ for the full version-bump policy and the live registry table.
 | `mixed_motivation-v1` | Mixed individual + team incentives |
 | `minimal_specialization-v1` | P3 specialization diagnostic — symmetric all-Hero NE ([see PAPER_RESULTS.md](PAPER_RESULTS.md#3-heterogeneous-nash-equilibria)) |
 | `v2_minimal-v1` | 2-house topology, PPO learnability diagnostic (#254) |
+| `positional_default-v1` | Positional-reward variant of `default` — PPO baseline (#384) + frozen-baseline release (#371) |
 
 `bucket_brigade.list_envs()` returns the live sorted list. The default
 number of agents for every frozen ID is **4**


### PR DESCRIPTION
## Summary

Adds the missing `positional_default-v1` entry to the frozen versioned scenario registry (`SCENARIO_VERSIONS`). The scenario already exists in legacy `SCENARIO_REGISTRY` but had no `-v1` counterpart, so `bucket_brigade.make("positional_default-v1")` raised `KeyError` and `list_envs()` was missing the ID. This caused a mismatch between PR #400's PPO baseline launcher (which trains `positional_default`) and PR #401's frozen-baseline loader (which keys on versioned IDs).

## Changes

- `bucket_brigade/envs/registry.py`: import `positional_default_scenario` and register `"positional_default-v1": positional_default_scenario` in `SCENARIO_VERSIONS`.
- `docs/ENV.md`: add the new ID to the scenario registry table.

Net diff: 2 files, +5 lines.

## Verification

- `bucket_brigade.make("positional_default-v1")` returns a working env; observation space `(168,)/float32` and action `nvec=[10,2,2]*4` match the legacy `positional_default` scenario constructed directly via `get_scenario_by_name`.
- `bucket_brigade.list_envs()` now returns 14 IDs and includes `"positional_default-v1"`.
- Deterministic: `env.reset(seed=42)` produces bit-exact obs for v1 vs. the legacy scenario.
- `tests/test_env_registry.py`: all 61 tests pass (the parametrized suite over `SCENARIO_VERSIONS.keys()` automatically exercises the new ID).
- `uv run ruff check bucket_brigade/ tests/` clean; `ruff format --check` clean.
- Env-adjacent suites (`test_env_registry`, `test_environment`, `test_macro_action_env`, `test_vector_env`, `test_env_health_diagnostics`) all pass: 201 passed, 15 skipped.

## Out of scope

- Bumping anything to `-v2` (the legacy factory is the v1 freeze point).
- Auditing other `SCENARIO_REGISTRY` entries for missing versioned IDs — left for a follow-up.

Closes #403

## Test plan

- [x] `bucket_brigade.make("positional_default-v1")` returns a Gymnasium env with matching spaces.
- [x] `bucket_brigade.list_envs()` includes `"positional_default-v1"`.
- [x] `uv run pytest tests/test_env_registry.py` passes (61/61).
- [x] `uv run ruff check` and `ruff format --check` clean on touched paths.