### PR TITLE
fix(scripts): launcher bootstrap missing --extra rl + $HOME/.local/bin

### DIFF
--- a/experiments/scripts/launch_het_ppo_sweep.sh
+++ b/experiments/scripts/launch_het_ppo_sweep.sh
@@ -236,7 +236,7 @@ done
 #     venv must have pip; uv ships venvs without pip by default.
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 

--- a/experiments/scripts/launch_phase_diagram_fill.sh
+++ b/experiments/scripts/launch_phase_diagram_fill.sh
@@ -210,7 +210,7 @@ DRIVER_CMD="uv run python experiments/scripts/compute_nash_phase_diagram.py --ou
 #     venv must have pip; uv ships venvs without pip by default.
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -290,7 +290,8 @@ fi
 
 # Remote bootstrap: try canonical repo paths, pull, build Rust ext, run.
 # Notes on the remote env (see CLAUDE.md):
-#   - PATH is bare under non-interactive SSH on macOS; prepend Homebrew + cargo.
+#   - PATH is bare under non-interactive SSH; prepend Homebrew (macOS),
+#     $HOME/.local/bin (Linux — uv installer's default), and $HOME/.cargo/bin.
 #   - PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 + unset RUSTC_WRAPPER for the build.
 #   - bucket-brigade-core/build.sh uses `python -m pip install -e .`, so the
 #     venv must have pip; uv ships venvs without pip by default. (See
@@ -298,7 +299,7 @@ fi
 #     before the editable install of bucket-brigade-core.)
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 
@@ -327,7 +328,14 @@ else
     uv venv
     uv pip install pip
 fi
-uv sync
+# --extra rl is mandatory for this sweep: experiments/p3_specialization/train.py
+# imports torch unconditionally. A bare `uv sync` produces a venv without
+# torch, every cell × seed crashes immediately at import, and the launcher
+# reports "0/7 cells produced metrics" after a few seconds. See
+# launch_ppo_baselines.sh:309 for the matching precedent (PPO baselines also
+# need --extra rl); launch_tier1_sweep.sh does NOT pass --extra rl because
+# its Rust-only trainers don't import torch.
+uv sync --extra rl
 
 # Build Rust extension (idempotent — skipped if .so is fresh).
 bash bucket-brigade-core/build.sh

--- a/experiments/scripts/launch_ppo_baselines.sh
+++ b/experiments/scripts/launch_ppo_baselines.sh
@@ -277,7 +277,7 @@ done
 #     venv must have pip; uv ships venvs without pip by default.
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 

--- a/experiments/scripts/launch_rest_trap_rerun.sh
+++ b/experiments/scripts/launch_rest_trap_rerun.sh
@@ -217,7 +217,7 @@ DRIVER_CMD+=" --output-dir '$OUTPUT_DIR'"
 #     venv must have pip; uv ships venvs without pip by default.
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -291,7 +291,7 @@ fi
 #     venv must have pip; uv ships venvs without pip by default.
 read -r -d '' REMOTE_BOOTSTRAP <<REMOTE_SCRIPT || true
 set -euo pipefail
-export PATH="/opt/homebrew/bin:\$HOME/.cargo/bin:\$PATH"
+export PATH="/opt/homebrew/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH"
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 unset RUSTC_WRAPPER || true
 

--- a/tests/test_launch_phase_diagram_ppo.py
+++ b/tests/test_launch_phase_diagram_ppo.py
@@ -160,3 +160,46 @@ def test_unknown_flag_exits_nonzero_with_message() -> None:
     result = _run(["--not-a-flag", "y", "--dry-run", "--skip-connectivity-check"])
     assert result.returncode != 0
     assert "unknown argument" in result.stderr.lower()
