### PR TITLE
fix(launchers): source .venv before uv sync to lock maturin location (#418)

### DIFF
--- a/experiments/scripts/launch_het_ppo_sweep.sh
+++ b/experiments/scripts/launch_het_ppo_sweep.sh
@@ -265,6 +265,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 uv sync --extra rl
 
 # Build Rust extension (idempotent — skipped if .so is fresh).

--- a/experiments/scripts/launch_phase_diagram_fill.sh
+++ b/experiments/scripts/launch_phase_diagram_fill.sh
@@ -239,6 +239,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 uv sync
 
 # Build Rust extension (idempotent — skipped if .so is fresh).

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -328,6 +328,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 # --extra rl is mandatory for this sweep: experiments/p3_specialization/train.py
 # imports torch unconditionally. A bare `uv sync` produces a venv without
 # torch, every cell × seed crashes immediately at import, and the launcher

--- a/experiments/scripts/launch_ppo_baselines.sh
+++ b/experiments/scripts/launch_ppo_baselines.sh
@@ -306,6 +306,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 uv sync --extra rl
 
 # Build Rust extension (idempotent — skipped if .so is fresh).

--- a/experiments/scripts/launch_rest_trap_rerun.sh
+++ b/experiments/scripts/launch_rest_trap_rerun.sh
@@ -246,6 +246,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 uv sync
 
 # Build Rust extension (idempotent — skipped if .so is fresh).

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -320,6 +320,12 @@ else
     uv venv
     uv pip install pip
 fi
+# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
+# install maturin` inside build.sh has occasionally landed in a different
+# location and the subsequent bare `maturin develop` call fails with
+# "Failed to spawn: maturin — No such file or directory".
+source .venv/bin/activate
 uv sync
 
 # Build Rust extension (idempotent — skipped if .so is fresh).

--- a/tests/test_launch_phase_diagram_ppo.py
+++ b/tests/test_launch_phase_diagram_ppo.py
@@ -203,3 +203,32 @@ def test_remote_bootstrap_path_includes_local_bin() -> None:
         "Linux installs of uv live there and the bootstrap will "
         "fail with `uv: command not found` on alc-* / Linux remotes."
     )
+
+
+def test_remote_bootstrap_sources_venv() -> None:
+    """The remote bootstrap heredoc must invoke ``source .venv/bin/activate``
+    after the venv exists, before ``uv sync`` and ``bash build.sh``.
+
+    Without an explicit activation, the bootstrap can intermittently hit
+    the issue-#418 failure mode: ``bucket-brigade-core/build.sh`` runs
+    ``uv pip install maturin`` followed by a bare ``maturin develop``
+    invocation, and when ``VIRTUAL_ENV`` is not exported the install
+    sometimes lands in a location that isn't on PATH and isn't
+    ``.venv/bin``. The bare ``maturin develop`` then fails to spawn:
+
+        error: Failed to spawn: `maturin`
+          Caused by: No such file or directory (os error 2)
+
+    Sourcing the venv before ``uv sync``/``build.sh`` exports
+    ``VIRTUAL_ENV`` and puts ``.venv/bin`` on PATH, so the install
+    location is unambiguous and ``maturin`` resolves on the very next
+    line. This was observed twice in a row on alc-9 during the
+    2026-06-11 phase-diagram fill (other hosts in the same batch were
+    unaffected).
+    """
+    text = SCRIPT.read_text()
+    assert "source .venv/bin/activate" in text, (
+        "remote bootstrap must source the venv before uv sync — "
+        "build.sh's `uv pip install maturin` writes to a different "
+        "location and `maturin develop` then fails to spawn (issue #418)."
+    )


### PR DESCRIPTION
## Summary

- Adds `source .venv/bin/activate` between the venv-seed block and `uv sync` in the remote bootstrap heredoc of all 6 launcher scripts.
- Locks the new pattern in place via `tests/test_launch_phase_diagram_ppo.py::test_remote_bootstrap_sources_venv`, mirroring the existing PR #412 assertions for `uv sync --extra rl` and `$HOME/.local/bin`.

## Root cause

Without explicit activation, `bucket-brigade-core/build.sh`'s `uv pip install maturin` occasionally lands in a location that isn't `.venv/bin` and isn't on PATH. The next line in build.sh — bare `maturin develop` — then fails:

```
error: Failed to spawn: maturin
  Caused by: No such file or directory (os error 2)
```

Hit twice in a row on alc-9 during the 2026-06-11 phase-diagram fill (other hosts in the same launch batch were unaffected — flaky, not deterministic). Sourcing the venv exports `VIRTUAL_ENV` and puts `.venv/bin` on PATH, so the install lands deterministically and `maturin` resolves on the next line.

## Launchers updated

- `experiments/scripts/launch_phase_diagram_ppo.sh`
- `experiments/scripts/launch_phase_diagram_fill.sh`
- `experiments/scripts/launch_tier1_sweep.sh`
- `experiments/scripts/launch_ppo_baselines.sh`
- `experiments/scripts/launch_het_ppo_sweep.sh`
- `experiments/scripts/launch_rest_trap_rerun.sh`

## Test plan

- [x] `uv run pytest tests/test_launch_phase_diagram_ppo.py -q` — 11/11 pass (10 prior + 1 new)
- [x] `./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run --skip-connectivity-check` shows `source .venv/bin/activate` in the bootstrap script
- [x] `ruff format` + `ruff check` clean on the changed test file
- [ ] Field-verify on alc-9 (the host that exhibited the flake on 2026-06-11) on the next phase-diagram run

Closes #418