### PR TITLE
fix(launchers): pre-pull guard for untracked sweep outputs (#419)

### DIFF
--- a/experiments/scripts/launch_het_ppo_sweep.sh
+++ b/experiments/scripts/launch_het_ppo_sweep.sh
@@ -255,6 +255,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/experiments/scripts/launch_phase_diagram_fill.sh
+++ b/experiments/scripts/launch_phase_diagram_fill.sh
@@ -229,6 +229,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -318,6 +318,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/experiments/scripts/launch_ppo_baselines.sh
+++ b/experiments/scripts/launch_ppo_baselines.sh
@@ -296,6 +296,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/experiments/scripts/launch_rest_trap_rerun.sh
+++ b/experiments/scripts/launch_rest_trap_rerun.sh
@@ -236,6 +236,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -310,6 +310,52 @@ cd "\$REPO"
 echo "Remote repo: \$REPO"
 
 git fetch origin
+
+# Pre-pull guard (#419): detect untracked sweep-output files that would
+# block \`git pull --ff-only origin main\`. After PR #414 some sweep paths
+# that were untracked on the hosts got committed to main; the next pull
+# then aborts because git refuses to overwrite the host's untracked file
+# with the now-tracked version. Bail loudly with the exact cleanup command
+# pasted in the message — silent auto-delete on a research cluster could
+# erase work-in-progress, and stash-and-pop can drop data if a later step
+# fails. The operator workaround (\`rm -rf <path> && git pull\`) is what
+# this guard prints, so the fix is one paste away.
+STALE_PATHS=(
+    "experiments/p3_specialization/phase_diagram_ppo/"
+    "experiments/p3_specialization/phase_diagram_ppo_v2/"
+    "experiments/p3_specialization/phase_diagram_ppo_longbudget/"
+    "experiments/p3_specialization/tier1_runs/"
+    "experiments/nash/phase_diagram/preview/"
+)
+UNTRACKED_BLOCKERS=()
+for path in "\${STALE_PATHS[@]}"; do
+    if [[ -e "\$path" ]]; then
+        # \`git ls-files --others --exclude-standard\` lists ONLY untracked
+        # files (not ignored, not tracked). Empty output = nothing to clean.
+        while IFS= read -r f; do
+            UNTRACKED_BLOCKERS+=("\$f")
+        done < <(git ls-files --others --exclude-standard -- "\$path")
+    fi
+done
+if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 0 ]]; then
+    echo "ERROR: Found \${#UNTRACKED_BLOCKERS[@]} untracked sweep-output file(s) that may block git pull (#419)." >&2
+    echo "These paths exist locally but were also committed to main; pulling will abort." >&2
+    echo "" >&2
+    echo "Offending files (first 20):" >&2
+    printf "  %s\n" "\${UNTRACKED_BLOCKERS[@]:0:20}" >&2
+    if [[ \${#UNTRACKED_BLOCKERS[@]} -gt 20 ]]; then
+        echo "  ... (\$(( \${#UNTRACKED_BLOCKERS[@]} - 20 )) more)" >&2
+    fi
+    echo "" >&2
+    echo "To proceed, remove the offending sweep-output dirs on this host and re-run:" >&2
+    echo "  rm -rf experiments/p3_specialization/phase_diagram_ppo*" >&2
+    echo "  rm -rf experiments/p3_specialization/tier1_runs" >&2
+    echo "  rm -rf experiments/nash/phase_diagram/preview" >&2
+    echo "" >&2
+    echo "These are gitignored sweep outputs; the .pt + per-cell summaries are already in main." >&2
+    exit 12
+fi
+
 git checkout main
 git pull --ff-only origin main
 

--- a/tests/test_launch_phase_diagram_ppo.py
+++ b/tests/test_launch_phase_diagram_ppo.py
@@ -205,6 +205,49 @@ def test_remote_bootstrap_path_includes_local_bin() -> None:
     )
 
 
+def test_remote_bootstrap_has_pre_pull_untracked_guard() -> None:
+    """The remote bootstrap must check for untracked sweep-output files
+    BEFORE ``git pull --ff-only`` (issue #419).
+
+    After PR #414 some sweep-output paths that were untracked on the
+    cluster hosts got committed to main. The next bootstrap then aborts
+    at ``git pull --ff-only origin main`` with::
+
+        error: The following untracked working tree files would be
+        overwritten by merge:
+            experiments/p3_specialization/phase_diagram_ppo/...
+        Aborting
+
+    Hit on alc-2, alc-4, alc-6 on 2026-06-11 during the 27-cell
+    phase-diagram fill. The fix is a defensive pre-pull guard that
+    detects untracked files under the known sweep-output dirs and bails
+    loudly with the exact cleanup command pasted in the error message,
+    so the operator can fix it in one paste. Auto-delete and
+    stash-and-pop were both rejected as too aggressive / data-lossy on
+    a research cluster.
+
+    The guard lives between ``git fetch origin`` and the ``git checkout
+    main && git pull`` lines inside the REMOTE_BOOTSTRAP heredoc.
+    """
+    text = SCRIPT.read_text()
+    assert "STALE_PATHS=(" in text, (
+        "remote bootstrap must include the pre-pull untracked-files guard — "
+        "without it, `git pull` aborts on stale sweep outputs (#419)."
+    )
+    assert "git ls-files --others --exclude-standard" in text, (
+        "pre-pull guard must use `git ls-files --others --exclude-standard` "
+        "to detect untracked sweep outputs (the canonical 'untracked-but-not-"
+        "ignored' query)."
+    )
+    # And the message must hand the operator the exact cleanup command,
+    # because that's the whole reason we picked the bail-loudly option
+    # over the alternatives (silent auto-delete / stash-and-pop).
+    assert "rm -rf experiments/p3_specialization/phase_diagram_ppo" in text, (
+        "guard error message must paste the canonical `rm -rf` cleanup "
+        "command so the operator can fix it in one paste."
+    )
+
+
 def test_remote_bootstrap_sources_venv() -> None:
     """The remote bootstrap heredoc must invoke ``source .venv/bin/activate``
     after the venv exists, before ``uv sync`` and ``bash build.sh``.


### PR DESCRIPTION
## Summary

- Adds a defensive pre-pull guard to the `REMOTE_BOOTSTRAP` heredoc of all 6 cluster launchers. After `git fetch origin` and before `git checkout main && git pull --ff-only`, the guard enumerates known sweep-output dirs, runs `git ls-files --others --exclude-standard` to find untracked blockers, and bails loudly (exit 12) with the exact `rm -rf` cleanup command pasted into the error message.
- Why bail-loudly (Option A from the issue) rather than stash-and-pop (B) or auto-delete (C): stash-and-pop can silently lose work if a later step fails, and auto-delete on a research cluster could erase in-progress outputs. The operator's manual workaround was already `rm -rf <path> && git pull`; the guard now hands them that exact command.

## Files changed

- `experiments/scripts/launch_phase_diagram_ppo.sh` — guard inserted between `git fetch` and `git checkout main`
- `experiments/scripts/launch_phase_diagram_fill.sh` — same
- `experiments/scripts/launch_tier1_sweep.sh` — same
- `experiments/scripts/launch_ppo_baselines.sh` — same
- `experiments/scripts/launch_het_ppo_sweep.sh` — same
- `experiments/scripts/launch_rest_trap_rerun.sh` — same
- `tests/test_launch_phase_diagram_ppo.py` — regression test asserts the guard text and cleanup command appear in the bootstrap

## Test plan

- [x] `uv run pytest tests/test_launch_phase_diagram_ppo.py` — 12/12 pass (11 existing + 1 new)
- [x] `uv run pytest tests/test_launch_*.py` — 87/87 pass across all 6 launcher test files
- [x] `./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run --skip-connectivity-check` exits 0 and prints a heredoc body containing `STALE_PATHS=(`, `git ls-files --others --exclude-standard`, and `exit 12`
- [x] Verified the same on all 6 launchers (`launch_phase_diagram_fill.sh`, `launch_tier1_sweep.sh`, `launch_ppo_baselines.sh`, `launch_het_ppo_sweep.sh`, `launch_rest_trap_rerun.sh` all need `--host alc-2`; `launch_phase_diagram_ppo.sh` has `DEFAULT_HOST=alc-2`)
- [x] `ruff format` + `ruff check` on `tests/` and `experiments/scripts/` are clean

Closes #419