### PR TITLE
hermit(p3): DRY launcher KNOWN_TRAINERS — source from driver (#405)

### DIFF
--- a/experiments/p3_specialization/run_tier1_cell.py
+++ b/experiments/p3_specialization/run_tier1_cell.py
@@ -673,9 +673,13 @@ def run_cell(
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
+    # ``--trainer`` is required for the normal dispatch path, but the
+    # ``--list-trainers`` introspection short-circuit (used by operator-launch
+    # shell wrappers to source the trainer set without duplicating it) does
+    # not need it. We therefore mark ``--trainer`` as not-required at the
+    # argparse layer and enforce its presence below, after the short-circuit.
     p.add_argument(
         "--trainer",
-        required=True,
         choices=sorted(TRAINERS),
         help="Trainer name (one of the #343 matrix arms).",
     )
@@ -704,7 +708,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="Skip the disk-space precheck (use for tests).",
     )
+    p.add_argument(
+        "--list-trainers",
+        action="store_true",
+        help=(
+            "Print the known trainer names (one per line) to stdout and exit. "
+            "Used by the operator-launch shell wrappers (e.g. "
+            "launch_tier1_sweep.sh) to validate operator-supplied trainer "
+            "names against this dispatch table without duplicating it."
+        ),
+    )
     args = p.parse_args(argv)
+
+    # Introspection short-circuit: print the known trainer names and exit.
+    # Consumed by the operator-launch shell wrappers so they can fail-fast on
+    # a typo against the canonical TRAINERS dict instead of a hand-maintained
+    # duplicate (issue #405).
+    if args.list_trainers:
+        print("\n".join(sorted(TRAINERS)))
+        return 0
+
+    if args.trainer is None:
+        p.error("the following arguments are required: --trainer")
 
     summary = run_cell(
         trainer=args.trainer,

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -180,26 +180,22 @@ done
 # Validate trainer list against the driver's known names
 # ---------------------------------------------------------------------------
 
-# Source of truth: experiments/p3_specialization/run_tier1_cell.py TRAINERS
-# table. Listed here verbatim so the launcher can fail fast on a typo
-# before consuming any remote compute. Keep in sync with that file.
-KNOWN_TRAINERS=(
-    ippo
-    mappo
-    high_lambda
-    bc_init_continuation
-    bc_init_high_lambda
-    lola
-    coma
-    hca
-    influence
-    nhr
-    progress
-    macro_actions
-    reinforce
-    pbt
-    het_ppo
-)
+# Source the trainer set from the driver itself (issue #405 — DRY the
+# launcher KNOWN_TRAINERS): the previous design kept a hand-maintained bash
+# array in lockstep with run_tier1_cell.py's TRAINERS dict, which drifted
+# (see PR #398). Calling --list-trainers on the driver eliminates the
+# duplicate at a ~200ms startup cost, paid once per launch.
+KNOWN_TRAINERS=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && KNOWN_TRAINERS+=("$line")
+done < <(uv run --quiet python "$REPO_ROOT/experiments/p3_specialization/run_tier1_cell.py" --list-trainers 2>/dev/null)
+
+if [[ "${#KNOWN_TRAINERS[@]}" -eq 0 ]]; then
+    echo "ERROR: could not enumerate trainers from run_tier1_cell.py --list-trainers" >&2
+    echo "       (is the local Python env / Rust extension set up?)" >&2
+    echo "       Try: uv sync && bash bucket-brigade-core/build.sh" >&2
+    exit 6
+fi
 
 is_known_trainer() {
     local name="$1"

--- a/tests/test_launch_ppo_baselines.py
+++ b/tests/test_launch_ppo_baselines.py
@@ -453,17 +453,15 @@ def test_launcher_trainer_name_matches_driver() -> None:
     """The launcher hardcodes ``--trainer ippo``. If the driver renames
     or removes the ippo entry from TRAINERS, the launcher silently
     produces a command that will error out on the remote host. Catch
-    drift here, locally, before consuming compute."""
-    out = subprocess.run(
-        [
-            "python",
-            "-c",
-            (
-                "import sys; sys.path.insert(0, '.'); "
-                "from experiments.p3_specialization.run_tier1_cell import TRAINERS; "
-                "print('ippo' if 'ippo' in TRAINERS else 'MISSING')"
-            ),
-        ],
+    drift here, locally, before consuming compute.
+
+    Uses the same ``--list-trainers`` introspection surface that the Tier-1
+    launcher consumes for its trainer-set validation (issue #405) so both
+    launchers exercise the same canonical contract.
+    """
+    driver = REPO_ROOT / "experiments" / "p3_specialization" / "run_tier1_cell.py"
+    out = subprocess.run(  # nosec B603 B607 (argv is hardcoded, no shell)
+        ["python", str(driver), "--list-trainers"],
         cwd=str(REPO_ROOT),
         capture_output=True,
         text=True,
@@ -471,10 +469,12 @@ def test_launcher_trainer_name_matches_driver() -> None:
     )
     if out.returncode != 0:
         pytest.skip(
-            f"cannot import run_tier1_cell.TRAINERS in test env "
+            f"cannot invoke run_tier1_cell.py --list-trainers in test env "
             f"(stderr: {out.stderr.strip()}); skipping drift check"
         )
-    assert out.stdout.strip() == "ippo", (
-        "launcher hardcodes --trainer ippo but driver does not expose it. "
-        "Either restore the ippo entry in TRAINERS or update the launcher."
+    trainers = {line.strip() for line in out.stdout.splitlines() if line.strip()}
+    assert "ippo" in trainers, (
+        "launcher hardcodes --trainer ippo but driver does not expose it via "
+        "--list-trainers. Either restore the ippo entry in TRAINERS or "
+        "update the launcher."
     )

--- a/tests/test_launch_tier1_sweep.py
+++ b/tests/test_launch_tier1_sweep.py
@@ -17,10 +17,13 @@ These tests cover:
 * --skip-aggregate
 * canonical runbook invocations from TIER1_LAUNCH_RUNBOOK.md
 
-We also assert that the launcher's KNOWN_TRAINERS list stays in sync with
-the driver's TRAINERS dict in ``run_tier1_cell.py``. A drift between the
-two would mean a typo in the launcher silently rejects (or accepts) a
-trainer the driver knows about.
+We also assert that the launcher sources its trainer set from the driver
+(issue #405 / PR #405): there is no longer a hand-maintained KNOWN_TRAINERS
+bash array. Instead, the launcher calls
+``run_tier1_cell.py --list-trainers`` at startup. The drift-test surface
+collapses to "the launcher actually wires --list-trainers through" plus
+a contract check that the driver's --list-trainers output matches the
+TRAINERS dict.
 """
 
 from __future__ import annotations
@@ -395,35 +398,31 @@ def test_runbook_canonical_invocations(
 
 
 # ---------------------------------------------------------------------------
-# Drift check: launcher's KNOWN_TRAINERS == driver's TRAINERS keys
+# DRY contract: launcher sources its trainer set from the driver
+# (issue #405). The old hand-maintained KNOWN_TRAINERS bash array is gone;
+# the launcher now calls run_tier1_cell.py --list-trainers at startup. The
+# fail-fast on a typoed --trainers is still exercised by
+# test_unknown_trainer_exits_with_clear_error above; what we need to lock
+# down here is (1) the launcher actually uses --list-trainers and (2) the
+# driver's --list-trainers output matches its TRAINERS dispatch table.
 # ---------------------------------------------------------------------------
 
 
-def _launcher_known_trainers() -> set[str]:
-    """Parse the KNOWN_TRAINERS bash array out of the launch script.
+def test_driver_list_trainers_matches_dispatch_table() -> None:
+    """``--list-trainers`` must enumerate the driver's full TRAINERS dict.
 
-    We do this with a regex rather than execing bash because the value is
-    a small literal list and we want a hermetic test that doesn't depend
-    on the bash version.
+    The launcher trusts this output as the single source of truth for
+    trainer validation. A regression that drops a trainer from the
+    printed list would silently break the launcher's fail-fast guard.
     """
-    text = SCRIPT.read_text()
-    m = re.search(r"KNOWN_TRAINERS=\(\s*([^)]+)\s*\)", text, re.DOTALL)
-    assert m is not None, "could not find KNOWN_TRAINERS array in launcher"
-    block = m.group(1)
-    # Strip comments and whitespace, split into tokens.
-    tokens = [
-        line.split("#", 1)[0].strip()
-        for line in block.splitlines()
-        if line.strip() and not line.strip().startswith("#")
-    ]
-    # Each non-empty token is one trainer name.
-    return {t for t in tokens if t}
-
-
-def _driver_trainers() -> set[str]:
-    """Import the driver's TRAINERS dict via a subprocess so we don't need
-    numpy / torch in the test interpreter."""
-    out = subprocess.run(
+    listed = subprocess.run(  # nosec B603 B607 (argv is hardcoded, no shell)
+        ["python", str(DRIVER), "--list-trainers"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dispatch = subprocess.run(  # nosec B603 B607 (argv is hardcoded, no shell)
         [
             "python",
             "-c",
@@ -438,22 +437,37 @@ def _driver_trainers() -> set[str]:
         text=True,
         check=False,
     )
-    if out.returncode != 0:
+    if listed.returncode != 0 or dispatch.returncode != 0:
         pytest.skip(
-            f"cannot import run_tier1_cell.TRAINERS in test env "
-            f"(stderr: {out.stderr.strip()}); skipping drift check"
+            "cannot invoke run_tier1_cell.py in test env "
+            f"(stderr: {listed.stderr.strip() or dispatch.stderr.strip()}); "
+            "skipping contract check"
         )
-    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+    listed_set = {line.strip() for line in listed.stdout.splitlines() if line.strip()}
+    dispatch_set = {
+        line.strip() for line in dispatch.stdout.splitlines() if line.strip()
+    }
+    assert listed_set == dispatch_set, (
+        f"--list-trainers output drifted from TRAINERS dict:\n"
+        f"  in --list-trainers but not TRAINERS: {listed_set - dispatch_set}\n"
+        f"  in TRAINERS but not --list-trainers: {dispatch_set - listed_set}"
+    )
 
 
-def test_launcher_known_trainers_matches_driver_trainers() -> None:
-    """The launcher's KNOWN_TRAINERS validation list must match the
-    driver's TRAINERS dict exactly. Drift means either a typo in the
-    launcher silently rejects a real trainer, or accepts a fake one."""
-    launcher = _launcher_known_trainers()
-    driver = _driver_trainers()
-    assert launcher == driver, (
-        f"KNOWN_TRAINERS drift detected:\n"
-        f"  in launcher but not driver: {launcher - driver}\n"
-        f"  in driver but not launcher: {driver - launcher}"
+def test_launcher_sources_trainer_set_from_driver() -> None:
+    """The launcher must call ``run_tier1_cell.py --list-trainers`` rather
+    than hard-coding a KNOWN_TRAINERS bash array. Any future revert that
+    re-adds a static array will trip this assertion.
+    """
+    text = SCRIPT.read_text()
+    assert "--list-trainers" in text, (
+        "launcher must source the trainer set via run_tier1_cell.py "
+        "--list-trainers (issue #405); did the DRY fix get reverted?"
+    )
+    # Reject re-emergence of a populated list-of-names form. We still allow
+    # the empty initializer KNOWN_TRAINERS=() that holds the parsed output.
+    assert not re.search(r"KNOWN_TRAINERS=\(\s*[A-Za-z]", text), (
+        "launcher appears to have re-introduced a hand-maintained "
+        "KNOWN_TRAINERS bash array; source it from --list-trainers instead "
+        "(issue #405)."
     )


### PR DESCRIPTION
## Summary

Hermit-flavored simplification: replace the hand-maintained `KNOWN_TRAINERS` bash array in `launch_tier1_sweep.sh` with a runtime call to `run_tier1_cell.py --list-trainers`. Eliminates the entire drift surface that caused the silent het_ppo mismatch caught by PR #398.

**Approach**: Option A from the issue (driver emits `--list-trainers`, launcher consumes via subprocess). The ~200ms startup cost is paid once per launch and matches the existing `uv run python -c "..."` pattern in sibling launchers.

## Changes

- **`experiments/p3_specialization/run_tier1_cell.py`**: add `--list-trainers` short-circuit. Prints one trainer key per line, exits 0. `--trainer` is no longer strictly `required=True` at the argparse layer so introspection works without it; missing-`--trainer` enforcement runs after the short-circuit.
- **`experiments/scripts/launch_tier1_sweep.sh`**: replace the 15-element static `KNOWN_TRAINERS=(...)` with process substitution `< <(uv run --quiet python ... --list-trainers)`. Fail-fast on a typoed `--trainers` still works (exit 5 unchanged); added exit 6 if `--list-trainers` itself fails (env not set up).
- **`tests/test_launch_tier1_sweep.py`**: the old `test_launcher_known_trainers_matches_driver_trainers` test parsed the bash array out of the script — that's gone. Replaced with two tests:
  - `test_driver_list_trainers_matches_dispatch_table` — contract check: `--list-trainers` output equals `TRAINERS.keys()`.
  - `test_launcher_sources_trainer_set_from_driver` — structural check: launcher uses `--list-trainers` and does not re-introduce a populated bash array (regex guard).
  - Both old invariants ("launcher and driver agree" + "typo fails fast at exit 5") remain enforced; the existing `test_unknown_trainer_exits_with_clear_error` continues to cover the typo path.
- **`tests/test_launch_ppo_baselines.py`**: update the single-name `test_launcher_trainer_name_matches_driver` drift check to use the same `--list-trainers` surface for consistency. No behavior change to the launcher itself (it still hardcodes `--trainer ippo`).

## LOC delta

`+115 / -80` (net **+35**). The net positive comes from the new `--list-trainers` flag in the driver (~27 lines) and the structural drift test. The bash-array removal saves ~15 lines. Test code is slightly larger but with a smaller surface (no bash-parsing regex).

## Sibling launchers covered

- `launch_tier1_sweep.sh` — primary target, KNOWN_TRAINERS array removed.
- `launch_ppo_baselines.sh` — no array to remove (it hardcodes `--trainer ippo`), but the drift test updated to use the new `--list-trainers` surface.
- `launch_het_ppo_sweep.sh` — also hardcodes `--trainer het_ppo`; no KNOWN_TRAINERS array. Existing remote-bootstrap check (`assert 'het_ppo' in TRAINERS`) is unchanged. Out of scope for this DRY cleanup.

## Test plan

- [x] `uv run pytest tests/test_launch_tier1_sweep.py tests/test_launch_ppo_baselines.py tests/test_tier1_driver.py` — 67 passed.
- [x] All other `tests/test_launch_*.py` still pass (77 launch tests total).
- [x] `uv run ruff check ...` clean for modified files.
- [x] `uv run ruff format --check ...` clean for modified files.
- [x] `bash -n experiments/scripts/launch_*.sh` syntax-clean.
- [x] Manual smoke: `uv run python experiments/p3_specialization/run_tier1_cell.py --list-trainers` prints 15 trainer names sorted alphabetically.

Closes #405