### PR TITLE
fix(launchers): escape backticks in REMOTE_BOOTSTRAP heredoc comments (#425)

### DIFF
--- a/experiments/scripts/launch_het_ppo_sweep.sh
+++ b/experiments/scripts/launch_het_ppo_sweep.sh
@@ -311,10 +311,10 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 uv sync --extra rl

--- a/experiments/scripts/launch_phase_diagram_fill.sh
+++ b/experiments/scripts/launch_phase_diagram_fill.sh
@@ -285,10 +285,10 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 uv sync

--- a/experiments/scripts/launch_phase_diagram_ppo.sh
+++ b/experiments/scripts/launch_phase_diagram_ppo.sh
@@ -374,14 +374,14 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 # --extra rl is mandatory for this sweep: experiments/p3_specialization/train.py
-# imports torch unconditionally. A bare `uv sync` produces a venv without
+# imports torch unconditionally. A bare \`uv sync\` produces a venv without
 # torch, every cell × seed crashes immediately at import, and the launcher
 # reports "0/7 cells produced metrics" after a few seconds. See
 # launch_ppo_baselines.sh:309 for the matching precedent (PPO baselines also

--- a/experiments/scripts/launch_ppo_baselines.sh
+++ b/experiments/scripts/launch_ppo_baselines.sh
@@ -352,10 +352,10 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 uv sync --extra rl

--- a/experiments/scripts/launch_rest_trap_rerun.sh
+++ b/experiments/scripts/launch_rest_trap_rerun.sh
@@ -292,10 +292,10 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 uv sync

--- a/experiments/scripts/launch_tier1_sweep.sh
+++ b/experiments/scripts/launch_tier1_sweep.sh
@@ -366,10 +366,10 @@ else
     uv venv
     uv pip install pip
 fi
-# Activate the venv so subsequent `uv pip install` and `bash build.sh` see
-# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, `uv pip
-# install maturin` inside build.sh has occasionally landed in a different
-# location and the subsequent bare `maturin develop` call fails with
+# Activate the venv so subsequent \`uv pip install\` and \`bash build.sh\` see
+# VIRTUAL_ENV and write to .venv/bin (issue #418). Without this, \`uv pip
+# install maturin\` inside build.sh has occasionally landed in a different
+# location and the subsequent bare \`maturin develop\` call fails with
 # "Failed to spawn: maturin — No such file or directory".
 source .venv/bin/activate
 uv sync

--- a/tests/test_launch_phase_diagram_ppo.py
+++ b/tests/test_launch_phase_diagram_ppo.py
@@ -248,6 +248,37 @@ def test_remote_bootstrap_has_pre_pull_untracked_guard() -> None:
     )
 
 
+def test_dry_run_does_not_execute_heredoc_backticks_locally() -> None:
+    """Unescaped backticks in REMOTE_BOOTSTRAP comments execute locally at
+    heredoc-read time, leaking pip/maturin output before the plan prints (#425).
+
+    The REMOTE_BOOTSTRAP heredoc opens with ``<<REMOTE_SCRIPT`` (unquoted),
+    so bash command-substitutes backtick content while READING the heredoc
+    on the local machine. The heredoc comments mention shell hints like
+    ``\\`uv pip install pip\\``` to point operators at the right fix — but
+    without escaping, bash actually runs those commands locally as the
+    launcher starts up, polluting --dry-run output with pip/maturin/uv
+    progress before the documented plan banner ever prints.
+
+    This test fails on the buggy state because the leaked pip-install
+    output appears before the plan banner. After escaping the backticks
+    (``\\`uv pip install pip\\```), the dry-run is silent except for the
+    plan.
+    """
+    result = _run(["--dry-run", "--skip-connectivity-check"])
+    assert result.returncode == 0
+    plan_marker = "Phase-diagram PPO sweep launch"
+    plan_start = result.stdout.find(plan_marker)
+    assert plan_start >= 0, f"plan banner not found; stdout={result.stdout!r}"
+    pre_plan = result.stdout[:plan_start] + result.stderr
+    for needle in ("Installed", "Resolved", "maturin", "from bucket_brigade_core"):
+        assert needle not in pre_plan, (
+            f"dry-run leaked {needle!r} before the plan banner — "
+            f"likely an unescaped backtick in REMOTE_BOOTSTRAP (#425).\n"
+            f"pre-plan output:\n{pre_plan[:1000]}"
+        )
+
+
 def test_remote_bootstrap_sources_venv() -> None:
     """The remote bootstrap heredoc must invoke ``source .venv/bin/activate``
     after the venv exists, before ``uv sync`` and ``bash build.sh``.


### PR DESCRIPTION
## Summary

The `REMOTE_BOOTSTRAP` heredoc in 6 launchers opens with `<<REMOTE_SCRIPT` (unquoted), so bash command-substitutes backtick content at **heredoc-read time on the local machine**. Operator-hint comments contained literal backticks around shell commands like `` `uv pip install` ``, `` `bash build.sh` ``, `` `maturin develop` ``, and `` `uv sync` `` — bash was actually executing those commands locally each time a launcher started, polluting `--dry-run` output with pip/maturin/uv progress before the documented plan banner ever printed.

Surfaced by the PR #424 Judge review as a pre-existing latent bug, not introduced by the #419 fix.

## Fix

Escape the backticks as `` \` `` to match the heredoc's existing escaping style for `$` (`\$VAR`). The dollar-sign escapes already defer expansion to the remote; the backslash-backtick escape does the same. No semantic change to the heredoc opener (avoiding the larger refactor of switching to single-quoted `<<'REMOTE_SCRIPT'`).

Lines fixed per launcher (all inside the `REMOTE_BOOTSTRAP` heredoc; each line had 1-2 backtick pairs):

- `launch_phase_diagram_ppo.sh`: lines 377, 378, 380, 384 (5 backtick pairs total)
- `launch_phase_diagram_fill.sh`: lines 288, 289, 291 (4 pairs)
- `launch_tier1_sweep.sh`: lines 369, 370, 372 (4 pairs)
- `launch_ppo_baselines.sh`: lines 355, 356, 358 (4 pairs)
- `launch_het_ppo_sweep.sh`: lines 314, 315, 317 (4 pairs)
- `launch_rest_trap_rerun.sh`: lines 295, 296, 298 (4 pairs)

The previously-escaped backticks (around `git pull --ff-only`, `rm -rf`, `git ls-files --others --exclude-standard`) were already correct and were left untouched.

## Verification

- Before fix: `./experiments/scripts/launch_phase_diagram_ppo.sh --dry-run --skip-connectivity-check` leaks `uv pip install` usage errors, `bash: build.sh: No such file or directory`, `maturin failed`, and an `Installed 16 packages` summary BEFORE the plan banner.
- After fix: dry-run output is clean — first line is the plan banner. Verified across all 6 launchers.

## Test plan

- [x] New regression test `test_dry_run_does_not_execute_heredoc_backticks_locally` asserts the dry-run produces no `Installed`/`Resolved`/`maturin`/`from bucket_brigade_core` leakage before the plan banner
- [x] Test FAILS against the pre-fix state (sanity-checked via `git stash`)
- [x] Test PASSES after the fix
- [x] Full launcher test suite: 88 passed (87 prior + 1 new)
- [x] `ruff format` + `ruff check` clean

Closes #425