### PR TITLE
feat(p3): phase-diagram PPO sweep launcher (#360)

### DIFF
--- a/experiments/p3_specialization/run_phase_diagram_ppo.py
+++ b/experiments/p3_specialization/run_phase_diagram_ppo.py
@@ -1,0 +1,612 @@
+"""Phase-diagram PPO sweep driver (issue #360).
+
+Trains ``JointPPOTrainer`` (IPPO) across the same (β, κ, c) grid the
+heterogeneous Nash phase-diagram search (#358) used, and writes
+per-(cell × seed) ``summary.json`` plus per-cell ``cell_summary.json``
+artifacts that the NE-vs-PPO side-by-side figure (parent issue #357 / M2.1)
+consumes.
+
+Cell source
+-----------
+By default we read the cells from
+``experiments/nash/phase_diagram/results.json``. Each entry has a ``beta``,
+``kappa``, ``c`` triple plus a tag and the NE-search verdict — we use only
+the triple here; the verdict is what we cross-tabulate against post-hoc.
+
+Per-cell training
+-----------------
+For each (β, κ, c) cell:
+    for each seed in --seeds:
+        python -m experiments.p3_specialization.train \\
+            --scenario <--scenario>           # default minimal_specialization
+            --algorithm ppo                   # JointPPOTrainer (IPPO)
+            --lambda-red 0.0
+            --seed <seed>
+            --output-dir <out>/cell_<tag>/seed_<seed>
+            --num-iterations <N>
+            --rollout-steps <R>
+            --prob-fire-spreads-to-neighbor <β>
+            --prob-solo-agent-extinguishes-fire <κ>
+            --cost-to-work-one-night <c>
+
+The three new ``--prob-*`` / ``--cost-*`` flags on ``train.py`` were added
+in #360 alongside this driver: they mutate the loaded ``Scenario`` instance
+the same way ``--action-shaping-alpha`` does, mirroring the
+``compute_nash_phase_diagram._make_scenario`` wiring so the NE-search and
+PPO-training rewards are bit-comparable.
+
+Per-cell aggregation
+--------------------
+After every (cell × seed) finishes we read ``metrics.json`` from each seed
+dir, compute ``gap_closed`` against the
+``bucket_brigade.baselines.MINSPEC_RANDOM`` / ``MINSPEC_SPECIALIST``
+baselines (same formula as ``analyze_270.py:45-46`` and ``run_tier1_cell``),
+and write:
+
+    <output-root>/cell_<tag>/seed_<seed>/summary.json
+        {cell, seed, gap_closed, verdict, final_episode_return, wall_seconds}
+
+    <output-root>/cell_<tag>/cell_summary.json
+        per-cell aggregate using run_tier1_cell.build_cell_summary
+
+The cell-level aggregate is the same Tier-1 schema (gap_closed_mean ± std,
+verdict tier, per-seed gaps, mean trajectory) so the existing
+``aggregate_tier1.py`` works on the output root without modification.
+
+Per-seed ``summary.json`` is a small superset of the Tier-1 schema that
+includes the NE-search cell context (β, κ, c, NE verdict if known) — that
+is what the cross-tab figure / Spearman ρ correlation in #360's acceptance
+criteria consume.
+
+CLAUDE.md note
+--------------
+This driver is meant to be run on a remote host (alc-* / Mac Studio) via
+``experiments/scripts/launch_phase_diagram_ppo.sh``. The launcher does the
+ssh + tmux + bootstrap. This file knows nothing about ssh; running it
+locally on the full grid will melt the CPU.
+
+Smoke-test (safe locally, validates wiring only):
+
+    uv run python experiments/p3_specialization/run_phase_diagram_ppo.py \\
+        --cells-source experiments/nash/phase_diagram/results.json \\
+        --seeds 42 \\
+        --num-iterations 1 \\
+        --rollout-steps 64 \\
+        --output-root /tmp/phase_diagram_ppo_smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess  # nosec B404 (orchestrator spawns train.py with fixed argv)
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+P3_DIR = REPO_ROOT / "experiments" / "p3_specialization"
+TRAIN_PY_MODULE = "experiments.p3_specialization.train"
+
+# Default NE phase-diagram results file (7 cells as of #358's partial
+# aggregate). The driver also accepts the freqtest variant or any other
+# results.json with the same schema.
+DEFAULT_CELLS_SOURCE = (
+    REPO_ROOT / "experiments" / "nash" / "phase_diagram" / "results.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Cell loading
+# ---------------------------------------------------------------------------
+
+
+def _cell_tag(beta: float, kappa: float, c: float) -> str:
+    """Filesystem-safe tag — matches ``compute_nash_phase_diagram._cell_tag``."""
+    return f"b{beta:.2f}_k{kappa:.2f}_c{c:.2f}"
+
+
+def load_cells(source: Path) -> list[dict]:
+    """Load the phase-diagram cells from a results.json.
+
+    Returns a list of dicts each containing at least ``beta``, ``kappa``,
+    ``c``, ``tag``. Any extra keys (e.g. NE ``verdict``) are passed through
+    untouched so the per-seed ``summary.json`` can include the NE-search
+    context the cross-tab figure needs.
+    """
+    if not source.exists():
+        raise SystemExit(
+            f"cells-source not found: {source}. Did #358 land its results.json?"
+        )
+    try:
+        data = json.loads(source.read_text())
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"cells-source {source} is not valid JSON: {exc}") from exc
+
+    cells = data.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise SystemExit(
+            f"cells-source {source} has no 'cells' array. "
+            f"Expected the schema from compute_nash_phase_diagram.py."
+        )
+
+    normalized: list[dict] = []
+    for raw in cells:
+        try:
+            beta = float(raw["beta"])
+            kappa = float(raw["kappa"])
+            c = float(raw["c"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise SystemExit(
+                f"cell entry missing required (β,κ,c): {raw}. ({exc})"
+            ) from exc
+        normalized.append(
+            {
+                "beta": beta,
+                "kappa": kappa,
+                "c": c,
+                "tag": raw.get("tag") or _cell_tag(beta, kappa, c),
+                "ne_verdict": raw.get("verdict"),
+                "ne_verdict_detail": raw.get("verdict_detail"),
+            }
+        )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Per-seed train.py dispatch
+# ---------------------------------------------------------------------------
+
+
+def _python() -> str:
+    return sys.executable
+
+
+def build_train_argv(
+    *,
+    scenario: str,
+    seed: int,
+    output_dir: Path,
+    num_iterations: int,
+    rollout_steps: int,
+    beta: float,
+    kappa: float,
+    c: float,
+) -> list[str]:
+    """Build the ``train.py`` argv for one seed inside one cell.
+
+    Uses the IPPO baseline (``--algorithm ppo``) — that is ``JointPPOTrainer``
+    in its default decentralized-critic configuration. Issue #360's
+    hypothesis is about PPO trainability per NE structure, so we want the
+    baseline trainer here, not MAPPO / LOLA / etc.
+    """
+    return [
+        _python(),
+        "-m",
+        TRAIN_PY_MODULE,
+        "--scenario",
+        scenario,
+        "--algorithm",
+        "ppo",
+        "--lambda-red",
+        "0.0",
+        "--seed",
+        str(seed),
+        "--output-dir",
+        str(output_dir),
+        "--num-iterations",
+        str(num_iterations),
+        "--rollout-steps",
+        str(rollout_steps),
+        "--prob-fire-spreads-to-neighbor",
+        str(beta),
+        "--prob-solo-agent-extinguishes-fire",
+        str(kappa),
+        "--cost-to-work-one-night",
+        str(c),
+    ]
+
+
+def _run_subprocess(argv: Sequence[str], *, cwd: Path) -> int:
+    print(f"\n$ {' '.join(argv)}", flush=True)
+    completed = subprocess.run(list(argv), cwd=str(cwd))  # nosec B603 (cmd is list, no shell)
+    return int(completed.returncode)
+
+
+def _git_sha(cwd: Path) -> str:
+    try:
+        out = subprocess.run(  # nosec B603 B607 (git rev-parse — argv is hardcoded, not user input)
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Per-seed summary
+# ---------------------------------------------------------------------------
+
+
+def _load_metrics(seed_dir: Path) -> Optional[list[dict]]:
+    f = seed_dir / "metrics.json"
+    if not f.exists():
+        return None
+    try:
+        return json.loads(f.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _safe_json_dump(obj: object) -> str:
+    """``json.dumps`` with NaN -> null so output is portable JSON.
+
+    Mirrors ``run_tier1_cell._safe_json_dump`` so downstream consumers can
+    treat phase-diagram and Tier-1 summaries identically.
+    """
+
+    def _replace(o):
+        if isinstance(o, float) and math.isnan(o):
+            return None
+        if isinstance(o, dict):
+            return {k: _replace(v) for k, v in o.items()}
+        if isinstance(o, (list, tuple)):
+            return [_replace(x) for x in o]
+        return o
+
+    return json.dumps(_replace(obj), indent=2)
+
+
+def _verdict_for(gap_closed_value: float) -> tuple[str, str]:
+    """Same verdict ladder as ``run_tier1_cell._verdict_for``.
+
+    Re-implemented inline (rather than imported) so this driver is a
+    self-contained read of the per-seed metrics — no import-time coupling
+    to the Tier-1 thresholds beyond the constants we copy below.
+    """
+    # Mirror run_tier1_cell.VERDICT_THRESHOLDS — re-declared so a change
+    # over there is a visible diff here, not a silent drift.
+    low, mid, high = 0.20, 0.49, 0.88
+    if gap_closed_value >= high:
+        return "closed", f"gap_closed = {gap_closed_value:.3f} >= {high}"
+    if gap_closed_value >= mid:
+        return "partial_upper", f"{mid} <= gap_closed < {high}"
+    if gap_closed_value >= low:
+        return "partial_lower", f"{low} <= gap_closed < {mid}"
+    return "insufficient", f"gap_closed = {gap_closed_value:.3f} < {low}"
+
+
+def write_seed_summary(
+    *,
+    cell: dict,
+    scenario: str,
+    seed: int,
+    seed_dir: Path,
+    wall_seconds: float,
+    command_invoked: str,
+    git_sha: str,
+) -> dict:
+    """Compute the per-seed ``summary.json`` payload and write it to disk.
+
+    Schema (matches issue #360's "at minimum" list, plus NE-search context):
+        cell:                   {beta, kappa, c, tag, ne_verdict?, ne_verdict_detail?}
+        scenario:               base scenario name (defaults to minimal_specialization)
+        seed:                   int
+        gap_closed:             trailing-5 mean_step_reward_team mapped via MINSPEC baselines
+        verdict:                tier name from the run_tier1_cell ladder
+        verdict_reason:         human-readable threshold string
+        final_episode_return:   last iteration's mean episode return (per-agent average)
+        trailing5_team_mean:    trailing-5 mean_step_reward_team (raw, pre-gap-closed)
+        wall_seconds:           subprocess wall time
+        command_invoked, git_sha
+        n_iterations_completed: how many iterations metrics.json actually has
+    """
+    # Lazy import — keeps the driver importable in environments without the
+    # Rust extension built (e.g. for CLI introspection / --help).
+    from bucket_brigade.baselines import MINSPEC_RANDOM, MINSPEC_SPECIALIST
+
+    metrics = _load_metrics(seed_dir)
+    if metrics is None or len(metrics) == 0:
+        payload = {
+            "cell": cell,
+            "scenario": scenario,
+            "seed": seed,
+            "gap_closed": None,
+            "verdict": "no_data",
+            "verdict_reason": "metrics.json missing or empty",
+            "final_episode_return": None,
+            "trailing5_team_mean": None,
+            "wall_seconds": wall_seconds,
+            "command_invoked": command_invoked,
+            "git_sha": git_sha,
+            "n_iterations_completed": 0,
+        }
+    else:
+        trajectory = [float(row["mean_step_reward_team"]) for row in metrics]
+        trail = trajectory[-5:] if len(trajectory) >= 5 else trajectory
+        trailing5 = sum(trail) / len(trail)
+        denom = MINSPEC_SPECIALIST - MINSPEC_RANDOM
+        gap_closed_val = (trailing5 - MINSPEC_RANDOM) / denom if denom != 0 else 0.0
+        verdict, reason = _verdict_for(gap_closed_val)
+        # ``mean_episode_return`` is the canonical per-iteration team-return
+        # metric that ``train.py`` writes; we just expose the final one here.
+        final_ret_key = (
+            "mean_episode_return"
+            if "mean_episode_return" in metrics[-1]
+            else "mean_step_reward_team"
+        )
+        final_ret = float(metrics[-1].get(final_ret_key, float("nan")))
+        payload = {
+            "cell": cell,
+            "scenario": scenario,
+            "seed": seed,
+            "gap_closed": gap_closed_val,
+            "verdict": verdict,
+            "verdict_reason": reason,
+            "final_episode_return": final_ret,
+            "trailing5_team_mean": trailing5,
+            "wall_seconds": wall_seconds,
+            "command_invoked": command_invoked,
+            "git_sha": git_sha,
+            "n_iterations_completed": len(metrics),
+        }
+
+    (seed_dir / "summary.json").write_text(_safe_json_dump(payload))
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Per-cell aggregation (Tier-1 schema reuse)
+# ---------------------------------------------------------------------------
+
+
+def build_cell_summary_for_phase_diagram(
+    *,
+    cell: dict,
+    scenario: str,
+    seeds: Sequence[int],
+    seed_dirs: Sequence[Path],
+    num_iterations: int,
+    rollout_steps: int,
+    command_invoked: str,
+    git_sha: str,
+    wall_clock_seconds: float,
+) -> dict:
+    """Aggregate per-seed metrics for one (β, κ, c) cell.
+
+    Delegates the gap_closed / verdict ladder math to
+    ``run_tier1_cell.build_cell_summary`` so the output is schema-compatible
+    with ``aggregate_tier1.py``. Adds the (β, κ, c) cell context as an
+    extra top-level field so the cross-tab figure / Spearman correlation
+    in #360's acceptance criteria can pivot on it without re-reading the
+    NE-search results.json.
+    """
+    # Lazy import — run_tier1_cell imports the baselines and other modules
+    # that need the Rust extension built; lifting that to driver import-time
+    # would break ``--help`` on a freshly-cloned host.
+    from experiments.p3_specialization.run_tier1_cell import build_cell_summary
+
+    tier1_like = build_cell_summary(
+        trainer="ippo",
+        scenario=scenario,
+        seeds=seeds,
+        seed_dirs=seed_dirs,
+        num_iterations=num_iterations,
+        command_invoked=command_invoked,
+        git_sha=git_sha,
+        wall_clock_seconds=wall_clock_seconds,
+    )
+    # Stitch the phase-diagram-specific context on top of the Tier-1 schema.
+    tier1_like["cell"] = cell
+    tier1_like["rollout_steps"] = rollout_steps
+    tier1_like["sweep"] = "phase_diagram_ppo"
+    return tier1_like
+
+
+# ---------------------------------------------------------------------------
+# Main per-cell loop
+# ---------------------------------------------------------------------------
+
+
+def run_cell(
+    *,
+    cell: dict,
+    scenario: str,
+    seeds: Sequence[int],
+    num_iterations: int,
+    rollout_steps: int,
+    output_root: Path,
+    cwd: Path = REPO_ROOT,
+) -> dict:
+    """Run all seeds for one (β, κ, c) cell and write summaries."""
+    cell_dir = output_root / f"cell_{cell['tag']}"
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    git_sha = _git_sha(cwd)
+
+    seed_dirs: list[Path] = []
+    invoked_commands: list[str] = []
+    cell_start = time.monotonic()
+
+    for seed in seeds:
+        seed_dir = cell_dir / f"seed_{seed}"
+        seed_dir.mkdir(parents=True, exist_ok=True)
+        argv = build_train_argv(
+            scenario=scenario,
+            seed=seed,
+            output_dir=seed_dir,
+            num_iterations=num_iterations,
+            rollout_steps=rollout_steps,
+            beta=cell["beta"],
+            kappa=cell["kappa"],
+            c=cell["c"],
+        )
+        cmd_str = " ".join(argv)
+        invoked_commands.append(cmd_str)
+
+        seed_start = time.monotonic()
+        code = _run_subprocess(argv, cwd=cwd)
+        seed_wall = time.monotonic() - seed_start
+
+        if code != 0:
+            print(
+                f"WARN: cell {cell['tag']} seed {seed} exited {code}; "
+                "writing whatever metrics.json the run produced.",
+                file=sys.stderr,
+            )
+
+        write_seed_summary(
+            cell=cell,
+            scenario=scenario,
+            seed=seed,
+            seed_dir=seed_dir,
+            wall_seconds=seed_wall,
+            command_invoked=cmd_str,
+            git_sha=git_sha,
+        )
+        seed_dirs.append(seed_dir)
+
+    cell_wall = time.monotonic() - cell_start
+    summary = build_cell_summary_for_phase_diagram(
+        cell=cell,
+        scenario=scenario,
+        seeds=seeds,
+        seed_dirs=seed_dirs,
+        num_iterations=num_iterations,
+        rollout_steps=rollout_steps,
+        command_invoked=" && ".join(invoked_commands),
+        git_sha=git_sha,
+        wall_clock_seconds=cell_wall,
+    )
+    out_path = cell_dir / "cell_summary.json"
+    out_path.write_text(_safe_json_dump(summary))
+    print(
+        f"\n== cell {cell['tag']} complete: verdict={summary['verdict_tier']} "
+        f"gap_closed_mean={summary['gap_closed_mean']!r} "
+        f"(NE: {cell.get('ne_verdict')}) -> {out_path}",
+        flush=True,
+    )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--cells-source",
+        type=Path,
+        default=DEFAULT_CELLS_SOURCE,
+        help=(
+            "Path to the NE phase-diagram results.json (default: "
+            "experiments/nash/phase_diagram/results.json). Must follow the "
+            "compute_nash_phase_diagram.py schema with a 'cells' array."
+        ),
+    )
+    p.add_argument(
+        "--scenario",
+        default="minimal_specialization",
+        help=(
+            "Base scenario whose (β, κ, c) get overridden per-cell. Default "
+            "minimal_specialization, matching compute_nash_phase_diagram's "
+            "BASE_SCENARIO_NAME. NOTE: scenario-level reward overrides "
+            "(action_shaping_*, team_welfare_*, etc.) compose freely with "
+            "the per-cell (β, κ, c) override — they touch different "
+            "Scenario fields. Only the three swept fields are touched here."
+        ),
+    )
+    p.add_argument(
+        "--seeds",
+        type=int,
+        nargs="+",
+        default=[42, 43, 44, 45],
+        help="Seeds per cell (default: 42 43 44 45 — 4 seeds, matching #360).",
+    )
+    p.add_argument("--num-iterations", type=int, default=50)
+    p.add_argument("--rollout-steps", type=int, default=2048)
+    p.add_argument(
+        "--output-root",
+        type=Path,
+        default=P3_DIR / "phase_diagram_ppo",
+        help=(
+            "Root for per-cell artifacts (default: "
+            "experiments/p3_specialization/phase_diagram_ppo/)."
+        ),
+    )
+    p.add_argument(
+        "--limit-cells",
+        type=int,
+        default=None,
+        help=(
+            "Stop after running this many cells (debug aid). Default None "
+            "runs every cell in cells-source."
+        ),
+    )
+    p.add_argument(
+        "--list-cells",
+        action="store_true",
+        help=(
+            "Print the (β, κ, c) cells loaded from --cells-source (one per "
+            "line) and exit. Used by the launcher to render the pre-launch "
+            "plan summary."
+        ),
+    )
+    args = p.parse_args(argv)
+
+    cells = load_cells(args.cells_source)
+    if args.limit_cells is not None:
+        cells = cells[: args.limit_cells]
+
+    if args.list_cells:
+        for cell in cells:
+            print(
+                f"{cell['tag']}\tβ={cell['beta']:.2f}\tκ={cell['kappa']:.2f}\t"
+                f"c={cell['c']:.2f}\tNE={cell.get('ne_verdict', '?')}"
+            )
+        return 0
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    print(
+        f"== phase-diagram PPO sweep: {len(cells)} cells × {len(args.seeds)} seeds "
+        f"× scenario={args.scenario} =="
+    )
+    print(f"   output-root: {args.output_root}")
+    print(f"   cells-source: {args.cells_source}")
+
+    n_failed_cells = 0
+    for idx, cell in enumerate(cells, start=1):
+        print(
+            f"\n[{idx}/{len(cells)}] cell {cell['tag']} "
+            f"(β={cell['beta']:.2f} κ={cell['kappa']:.2f} c={cell['c']:.2f}, "
+            f"NE={cell.get('ne_verdict', '?')})"
+        )
+        summary = run_cell(
+            cell=cell,
+            scenario=args.scenario,
+            seeds=args.seeds,
+            num_iterations=args.num_iterations,
+            rollout_steps=args.rollout_steps,
+            output_root=args.output_root,
+        )
+        if summary["n_seeds_completed"] == 0:
+            n_failed_cells += 1
+
+    print(
+        f"\n== phase-diagram PPO sweep complete: "
+        f"{len(cells) - n_failed_cells}/{len(cells)} cells produced metrics =="
+    )
+    # Non-zero exit only if *every* cell failed — partial success should let
+    # the launcher's post-rsync aggregate step still run.
+    return 0 if n_failed_cells < len(cells) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/p3_specialization/run_phase_diagram_ppo.py
+++ b/experiments/p3_specialization/run_phase_diagram_ppo.py
@@ -90,6 +90,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 P3_DIR = REPO_ROOT / "experiments" / "p3_specialization"
 TRAIN_PY_MODULE = "experiments.p3_specialization.train"
 
+# The gap_closed metric written below is hard-coded to the MINSPEC_RANDOM /
+# MINSPEC_SPECIALIST baselines (see write_seed_summary and the analogous
+# run_tier1_cell.gap_closed). Running on any other scenario silently
+# produces uncalibrated numbers. We lock the scenario at the CLI and offer
+# an explicit opt-out (--allow-non-minspec-gap) so the failure mode is loud,
+# not silent. See PR #410 review feedback.
+MINSPEC_LOCKED_SCENARIO = "minimal_specialization"
+
 # Default NE phase-diagram results file (7 cells as of #358's partial
 # aggregate). The driver also accepts the freqtest variant or any other
 # results.json with the same schema.
@@ -559,7 +567,30 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "plan summary."
         ),
     )
+    p.add_argument(
+        "--allow-non-minspec-gap",
+        action="store_true",
+        help=(
+            "Opt out of the scenario lock that restricts --scenario to "
+            "minimal_specialization. gap_closed values written by this "
+            "driver are calibrated only against the MINSPEC_RANDOM / "
+            "MINSPEC_SPECIALIST baselines; any other scenario yields "
+            "uncalibrated numbers. Set this flag only if you know you want "
+            "raw trajectories without a comparable gap_closed."
+        ),
+    )
     args = p.parse_args(argv)
+
+    if args.scenario != MINSPEC_LOCKED_SCENARIO and not args.allow_non_minspec_gap:
+        print(
+            f"ERROR: --scenario '{args.scenario}' rejected.\n"
+            "       gap_closed metric is calibrated only for "
+            "minimal_specialization; other scenarios will produce "
+            "uncalibrated gap_closed values.\n"
+            "       Re-run with --allow-non-minspec-gap to override.",
+            file=sys.stderr,
+        )
+        return 5
 
     cells = load_cells(args.cells_source)
     if args.limit_cells is not None:

--- a/experiments/p3_specialization/train.py
+++ b/experiments/p3_specialization/train.py
@@ -120,6 +120,18 @@ class CellConfig:
     # the ``--action-shaping-alpha`` / ``--action-shaping-beta`` flags.
     action_shaping_alpha: float = 0.0
     action_shaping_beta: float = 0.0
+    # Issue #360: per-cell (β, κ, c) overrides for the NE phase-diagram sweep.
+    # ``None`` (default) preserves whatever values the base scenario shipped
+    # with — bit-identical to pre-#360 behavior. When set, the loaded
+    # ``Scenario`` instance is mutated in ``train_one_cell`` so per-step
+    # rewards and fire dynamics match the cell's NE search. Mirrors the
+    # ``compute_nash_phase_diagram._make_scenario`` wiring (β ->
+    # ``prob_fire_spreads_to_neighbor``, κ ->
+    # ``prob_solo_agent_extinguishes_fire``, c ->
+    # ``cost_to_work_one_night``).
+    prob_fire_spreads_to_neighbor: Optional[float] = None
+    prob_solo_agent_extinguishes_fire: Optional[float] = None
+    cost_to_work_one_night: Optional[float] = None
     # Issue #265: dense progress shaping coefficient. Mutated onto the loaded
     # ``Scenario`` instance in ``train_one_cell`` so the per-cell knob takes
     # effect inside ``_compute_rewards``. Default ``0.0`` matches the
@@ -926,6 +938,23 @@ def train_one_cell(cfg: CellConfig, output_dir: Path) -> None:
     scenario.action_shaping_alpha = float(cfg.action_shaping_alpha)
     scenario.action_shaping_beta = float(cfg.action_shaping_beta)
 
+    # Issue #360: per-cell (β, κ, c) overrides for the NE phase-diagram sweep.
+    # ``None`` leaves the scenario's shipped value untouched (bit-identical
+    # pre-#360 behavior); a float mutates the loaded ``Scenario`` instance
+    # so the env's rollout uses the cell's reward params. Mirrors the
+    # ``compute_nash_phase_diagram._make_scenario`` mapping so the NE
+    # phase-diagram cells are reward-comparable to PPO training cells.
+    if cfg.prob_fire_spreads_to_neighbor is not None:
+        scenario.prob_fire_spreads_to_neighbor = float(
+            cfg.prob_fire_spreads_to_neighbor
+        )
+    if cfg.prob_solo_agent_extinguishes_fire is not None:
+        scenario.prob_solo_agent_extinguishes_fire = float(
+            cfg.prob_solo_agent_extinguishes_fire
+        )
+    if cfg.cost_to_work_one_night is not None:
+        scenario.cost_to_work_one_night = float(cfg.cost_to_work_one_night)
+
     # Issue #265: mutate the dense progress shaping coefficient. Default
     # ``0.0`` keeps the env fast-path skip and bit-identical pre-#265
     # behavior; the #265 sweep driver passes per-cell values.
@@ -1322,6 +1351,37 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--prob-fire-spreads-to-neighbor",
+        type=float,
+        default=None,
+        help=(
+            "Issue #360: per-cell β override for the NE phase-diagram sweep "
+            "(mutates Scenario.prob_fire_spreads_to_neighbor). Default None "
+            "leaves the base scenario's value untouched. Matches the "
+            "compute_nash_phase_diagram._make_scenario wiring."
+        ),
+    )
+    p.add_argument(
+        "--prob-solo-agent-extinguishes-fire",
+        type=float,
+        default=None,
+        help=(
+            "Issue #360: per-cell κ override for the NE phase-diagram sweep "
+            "(mutates Scenario.prob_solo_agent_extinguishes_fire). Default "
+            "None leaves the base scenario's value untouched."
+        ),
+    )
+    p.add_argument(
+        "--cost-to-work-one-night",
+        type=float,
+        default=None,
+        help=(
+            "Issue #360: per-cell c override for the NE phase-diagram sweep "
+            "(mutates Scenario.cost_to_work_one_night). Default None leaves "
+            "the base scenario's value untouched."
+        ),
+    )
+    p.add_argument(
         "--progress-shaping-coef",
         type=float,
         default=CellConfig.__dataclass_fields__["progress_shaping_coef"].default,
@@ -1660,6 +1720,9 @@ def main() -> None:
         curriculum=args.curriculum,
         action_shaping_alpha=args.action_shaping_alpha,
         action_shaping_beta=args.action_shaping_beta,
+        prob_fire_spreads_to_neighbor=args.prob_fire_spreads_to_neighbor,
+        prob_solo_agent_extinguishes_fire=args.prob_solo_agent_extinguishes_fire,
+        cost_to_work_one_night=args.cost_to_work_one_night,
         progress_shaping_coef=args.progress_shaping_coef,
         team_welfare_lambda=args.team_welfare_lambda,
         team_welfare_gamma=args.team_welfare_gamma,

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -66,6 +66,14 @@ DEFAULT_HOST="alc-2"
 
 DEFAULT_CELLS_SOURCE="experiments/nash/phase_diagram/results.json"
 DEFAULT_SCENARIO="minimal_specialization"
+# The gap_closed metric is calibrated against the MINSPEC_RANDOM /
+# MINSPEC_SPECIALIST baselines in bucket_brigade.baselines (see
+# run_tier1_cell.py:306-312 and run_phase_diagram_ppo.py:334-335). Running
+# the sweep on any other scenario produces uncalibrated gap_closed numbers
+# — we lock the scenario at the CLI to prevent the silent-garbage failure
+# mode. Operators who know what they're doing can opt out with
+# --allow-non-minspec-gap.
+MINSPEC_LOCKED_SCENARIO="minimal_specialization"
 DEFAULT_SEEDS="42 43 44 45"
 # Mirror launch_tier1_sweep.sh's budget — 50 PPO iterations × 2048 rollout
 # steps is the Tier-1 baseline gap_closed measurement budget.
@@ -85,9 +93,10 @@ SESSION_NAME=""
 LIMIT_CELLS=""
 DRY_RUN=0
 SKIP_CONNECTIVITY_CHECK=0
+ALLOW_NON_MINSPEC_GAP=0
 
 print_usage() {
-    sed -n '2,52p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 # Resolve a host alias from .env using the documented priority order.
@@ -170,6 +179,14 @@ while [[ $# -gt 0 ]]; do
             SKIP_CONNECTIVITY_CHECK=1
             shift
             ;;
+        --allow-non-minspec-gap)
+            # Escape hatch for an operator who knows the gap_closed metric
+            # will be uncalibrated and wants to run the sweep anyway (e.g.
+            # for raw trajectory inspection). See MINSPEC_LOCKED_SCENARIO
+            # comment above.
+            ALLOW_NON_MINSPEC_GAP=1
+            shift
+            ;;
         -h|--help)
             print_usage
             exit 0
@@ -181,6 +198,25 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# ---------------------------------------------------------------------------
+# Validate scenario (gap_closed lock)
+# ---------------------------------------------------------------------------
+#
+# The gap_closed metric written by run_phase_diagram_ppo.py is hard-coded to
+# the MINSPEC_RANDOM / MINSPEC_SPECIALIST baselines. Running with any other
+# --scenario produces summary.json / cell_summary.json files whose
+# gap_closed numbers are not comparable to anything — the operator concern
+# from PR #410's review is that this fails silently. Reject non-minspec
+# scenarios at the CLI unless --allow-non-minspec-gap is set.
+
+if [[ "$SCENARIO" != "$MINSPEC_LOCKED_SCENARIO" && "$ALLOW_NON_MINSPEC_GAP" -eq 0 ]]; then
+    echo "ERROR: --scenario '$SCENARIO' rejected." >&2
+    echo "       gap_closed metric is calibrated only for minimal_specialization;" >&2
+    echo "       other scenarios will produce uncalibrated gap_closed values." >&2
+    echo "       Re-run with --allow-non-minspec-gap to override." >&2
+    exit 5
+fi
 
 # ---------------------------------------------------------------------------
 # Resolve host
@@ -245,6 +281,11 @@ DRIVER_CMD+=" --rollout-steps $ROLLOUT_STEPS"
 DRIVER_CMD+=" --output-root '$OUTPUT_ROOT'"
 if [[ -n "$LIMIT_CELLS" ]]; then
     DRIVER_CMD+=" --limit-cells $LIMIT_CELLS"
+fi
+if [[ "$ALLOW_NON_MINSPEC_GAP" -eq 1 ]]; then
+    # Forward the opt-out so the driver's own scenario lock also lets it
+    # through. (We've already passed the launcher-side lock above.)
+    DRIVER_CMD+=" --allow-non-minspec-gap"
 fi
 
 # Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# Launch the phase-diagram PPO sweep (issue #360 / parent #357 M2.1) on a
+# remote host. Dispatches experiments/p3_specialization/run_phase_diagram_ppo.py
+# which itself drives experiments/p3_specialization/train.py with the per-cell
+# (β, κ, c) override flags added in #360.
+#
+# Default host: alc-2 (RTX 4090 CPU host). The CPU-bound bucket-brigade env
+# benefits from alc-2's core count + reliability (see
+# memory/reference_cluster_host_reliability.md). If alc-2 isn't reachable the
+# script falls back to whatever .env's COMPUTE_HOST_* aliases resolve to, in
+# the same priority order as launch_tier1_sweep.sh.
+#
+# The script does NOT compute anything locally. It only:
+#   1. Resolves a target host (--host wins; else COMPUTE_HOST_* from .env;
+#      else exits non-zero).
+#   2. Verifies the host is reachable via SSH BatchMode.
+#   3. SSHs in, pulls latest main, builds the Rust extension, and starts a
+#      detached tmux session running the per-cell driver.
+#   4. Prints monitor / rsync instructions.
+#
+# CLAUDE.md is explicit: long unattended cluster runs are operator-driven,
+# not safe for an autonomous agent to spawn. This script is the operator's
+# launch tool. It does its job and exits — the actual cells fill over hours
+# inside the remote tmux session.
+#
+# Usage
+# -----
+#   # Default: alc-2, 7 NE-phase-diagram cells × 4 seeds × minimal_specialization
+#   ./experiments/scripts/launch_phase_diagram_ppo.sh
+#
+#   # Pick a different host (alc-6 / alc-9 are also reliable, see memory)
+#   ./experiments/scripts/launch_phase_diagram_ppo.sh --host alc-6
+#
+#   # Sanity-check a single cell at smoke budget before the full sweep
+#   ./experiments/scripts/launch_phase_diagram_ppo.sh \
+#       --limit-cells 1 --num-iterations 5 --rollout-steps 256
+#
+#   # Dry-run prints the ssh + driver command without launching
+#   ./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run
+#
+#   # Use a different NE-search results source (e.g. the freqtest variant)
+#   ./experiments/scripts/launch_phase_diagram_ppo.sh \
+#       --cells-source experiments/nash/phase_diagram/results_freqtest.json
+#
+# See experiments/p3_specialization/run_phase_diagram_ppo.py for the
+# per-(cell × seed) summary schema and the per-cell aggregation.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults & helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where the bucket-brigade repo lives on remote hosts. Tried in order; first
+# that exists wins. Matches CLAUDE.md guidance ("~/GitHub/bucket-brigade
+# first, fall back to ~/bucket-brigade").
+REMOTE_REPO_CANDIDATES=("\$HOME/GitHub/bucket-brigade" "\$HOME/bucket-brigade")
+
+# Documented default host for this sweep (operator may override with --host).
+# Resolver still falls back to .env's COMPUTE_HOST_* if alc-2 isn't reachable
+# or isn't configured.
+DEFAULT_HOST="alc-2"
+
+DEFAULT_CELLS_SOURCE="experiments/nash/phase_diagram/results.json"
+DEFAULT_SCENARIO="minimal_specialization"
+DEFAULT_SEEDS="42 43 44 45"
+# Mirror launch_tier1_sweep.sh's budget — 50 PPO iterations × 2048 rollout
+# steps is the Tier-1 baseline gap_closed measurement budget.
+DEFAULT_NUM_ITERATIONS="50"
+DEFAULT_ROLLOUT_STEPS="2048"
+DEFAULT_OUTPUT_ROOT="experiments/p3_specialization/phase_diagram_ppo"
+DEFAULT_SESSION_PREFIX="phase-diagram-ppo"
+
+HOST=""
+CELLS_SOURCE="$DEFAULT_CELLS_SOURCE"
+SCENARIO="$DEFAULT_SCENARIO"
+SEEDS="$DEFAULT_SEEDS"
+NUM_ITERATIONS="$DEFAULT_NUM_ITERATIONS"
+ROLLOUT_STEPS="$DEFAULT_ROLLOUT_STEPS"
+OUTPUT_ROOT="$DEFAULT_OUTPUT_ROOT"
+SESSION_NAME=""
+LIMIT_CELLS=""
+DRY_RUN=0
+SKIP_CONNECTIVITY_CHECK=0
+
+print_usage() {
+    sed -n '2,52p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Resolve a host alias from .env using the documented priority order.
+# Echoes the first non-empty option; empty string if none configured.
+# Copied verbatim from launch_tier1_sweep.sh so both launchers see the same
+# host inventory.
+resolve_host_from_env() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+    local primary cluster lambda gcp
+    primary=$(grep -E '^COMPUTE_HOST_PRIMARY=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    cluster=$(grep -E '^COMPUTE_HOST_CLUSTER=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    lambda=$(grep -E '^COMPUTE_HOST_LAMBDA=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    gcp=$(grep -E '^COMPUTE_HOST_GCP=' "$env_file" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+    for h in "$primary" "$cluster" "$lambda" "$gcp"; do
+        if [[ -n "$h" ]]; then
+            echo "$h"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Confirm an SSH alias resolves and accepts a non-interactive connection.
+check_ssh_reachable() {
+    local host="$1"
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" echo ok >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --cells-source)
+            CELLS_SOURCE="$2"
+            shift 2
+            ;;
+        --scenario)
+            SCENARIO="$2"
+            shift 2
+            ;;
+        --seeds)
+            SEEDS="$2"
+            shift 2
+            ;;
+        --num-iterations)
+            NUM_ITERATIONS="$2"
+            shift 2
+            ;;
+        --rollout-steps)
+            ROLLOUT_STEPS="$2"
+            shift 2
+            ;;
+        --output-root)
+            OUTPUT_ROOT="$2"
+            shift 2
+            ;;
+        --session-name)
+            SESSION_NAME="$2"
+            shift 2
+            ;;
+        --limit-cells)
+            LIMIT_CELLS="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-connectivity-check)
+            # Useful in CI / smoke tests where we can't actually ssh out.
+            SKIP_CONNECTIVITY_CHECK=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve host
+# ---------------------------------------------------------------------------
+#
+# Priority:
+#   1. --host explicit
+#   2. DEFAULT_HOST (alc-2) if SSH-reachable
+#   3. .env COMPUTE_HOST_PRIMARY / _CLUSTER / _LAMBDA / _GCP in that order
+#
+# The .env fallback keeps the script useful on a fresh clone that doesn't
+# happen to have alc-2 wired up. We do the reachability check up-front
+# (unless --dry-run / --skip-connectivity-check) so misconfigured operators
+# fail fast, not after committing a tmux session.
+
+if [[ -z "$HOST" ]]; then
+    if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+        if check_ssh_reachable "$DEFAULT_HOST"; then
+            HOST="$DEFAULT_HOST"
+        else
+            HOST=$(resolve_host_from_env)
+        fi
+    else
+        # Skip the probe in dry-run; just take the documented default.
+        HOST="$DEFAULT_HOST"
+    fi
+fi
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: no host specified and none resolvable from .env" >&2
+    echo "       Pass --host <alias> or set COMPUTE_HOST_* in .env" >&2
+    exit 3
+fi
+
+if [[ "$SKIP_CONNECTIVITY_CHECK" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+    if ! check_ssh_reachable "$HOST"; then
+        echo "ERROR: cannot reach SSH host '$HOST' (BatchMode, 5s timeout)" >&2
+        echo "       Try: ssh -v $HOST" >&2
+        exit 4
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build the driver command + tmux session name
+# ---------------------------------------------------------------------------
+
+if [[ -z "$SESSION_NAME" ]]; then
+    # Compact tag so two concurrent launches on the same host don't collide.
+    # Use the scenario + seed count as a stable fingerprint.
+    seed_count=$(echo "$SEEDS" | wc -w | tr -d ' ')
+    SESSION_NAME="${DEFAULT_SESSION_PREFIX}-${SCENARIO}-n${seed_count}"
+fi
+
+# Compose the driver invocation. One python entrypoint covers all cells; the
+# driver writes per-(cell × seed) summary.json and per-cell cell_summary.json.
+DRIVER_CMD="uv run python experiments/p3_specialization/run_phase_diagram_ppo.py"
+DRIVER_CMD+=" --cells-source '$CELLS_SOURCE'"
+DRIVER_CMD+=" --scenario '$SCENARIO'"
+DRIVER_CMD+=" --seeds $SEEDS"
+DRIVER_CMD+=" --num-iterations $NUM_ITERATIONS"
+DRIVER_CMD+=" --rollout-steps $ROLLOUT_STEPS"
+DRIVER_CMD+=" --output-root '$OUTPUT_ROOT'"
+if [[ -n "$LIMIT_CELLS" ]]; then
+    DRIVER_CMD+=" --limit-cells $LIMIT_CELLS"
+fi
+
+# Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
+# Notes on the remote env (see CLAUDE.md):
+#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
+#   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
+#     venv must have pip; uv ships venvs without pip by default. (See
+#     memory/feedback_cluster_bootstrap_uv_sync.md — uv sync must come
+#     before the editable install of bucket-brigade-core.)
+read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
+set -euo pipefail
+export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+unset RUSTC_WRAPPER || true
+
+REPO=""
+for candidate in ${REMOTE_REPO_CANDIDATES[*]}; do
+    if [[ -d "\$candidate/.git" ]]; then
+        REPO="\$candidate"
+        break
+    fi
+done
+if [[ -z "\$REPO" ]]; then
+    echo "ERROR: bucket-brigade not found in any of: ${REMOTE_REPO_CANDIDATES[*]}" >&2
+    exit 10
+fi
+cd "\$REPO"
+echo "Remote repo: \$REPO"
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Seed pip if needed (uv-created venvs ship without pip; build.sh needs it).
+if [[ -d .venv ]]; then
+    .venv/bin/python -m pip --version >/dev/null 2>&1 || uv pip install pip
+else
+    uv venv
+    uv pip install pip
+fi
+uv sync
+
+# Build Rust extension (idempotent — skipped if .so is fresh).
+bash bucket-brigade-core/build.sh
+
+# Sanity-check the import + cells file exists before consuming a tmux
+# session for a multi-hour run.
+uv run python -c "from experiments.p3_specialization.run_phase_diagram_ppo import load_cells; cells = load_cells(__import__('pathlib').Path('$CELLS_SOURCE')); print(f'driver ok, {len(cells)} cells')"
+
+mkdir -p $OUTPUT_ROOT
+
+# Kill any prior session with the same name so re-launches are idempotent.
+tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true
+
+tmux new-session -d -s '$SESSION_NAME' "cd \$REPO && export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 && ( $DRIVER_CMD ) 2>&1 | tee -a '$OUTPUT_ROOT/${SESSION_NAME}.log'"
+
+echo ""
+echo "Launched tmux session: $SESSION_NAME"
+echo "Log: \$REPO/$OUTPUT_ROOT/${SESSION_NAME}.log"
+echo "Attach with: tmux attach -t $SESSION_NAME"
+REMOTE_SCRIPT
+
+# ---------------------------------------------------------------------------
+# Print plan / execute
+# ---------------------------------------------------------------------------
+
+seed_count=$(echo "$SEEDS" | wc -w | tr -d ' ')
+
+echo "===================================================================="
+echo "Phase-diagram PPO sweep launch (issue #360)"
+echo "===================================================================="
+echo "Host:           $HOST"
+echo "Session name:   $SESSION_NAME"
+echo "Output root:    $OUTPUT_ROOT    (on remote)"
+echo "Cells source:   $CELLS_SOURCE"
+echo "Scenario:       $SCENARIO"
+echo "Seeds:          $SEEDS    ($seed_count per cell)"
+echo "Num iterations: $NUM_ITERATIONS"
+echo "Rollout steps:  $ROLLOUT_STEPS"
+if [[ -n "$LIMIT_CELLS" ]]; then
+    echo "Limit cells:    $LIMIT_CELLS"
+fi
+echo ""
+echo "Driver command (to be run inside tmux on remote):"
+echo "  $DRIVER_CMD"
+echo "===================================================================="
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "[dry-run] not connecting to $HOST. Remote bootstrap script would be:"
+    echo "---"
+    echo "$REMOTE_BOOTSTRAP"
+    echo "---"
+    exit 0
+fi
+
+echo ""
+echo "Connecting to $HOST and bootstrapping..."
+ssh "$HOST" bash <<EOF
+$REMOTE_BOOTSTRAP
+EOF
+
+echo ""
+echo "===================================================================="
+echo "Launched. Useful follow-ups:"
+echo ""
+echo "  # Watch progress live"
+echo "  ssh $HOST -t 'tmux attach -t $SESSION_NAME'"
+echo ""
+echo "  # Tail the log without attaching"
+echo "  ssh $HOST 'tail -f bucket-brigade/${OUTPUT_ROOT}/${SESSION_NAME}.log'"
+echo ""
+echo "  # When done, rsync results back to this checkout:"
+echo "  rsync -avz $HOST:bucket-brigade/${OUTPUT_ROOT}/ ${OUTPUT_ROOT}/"
+echo ""
+echo "  # Once results are local, the Tier-1 aggregator already understands"
+echo "  # the cell_summary.json schema (we reused build_cell_summary), so:"
+echo "  uv run python experiments/p3_specialization/aggregate_tier1.py \\"
+echo "      --tier1-root ${OUTPUT_ROOT}"
+echo "===================================================================="

--- a/tests/test_launch_phase_diagram_ppo.py
+++ b/tests/test_launch_phase_diagram_ppo.py
@@ -1,0 +1,162 @@
+"""Tests for ``experiments/scripts/launch_phase_diagram_ppo.sh``.
+
+The launcher dispatches the phase-diagram PPO sweep (issue #360) to a
+remote host. Because it shells out to ``ssh`` we cannot exercise the
+live-run path in unit tests — ``--dry-run`` + ``--skip-connectivity-check``
+exist exactly so the wiring (arg parsing, scenario lock, host resolution,
+driver-command synthesis) can be asserted without touching the network.
+
+The PR #410 Judge review identified one blocking issue: ``--scenario foo``
+must be rejected at the CLI because the gap_closed metric written by
+``run_phase_diagram_ppo.py`` is hard-coded to the MINSPEC_RANDOM /
+MINSPEC_SPECIALIST baselines. These tests lock that fix in place.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "experiments" / "scripts" / "launch_phase_diagram_ppo.sh"
+
+
+def _run(args: list[str], env: dict | None = None, cwd: Path | None = None):
+    """Invoke the launch script with the given args; return CompletedProcess."""
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable() -> None:
+    """The launch script must be present and have the +x bit set."""
+    assert SCRIPT.exists(), f"launch script missing: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), (
+        f"launch script not executable: {SCRIPT} — chmod +x it before commit"
+    )
+
+
+def test_help_flag_prints_usage_and_exits_zero() -> None:
+    """``--help`` must succeed without trying to ssh anywhere."""
+    result = _run(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    # Spot-check canonical flags appear in the doc string.
+    for flag in (
+        "--host",
+        "--cells-source",
+        "--limit-cells",
+        "--dry-run",
+    ):
+        assert flag in result.stdout, f"--help is missing documentation for {flag}"
+
+
+def test_help_does_not_leak_set_euo_pipefail() -> None:
+    """The sed range that produces --help output must stop before the
+    ``set -euo pipefail`` directive (cosmetic fix from PR #410 review)."""
+    result = _run(["--help"])
+    assert result.returncode == 0
+    assert "set -euo pipefail" not in result.stdout, (
+        "print_usage sed range overshoots into shell directives — check "
+        "the '2,Np' range matches the actual header length."
+    )
+
+
+def test_scenario_lock_rejects_non_minspec() -> None:
+    """``--scenario`` other than minimal_specialization must be rejected.
+
+    Lock the PR #410 blocking fix in place: the gap_closed metric written
+    by run_phase_diagram_ppo.py is calibrated only for the MINSPEC
+    baselines. Running with any other scenario produces uncalibrated
+    numbers, so the launcher refuses to start the sweep without an
+    explicit opt-out flag.
+    """
+    result = _run(
+        [
+            "--scenario",
+            "default",
+            "--dry-run",
+            "--skip-connectivity-check",
+        ]
+    )
+    assert result.returncode == 5, (
+        f"expected exit 5 (scenario lock), got {result.returncode}: "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    # The error message must name the root cause so an operator can act on
+    # it without re-reading the source.
+    err = result.stderr.lower()
+    assert "gap_closed" in err, (
+        f"scenario lock error must reference the gap_closed metric: {result.stderr!r}"
+    )
+    assert "minimal_specialization" in err
+    assert "--allow-non-minspec-gap" in result.stderr
+
+
+def test_allow_non_minspec_gap_overrides_lock() -> None:
+    """``--allow-non-minspec-gap`` is the documented opt-out for operators
+    who know they want raw trajectories without a comparable gap_closed."""
+    result = _run(
+        [
+            "--scenario",
+            "default",
+            "--allow-non-minspec-gap",
+            "--dry-run",
+            "--skip-connectivity-check",
+        ]
+    )
+    assert result.returncode == 0, (
+        f"override flag should let non-minspec scenarios through, "
+        f"got exit {result.returncode}: {result.stderr!r}"
+    )
+    # Driver invocation must propagate the override so the driver's own
+    # scenario lock also lets the run through.
+    assert "--allow-non-minspec-gap" in result.stdout, (
+        "launcher must forward --allow-non-minspec-gap to the driver"
+    )
+    assert "--scenario 'default'" in result.stdout
+
+
+def test_default_scenario_passes_lock() -> None:
+    """Default scenario (minimal_specialization) must not be blocked."""
+    result = _run(["--dry-run", "--skip-connectivity-check"])
+    assert result.returncode == 0, (
+        f"default scenario should pass the lock, got exit "
+        f"{result.returncode}: {result.stderr!r}"
+    )
+    assert "minimal_specialization" in result.stdout
+    # Driver invocation should NOT include --allow-non-minspec-gap when
+    # the operator hasn't explicitly opted out (it's a no-op but cleaner).
+    assert "--allow-non-minspec-gap" not in result.stdout
+
+
+def test_dry_run_emits_driver_command() -> None:
+    """``--dry-run`` must print the synthesized driver invocation so the
+    operator can confirm wiring before the real launch."""
+    result = _run(["--dry-run", "--skip-connectivity-check"])
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Argument plumbing through to the driver:
+    assert "run_phase_diagram_ppo.py" in out
+    assert "--cells-source 'experiments/nash/phase_diagram/results.json'" in out
+    assert "--seeds 42 43 44 45" in out
+    assert "--num-iterations 50" in out
+    assert "--rollout-steps 2048" in out
+    # Dry-run banner must be present.
+    assert "dry-run" in out.lower()
+
+
+def test_unknown_flag_exits_nonzero_with_message() -> None:
+    """Operator typos must fail loudly, not silently launch the wrong thing."""
+    result = _run(["--not-a-flag", "y", "--dry-run", "--skip-connectivity-check"])
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Adds the launcher + driver for issue #360 (M2.1): train `JointPPOTrainer` across the same (β, κ, c) cells the heterogeneous NE phase-diagram search (#358) produced, so the cross-tab figure and Spearman ρ correlation in #360's acceptance criteria have the data they need.

### Files

- **`experiments/p3_specialization/run_phase_diagram_ppo.py`** (new)
  - Per-cell × per-seed driver.
  - Reads cells from `experiments/nash/phase_diagram/results.json` (the #358 schema).
  - Subprocesses `train.py` with `--algorithm ppo` per cell using the new (β, κ, c) override flags.
  - Writes per-(cell × seed) `summary.json` (gap_closed, verdict, final_episode_return, wall_seconds, plus NE-search context) and per-cell `cell_summary.json` via `run_tier1_cell.build_cell_summary` — schema-compatible with `aggregate_tier1.py`.

- **`experiments/scripts/launch_phase_diagram_ppo.sh`** (new, executable)
  - Operator launcher modeled on `launch_tier1_sweep.sh`.
  - Same host resolution, ssh + tmux bootstrap, `--dry-run`, `--skip-connectivity-check`.
  - Documented default host: `alc-2` (per the user's choice for this issue + the cluster-reliability memo). Resolver falls back to `.env` `COMPUTE_HOST_*` if `alc-2` isn't reachable.
  - Defaults: 7 cells × 4 seeds (42 43 44 45) × `minimal_specialization`, 50 iterations × 2048 rollout steps (matches Tier-1 budget).

- **`experiments/p3_specialization/train.py`** (modified)
  - Three new flags: `--prob-fire-spreads-to-neighbor`, `--prob-solo-agent-extinguishes-fire`, `--cost-to-work-one-night`.
  - Each mutates the loaded `Scenario` instance the same way `--action-shaping-alpha` does. Defaults `None` preserve bit-identical pre-#360 behavior.
  - Mirrors `compute_nash_phase_diagram._make_scenario` so NE-search and PPO-training rewards are comparable.

### Sanity checks performed locally

- `./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run --skip-connectivity-check` renders the expected per-cell driver command without hitting alc-2.
- `run_phase_diagram_ppo.py --list-cells` loads 7 cells from the current `results.json`.
- End-to-end local smoke with `--limit-cells 1 --seeds 42 --num-iterations 1 --rollout-steps 64` produced `seed_42/summary.json` and `cell_summary.json` with the documented schemas.
- `train.py --prob-fire-spreads-to-neighbor 0.9 --prob-solo-agent-extinguishes-fire 0.9 --cost-to-work-one-night 0.5` smoke run shows the values round-trip into `config.json`.
- `ruff format` + `ruff check` + pre-commit all pass.

### Notes for the reviewer

- The launcher is intentionally not auto-launched; CLAUDE.md is explicit that cluster runs are operator-driven. The operator launches with `./experiments/scripts/launch_phase_diagram_ppo.sh` once they're ready.
- Issue #360 was previously labeled `loom:blocked` pending the NE grid from #358. In fact `experiments/nash/phase_diagram/results.json` does exist (partial 7-cell aggregate from the 2026-06-05 recovery). This PR consumes that file. The 7 cells are partial (β=0.1 row incomplete, c=2.0 slice never recovered), so the resulting sweep is the right-sized first run — when #358 produces a fuller grid, the same launcher consumes it without modification via `--cells-source`.

## Test plan

- [ ] Reviewer confirms dry-run output looks right
- [ ] Reviewer confirms the per-seed `summary.json` schema matches what the downstream cross-tab figure expects
- [ ] Reviewer confirms the train.py CLI flag names match the conventions used by other Scenario-override flags (`--action-shaping-alpha`, etc.)
- [ ] Operator runs the full sweep on alc-2 (or fallback host) when compute is available

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)