+
+
+def test_remote_bootstrap_installs_rl_extra() -> None:
+    """The remote bootstrap heredoc must invoke ``uv sync --extra rl``.
+
+    The first #360 alc-2 launch shipped with bare ``uv sync``, which
+    builds a venv without torch. Every (cell × seed) crashed at
+    ``import torch`` and the launcher reported "0/7 cells produced
+    metrics" after a few seconds of pure setup time. ``experiments/
+    p3_specialization/train.py`` imports torch unconditionally so the
+    ``rl`` extra is mandatory for this sweep — see launch_ppo_baselines.sh
+    for the matching precedent.
+    """
+    text = SCRIPT.read_text()
+    assert "uv sync --extra rl" in text, (
+        "remote bootstrap must use `uv sync --extra rl` — "
+        "bare `uv sync` produces a venv without torch and every "
+        "cell × seed crashes at import."
+    )
+    # And specifically NOT bare `uv sync` (which would mean the line was
+    # added without removing the bug).
+    lines = [ln.strip() for ln in text.splitlines()]
+    assert "uv sync" not in lines, (
+        "remote bootstrap still contains a bare `uv sync` line — "
+        "every `uv sync` invocation needs `--extra rl` for this sweep."
+    )
+
+
+def test_remote_bootstrap_path_includes_local_bin() -> None:
+    """The remote bootstrap PATH must include ``$HOME/.local/bin``.
+
+    Linux installs of uv land in ``$HOME/.local/bin/uv``. The previous
+    PATH export only listed ``/opt/homebrew/bin`` (macOS) and
+    ``$HOME/.cargo/bin`` (rustup), so the bootstrap would fail with
+    ``uv: command not found`` on Linux remotes (e.g. alc-2). The fix is
+    to insert ``$HOME/.local/bin`` between Homebrew and cargo.
+    """
+    text = SCRIPT.read_text()
+    assert "$HOME/.local/bin" in text, (
+        "remote bootstrap PATH is missing $HOME/.local/bin — "
+        "Linux installs of uv live there and the bootstrap will "
+        "fail with `uv: command not found` on alc-* / Linux remotes."
+    )


### PR DESCRIPTION
## Summary

Two cluster-bootstrap regressions surfaced when the #360 phase-diagram PPO sweep ran on alc-2: every cell × seed crashed with `ModuleNotFoundError: No module named 'torch'`, and the launcher reported "0/7 cells produced metrics" in seconds rather than hours.

- `launch_phase_diagram_ppo.sh` ran bare `uv sync` instead of `uv sync --extra rl`. The `rl` extra contains torch, which the driver imports unconditionally.
- Six launchers exported a remote `PATH` that omitted `\$HOME/.local/bin` — the default install location for the Linux `uv` installer — so the bootstrap also hit `uv: command not found` on alc-* until a manual symlink was put in place.

## Root cause

`launch_phase_diagram_ppo.sh` was modeled after `launch_tier1_sweep.sh` (Rust-only trainers, no torch) rather than `launch_ppo_baselines.sh` (Python PPO, correctly passes `--extra rl`). The PATH bug was identical across all six launchers — copy-paste drift, not a regression specific to one script.

## Changes

- `launch_phase_diagram_ppo.sh`: `uv sync` → `uv sync --extra rl` with a comment naming the precedent.
- Six launchers (`launch_tier1_sweep`, `launch_ppo_baselines`, `launch_het_ppo_sweep`, `launch_phase_diagram_fill`, `launch_phase_diagram_ppo`, `launch_rest_trap_rerun`): prepend `\$HOME/.local/bin` to the remote PATH export.
- `tests/test_launch_phase_diagram_ppo.py`: two new regression tests pinning the bootstrap (asserts `uv sync --extra rl` appears and bare `uv sync` does not; asserts PATH contains `\$HOME/.local/bin`).

## Test plan

- [x] \`uv run pytest tests/test_launch_phase_diagram_ppo.py\` — 10 passed
- [x] \`./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run --skip-connectivity-check\` exits 0 and prints the expected driver command
- [ ] After merge: re-launch #360 on alc-2 (the original launch that surfaced this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)