### PR TITLE
feat(baselines): reward-scale parity check CLI + manifest for downstream consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Architecture details: [docs/SIMPLIFIED_ARCHITECTURE.md](docs/SIMPLIFIED_ARCHITEC
 
 Fourteen named scenarios live in `bucket-brigade-core/src/scenarios.rs` (the canonical source): `default`, `easy`, `hard`, `trivial_cooperation`, `early_containment`, `greedy_neighbor`, `sparse_heroics`, `rest_trap`, `chain_reaction`, `deceptive_calm`, `overcrowding`, `mixed_motivation`, `minimal_specialization`, `positional_default`. Each isolates a different dynamic — coordination pressure, social dilemma, sparse work, deceptive signaling, etc. See [docs/game_description.md](docs/game_description.md) for narrative descriptions.
 
+**External consumers** (forks, re-bindings, re-implementations, evaluation harnesses): before scoring anything, verify your build is on the canonical reward scale with the seconds-cheap parity check — `python -m bucket_brigade.baselines.parity --all`. See [docs/PARITY.md](docs/PARITY.md).
+
 ## Custom agents
 
 User policies subclass `AgentBase` and implement `act(obs) -> np.ndarray([house_index, mode_flag])`. Examples for each scenario live in `bucket_brigade/agents/scenario_optimal/`. The archetype library (`bucket_brigade/agents/archetypes.py`) gives parameterized starting points (Firefighter, Free Rider, Hero, Coordinator, Liar).

--- a/bucket_brigade/baselines/__init__.py
+++ b/bucket_brigade/baselines/__init__.py
@@ -27,6 +27,11 @@ Currently exports:
 For the **frozen baseline distribution** (archetype pickles, Nash vectors,
 PPO checkpoints shipped with the pip wheel + mirrored to HuggingFace), see
 :mod:`bucket_brigade.baselines.release` (issue #373 / parent epic #365).
+
+For the **reward-scale parity check** that packages
+``SCENARIO_RANDOM_BASELINES`` as an executable check for downstream
+consumers (``python -m bucket_brigade.baselines.parity``), see
+:mod:`bucket_brigade.baselines.parity` (issue #437) and ``docs/PARITY.md``.
 """
 
 from bucket_brigade.baselines.specialist import (

--- a/bucket_brigade/baselines/parity.py
+++ b/bucket_brigade/baselines/parity.py
@@ -1,0 +1,584 @@
+"""Reward-scale parity check for downstream consumers (issue #437).
+
+Motivation: PR #432 found that a downstream harness's headline claim about
+this benchmark did not reproduce repo-natively — the quoted magnitudes were
+~7x larger than repo-native numbers, "consistent with a differently-weighted
+reward configuration". A full study ran to completion on the wrong reward
+scale before a repo-side oracle exposed it. This module converts that class
+of silent, study-invalidating config mismatch into an immediate loud failure
+that costs seconds to run.
+
+It packages the *existing* canonical numbers — no new measurement — as an
+executable check:
+
+1. **Reference manifest** (:func:`build_manifest`): machine-readable, keyed
+   by frozen scenario ID (``bucket_brigade.envs.registry.SCENARIO_VERSIONS``).
+   Each entry carries the canonical uniform-random per-step team reward
+   (mirroring :data:`bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES`),
+   the measurement convention it was derived under, the committed n=1000
+   95% bootstrap CI from the issue #237 derivation logs, and a stable
+   **scenario fingerprint** (sha256 over the resolved
+   :class:`~bucket_brigade.envs.scenarios_generated.Scenario` fields).
+
+2. **Statistical parity check** (:func:`check_scenario` / the CLI): runs a
+   few hundred cheap uniform-random episodes with the documented convention
+   against the caller's installed env and compares the measured per-step
+   team reward to the manifest within a tolerance derived from the committed
+   measurement CI. On mismatch the CLI exits non-zero and prints the
+   observed/expected **ratio** — a #432-style 7x scale error is unmissable.
+
+3. **Fingerprint check**: for consumers that can construct the Python
+   ``Scenario``, the pinned :data:`SCENARIO_FINGERPRINTS` hashes catch
+   scenario *parameter* drift even when the reward scale happens to
+   coincide. In-repo, ``tests/test_parity.py`` recomputes these hashes so a
+   parameter change forces a conscious version-bump decision (see the
+   version-bump policy in :mod:`bucket_brigade.envs.registry`).
+
+Measurement convention (must be reproduced exactly by re-implementations)
+--------------------------------------------------------------------------
+
+* Policy: uniform random over ``MultiDiscrete([num_houses, 2, 2])``
+  (``[house, mode, signal]``; post-#236 signal-as-first-class-action),
+  sampled independently per agent per step.
+* Per-step team reward: total episode team reward (``rewards.sum()``
+  accumulated over all steps and agents) divided by ``env.night`` at done.
+  Episodes run to natural termination (``min_nights`` + no-active-fire
+  rule), NOT a fixed night count.
+* ``num_agents = 4`` (the registry default for frozen IDs).
+* The rollout loop is shared with the calibration path
+  (:func:`bucket_brigade.baselines.per_cell._run_random_episode`) so the
+  check and the canonical derivation cannot drift apart.
+
+Reference derivation: issue #237 post-#236 re-derivation at commit
+``dffe1060``, n=1000 episodes per scenario (200 episodes x 5 seeds 42..46).
+Committed logs: ``experiments/p3_specialization/diagnostics/results/
+issue237_postmerge/``.
+
+Usage
+-----
+
+Run locally — this is a few hundred cheap env episodes (seconds), not
+training. Safe per the CLAUDE.md compute guidelines. ::
+
+    # Check one scenario (exits non-zero on mismatch, with the ratio):
+    python -m bucket_brigade.baselines.parity --scenario-id rest_trap-v1
+
+    # Check every manifest scenario:
+    python -m bucket_brigade.baselines.parity --all
+
+    # Dump the machine-readable reference manifest:
+    python -m bucket_brigade.baselines.parity --manifest
+
+    # More episodes -> tighter check:
+    python -m bucket_brigade.baselines.parity --scenario-id default-v1 \\
+        --episodes 2000
+
+See ``docs/PARITY.md`` for the downstream-consumer workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from bucket_brigade.baselines import SCENARIO_RANDOM_BASELINES
+from bucket_brigade.baselines.per_cell import _run_random_episode, _seeds_for
+from bucket_brigade.envs.registry import (
+    DEFAULT_NUM_AGENTS,
+    get_scenario_by_id,
+    parse_scenario_id,
+)
+from bucket_brigade.envs.scenarios_generated import Scenario
+
+__all__ = [
+    "MANIFEST_VERSION",
+    "DEFAULT_EPISODES",
+    "DEFAULT_SEED",
+    "DEFAULT_Z",
+    "REFERENCE_CI95",
+    "SCENARIO_FINGERPRINTS",
+    "ParityResult",
+    "scenario_fingerprint",
+    "build_manifest",
+    "measure_random_per_step",
+    "check_scenario",
+    "main",
+]
+
+
+# Bump when the manifest schema or any reference value changes, so
+# downstream results can cite "scenario ID + manifest version" (issue #437
+# acceptance criteria / docs/PARITY.md).
+MANIFEST_VERSION: int = 1
+
+# CLI defaults. 500 episodes is a few seconds of pure env stepping and
+# shrinks the observed-side standard error well below the reference CI for
+# every manifest scenario; ``--episodes`` can raise it for a tighter check.
+DEFAULT_EPISODES: int = 500
+DEFAULT_SEED: int = 42
+# Tolerance multiplier: |observed - expected| must be <= z * combined SE
+# (see :func:`check_scenario`). z=3 keeps false alarms rare across the whole
+# 14-scenario manifest while a 7x scale error sits hundreds of SEs out.
+DEFAULT_Z: float = 3.0
+
+# Absolute tolerance floor (reward units per step). Covers the 2-decimal
+# rounding of the published reference means (max 0.005) with margin, and
+# keeps near-deterministic scenarios (trivial_cooperation's reference CI is
+# [399.98, 400.01]) from producing a vacuously tight tolerance.
+_TOLERANCE_FLOOR: float = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Committed reference measurement CIs (issue #237 derivation, n=1000)
+# ---------------------------------------------------------------------------
+#
+# Per-step team-reward 95% bootstrap CIs lifted from the committed issue #237
+# derivation logs (``experiments/p3_specialization/diagnostics/results/
+# issue237_postmerge/<base_name>.log``, "per-step" line, n=1000 episodes,
+# commit ``dffe1060``). These are the same runs that produced
+# ``SCENARIO_RANDOM_BASELINES``; lifting the CIs into code (issue #437) lets
+# the parity tolerance derive from the committed measurement uncertainty
+# instead of a made-up epsilon. Keyed by frozen scenario ID.
+#
+# Drift guard: ``tests/test_parity.py`` asserts each interval contains the
+# corresponding ``SCENARIO_RANDOM_BASELINES`` mean and that the key set
+# aligns with both ``SCENARIO_RANDOM_BASELINES`` and ``SCENARIO_VERSIONS``.
+REFERENCE_CI95: Dict[str, Tuple[float, float]] = {
+    "default-v1": (244.86, 257.51),
+    "easy-v1": (352.07, 358.06),
+    "hard-v1": (118.62, 130.63),
+    "trivial_cooperation-v1": (399.98, 400.01),
+    "early_containment-v1": (292.88, 301.55),
+    "greedy_neighbor-v1": (288.46, 297.13),
+    "sparse_heroics-v1": (240.99, 251.08),
+    "rest_trap-v1": (298.63, 307.07),
+    "chain_reaction-v1": (221.96, 232.70),
+    "deceptive_calm-v1": (72.68, 84.49),
+    "overcrowding-v1": (116.93, 123.42),
+    "mixed_motivation-v1": (218.83, 229.26),
+    "minimal_specialization-v1": (-93.31, -82.16),
+    "positional_default-v1": (244.36, 257.01),
+}
+
+# Reference sample size behind every entry above (episodes per scenario in
+# the issue #237 derivation).
+REFERENCE_N_EPISODES: int = 1000
+
+
+# ---------------------------------------------------------------------------
+# Scenario fingerprints
+# ---------------------------------------------------------------------------
+
+
+def scenario_fingerprint(scenario: Scenario) -> str:
+    """Stable hash of a resolved :class:`Scenario`'s parameters.
+
+    Canonicalizes ``dataclasses.asdict(scenario)`` as compact JSON with
+    sorted keys and returns ``"sha256:<hexdigest>"``. Any single-field
+    change to the resolved scenario (reward weights, fire dynamics, costs,
+    topology, num_agents, shaping knobs, ...) changes the fingerprint.
+
+    Note: this fingerprints the *constructed Python dataclass*, so it is
+    only directly usable by consumers that can build the Python
+    ``Scenario``. Pure re-implementations should verify parameter-by-
+    parameter against their scenario source and rely on the statistical
+    check for end-to-end reward-scale parity.
+    """
+    payload = dataclasses.asdict(scenario)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# Pinned fingerprints of every manifest scenario, computed from
+# ``get_scenario_by_id(<id>, num_agents=4)`` at the commit that landed
+# issue #437. ``tests/test_parity.py`` recomputes these from the live
+# registry: if a scenario's parameters drift, the test fails and forces the
+# registry version-bump decision (frozen IDs must not mutate — see
+# ``bucket_brigade/envs/registry.py``). Downstream consumers compare their
+# constructed scenario's fingerprint against these published values.
+SCENARIO_FINGERPRINTS: Dict[str, str] = {
+    "chain_reaction-v1": (
+        "sha256:f1386042d1618ab5b5429e4290cb9bc435e0643f34d7bc2e279d04e3c5443bf9"
+    ),
+    "deceptive_calm-v1": (
+        "sha256:867f9bd71bcaa68cc4a94f4e5a2c6e4f4e9584d019ac2ead42c9047eb54d4c20"
+    ),
+    "default-v1": (
+        "sha256:d5171b48b046c330fa860d6cb87032d6970f92879375f8623901312af5920fbd"
+    ),
+    "early_containment-v1": (
+        "sha256:8c78037a7730ef8d8f0032465f1cd7d00f9283a1b3dd82c6ea7f5bf2fc5275ae"
+    ),
+    "easy-v1": (
+        "sha256:5d63a61a5cc7b0f3b3dbda0bd040f88985d780674c1f74d32a3eb46eb83216a2"
+    ),
+    "greedy_neighbor-v1": (
+        "sha256:ecf39439a702ac1c70f8d0c5fa42e28912290c9fee93227880cb8a342501711f"
+    ),
+    "hard-v1": (
+        "sha256:48b414edefb5697b806b2a92eeb45fc61e62168736443d6be069ccbde685cce0"
+    ),
+    "minimal_specialization-v1": (
+        "sha256:eb0c93b8d45550d8adea36d499ef2a5994e7d2198de14fc908991b99e61cfc4f"
+    ),
+    "mixed_motivation-v1": (
+        "sha256:c191757e40a194339f20ade84e946c2457f7d3be81f6373470c09cc238f1fb56"
+    ),
+    "overcrowding-v1": (
+        "sha256:70c2da7347a9f41b17dd8f99615020e95dcb409290bea3c6c776adc5a3cd9999"
+    ),
+    "positional_default-v1": (
+        "sha256:9786f49b2480031b59c88fb61bc3c81595aea2e43c4b7424d37dd8651deb75e6"
+    ),
+    "rest_trap-v1": (
+        "sha256:098ba0ed1cb67779bfb3abd4aea769b6de49d827e3c693554284f00feeabcf5f"
+    ),
+    "sparse_heroics-v1": (
+        "sha256:e6f4304bdba5dd444f09ee5a2279e56c1d9353f579d2ebe127dc4783ea84fd21"
+    ),
+    "trivial_cooperation-v1": (
+        "sha256:15a5878e07a1d8d6f5ea75518f39818fd66504783405ecf2b8914f67e6f9e2a4"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def build_manifest() -> Dict[str, object]:
+    """Build the machine-readable parity reference manifest.
+
+    Generated from the existing canonical sources — the baseline means come
+    straight from :data:`SCENARIO_RANDOM_BASELINES`, so the manifest cannot
+    diverge from the single source of truth by construction. Keyed by
+    frozen scenario ID from :data:`SCENARIO_VERSIONS`.
+    """
+    scenarios: Dict[str, object] = {}
+    for scenario_id in sorted(REFERENCE_CI95):
+        base_name, _version = parse_scenario_id(scenario_id)
+        lo, hi = REFERENCE_CI95[scenario_id]
+        scenarios[scenario_id] = {
+            "base_name": base_name,
+            "random_per_step_team": SCENARIO_RANDOM_BASELINES[base_name],
+            "ci95": [lo, hi],
+            "n_episodes": REFERENCE_N_EPISODES,
+            "scenario_fingerprint": SCENARIO_FINGERPRINTS[scenario_id],
+        }
+    return {
+        "manifest_version": MANIFEST_VERSION,
+        "measurement_convention": {
+            "policy": "uniform_random",
+            "action_layout": "[house, mode, signal]",
+            "sampler": (
+                "MultiDiscrete([num_houses, 2, 2]) uniform, sampled "
+                "independently per agent per step (post-#236 signal-as-"
+                "first-class-action)"
+            ),
+            "per_step_normalization": (
+                "total episode team reward (rewards.sum() over all agents "
+                "and steps) / env.night at natural episode termination"
+            ),
+            "num_agents": DEFAULT_NUM_AGENTS,
+            "n_episodes": REFERENCE_N_EPISODES,
+            "seeds": "42..46 (200 episodes per seed)",
+            "source_commit": "dffe1060",
+            "provenance": (
+                "issue #237 post-#236 re-derivation; committed logs under "
+                "experiments/p3_specialization/diagnostics/results/"
+                "issue237_postmerge/"
+            ),
+        },
+        "fingerprint_convention": {
+            "algorithm": (
+                "sha256 over json.dumps(dataclasses.asdict(scenario), "
+                "sort_keys=True, separators=(',', ':')) of the Scenario "
+                "resolved via get_scenario_by_id(scenario_id, num_agents=4)"
+            ),
+            "num_agents": DEFAULT_NUM_AGENTS,
+        },
+        "scenarios": scenarios,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Statistical parity check
+# ---------------------------------------------------------------------------
+
+
+def measure_random_per_step(
+    scenario: Scenario, n_episodes: int, seed: int
+) -> np.ndarray:
+    """Per-episode per-step team rewards for uniform-random play.
+
+    Uses the exact rollout loop shared with the calibration path
+    (:func:`bucket_brigade.baselines.per_cell._run_random_episode`) and the
+    same deterministic per-episode seed derivation, so results are
+    reproducible for a given ``(scenario, n_episodes, seed)``.
+    """
+    if n_episodes < 2:
+        raise ValueError("n_episodes must be >= 2 to estimate a standard error")
+    seeds = _seeds_for(seed, n_episodes)
+    return np.asarray([_run_random_episode((scenario, s)) for s in seeds])
+
+
+@dataclass(frozen=True)
+class ParityResult:
+    """Outcome of a single-scenario parity check."""
+
+    scenario_id: str
+    expected: float
+    observed: float
+    ratio: float
+    diff: float
+    tolerance: float
+    z: float
+    n_episodes: int
+    seed: int
+    reward_ok: bool
+    fingerprint_expected: str
+    fingerprint_observed: str
+    fingerprint_ok: bool
+
+    @property
+    def passed(self) -> bool:
+        return self.reward_ok and self.fingerprint_ok
+
+    def to_dict(self) -> Dict[str, object]:
+        d = dataclasses.asdict(self)
+        d["passed"] = self.passed
+        return d
+
+    def summary(self) -> str:
+        """One-line human-readable verdict (the ratio is load-bearing)."""
+        if self.reward_ok:
+            head = f"PARITY OK   {self.scenario_id}:"
+            tail = (
+                f"|diff| {abs(self.diff):.2f} <= tolerance {self.tolerance:.2f} "
+                f"(z={self.z:g}, n={self.n_episodes})"
+            )
+        else:
+            head = f"PARITY FAIL {self.scenario_id}:"
+            tail = (
+                f"|diff| {abs(self.diff):.2f} > tolerance {self.tolerance:.2f} "
+                f"(z={self.z:g}, n={self.n_episodes}). Your build/binding is "
+                "likely on a different reward scale than the canonical "
+                "scenario (see docs/PARITY.md and PR #432 for the motivating "
+                "7x incident)."
+            )
+        line = (
+            f"{head} observed per-step random team reward {self.observed:.2f} "
+            f"vs expected {self.expected:.2f} — observed/expected ratio = "
+            f"{self.ratio:.3f}; {tail}"
+        )
+        if not self.fingerprint_ok:
+            line += (
+                f"\nFINGERPRINT MISMATCH {self.scenario_id}: constructed "
+                f"scenario hash {self.fingerprint_observed} != manifest "
+                f"{self.fingerprint_expected} — scenario parameters differ "
+                "from the frozen definition even if the reward scale "
+                "coincides."
+            )
+        return line
+
+
+def check_scenario(
+    scenario_id: str,
+    n_episodes: int = DEFAULT_EPISODES,
+    seed: int = DEFAULT_SEED,
+    z: float = DEFAULT_Z,
+    scenario: Optional[Scenario] = None,
+) -> ParityResult:
+    """Run the reward-scale parity check for one frozen scenario ID.
+
+    Tolerance policy: the reference side contributes a standard error
+    recovered from the committed n=1000 95% bootstrap CI
+    (``SE_ref = half_width / 1.96``); the observed side contributes its own
+    sample standard error (``sample std / sqrt(n)``). The check passes when
+    ``|observed - expected| <= max(z * sqrt(SE_ref^2 + SE_obs^2), 0.05)``.
+    Raising ``n_episodes`` shrinks the observed-side term (issue #437 risk
+    mitigation for false alarms on legitimate RNG variation).
+
+    Args:
+        scenario_id: Frozen ID present in the manifest, e.g. ``rest_trap-v1``.
+        n_episodes: Uniform-random episodes to roll out (seconds-cheap).
+        seed: Base seed for the deterministic per-episode seed derivation.
+        z: Tolerance multiplier on the combined standard error.
+        scenario: Optional pre-constructed scenario override. Used by tests
+            to inject a perturbed scenario; normal callers omit it so the
+            check exercises the registry construction path end-to-end.
+
+    Returns:
+        :class:`ParityResult` with both the statistical verdict and the
+        fingerprint verdict.
+
+    Raises:
+        KeyError: If ``scenario_id`` is not in the parity manifest.
+    """
+    if scenario_id not in REFERENCE_CI95:
+        available = ", ".join(sorted(REFERENCE_CI95))
+        raise KeyError(
+            f"Scenario ID {scenario_id!r} is not in the parity manifest. "
+            f"Available IDs: {available}"
+        )
+    base_name, _version = parse_scenario_id(scenario_id)
+    expected = float(SCENARIO_RANDOM_BASELINES[base_name])
+    if scenario is None:
+        scenario = get_scenario_by_id(scenario_id, num_agents=DEFAULT_NUM_AGENTS)
+
+    fingerprint_observed = scenario_fingerprint(scenario)
+    fingerprint_expected = SCENARIO_FINGERPRINTS[scenario_id]
+    fingerprint_ok = fingerprint_observed == fingerprint_expected
+
+    values = measure_random_per_step(scenario, n_episodes=n_episodes, seed=seed)
+    observed = float(values.mean())
+
+    lo, hi = REFERENCE_CI95[scenario_id]
+    se_ref = (hi - lo) / 2.0 / 1.96
+    se_obs = float(values.std(ddof=1)) / math.sqrt(n_episodes)
+    tolerance = max(z * math.sqrt(se_ref**2 + se_obs**2), _TOLERANCE_FLOOR)
+
+    diff = observed - expected
+    # All manifest baselines are far from zero (|expected| >= 78), so the
+    # ratio is always well-defined; guard anyway for future entries.
+    ratio = observed / expected if expected != 0.0 else float("inf")
+
+    return ParityResult(
+        scenario_id=scenario_id,
+        expected=expected,
+        observed=observed,
+        ratio=ratio,
+        diff=diff,
+        tolerance=tolerance,
+        z=z,
+        n_episodes=n_episodes,
+        seed=seed,
+        reward_ok=abs(diff) <= tolerance,
+        fingerprint_expected=fingerprint_expected,
+        fingerprint_observed=fingerprint_observed,
+        fingerprint_ok=fingerprint_ok,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m bucket_brigade.baselines.parity",
+        description=(
+            "Reward-scale parity check: verify that this build/binding of "
+            "Bucket Brigade is on the canonical reward scale by comparing "
+            "a cheap uniform-random rollout against the committed reference "
+            "manifest. Exits non-zero (with the observed/expected ratio) on "
+            "mismatch. Seconds-cheap; safe to run locally."
+        ),
+    )
+    parser.add_argument(
+        "--scenario-id",
+        action="append",
+        default=None,
+        metavar="ID",
+        help=(
+            "Frozen scenario ID to check (repeatable), e.g. rest_trap-v1. "
+            "See --manifest for the full list."
+        ),
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Check every scenario in the manifest.",
+    )
+    parser.add_argument(
+        "--episodes",
+        type=int,
+        default=DEFAULT_EPISODES,
+        help=f"Uniform-random episodes per scenario (default {DEFAULT_EPISODES}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"Base seed for episode seed derivation (default {DEFAULT_SEED}).",
+    )
+    parser.add_argument(
+        "--z",
+        type=float,
+        default=DEFAULT_Z,
+        help=f"Tolerance multiplier on the combined SE (default {DEFAULT_Z}).",
+    )
+    parser.add_argument(
+        "--manifest",
+        action="store_true",
+        help="Print the machine-readable reference manifest as JSON and exit.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit per-scenario results as JSON instead of text lines.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns 0 iff every requested check passed."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.manifest:
+        print(json.dumps(build_manifest(), indent=2, sort_keys=True))
+        return 0
+
+    if args.all:
+        scenario_ids = sorted(REFERENCE_CI95)
+    elif args.scenario_id:
+        scenario_ids = list(args.scenario_id)
+    else:
+        parser.error("provide --scenario-id ID (repeatable), --all, or --manifest")
+
+    results: List[ParityResult] = []
+    for scenario_id in scenario_ids:
+        try:
+            result = check_scenario(
+                scenario_id,
+                n_episodes=args.episodes,
+                seed=args.seed,
+                z=args.z,
+            )
+        except KeyError as exc:
+            print(f"ERROR: {exc.args[0]}", file=sys.stderr)
+            return 2
+        results.append(result)
+        if not args.json:
+            print(result.summary())
+
+    if args.json:
+        print(json.dumps([r.to_dict() for r in results], indent=2))
+
+    failed = [r for r in results if not r.passed]
+    if failed:
+        ratios = ", ".join(
+            f"{r.scenario_id}: observed/expected = {r.ratio:.3f}" for r in failed
+        )
+        print(
+            f"PARITY CHECK FAILED for {len(failed)}/{len(results)} "
+            f"scenario(s) — {ratios}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bucket_brigade/envs/registry.py
+++ b/bucket_brigade/envs/registry.py
@@ -71,6 +71,7 @@ from .scenarios_generated import (
     default_scenario,
     deceptive_calm_scenario,
     early_containment_scenario,
+    easy_scenario,
     greedy_neighbor_scenario,
     hard_scenario,
     minimal_specialization_scenario,
@@ -123,6 +124,10 @@ _ScenarioFactory = Callable[[int], Scenario]
 SCENARIO_VERSIONS: Dict[str, _ScenarioFactory] = {
     # Default-family scenarios (covered by most diagnostic suites).
     "default-v1": default_scenario,
+    # ``easy-v1`` added by issue #437 so every scenario with a canonical
+    # random baseline (``SCENARIO_RANDOM_BASELINES``) has a frozen ID the
+    # parity manifest can key on. New ``-v1`` entries never require a bump.
+    "easy-v1": easy_scenario,
     "hard-v1": hard_scenario,
     # Named test scenarios from ``definitions/scenarios.json``.
     "trivial_cooperation-v1": trivial_cooperation_scenario,

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,0 +1,108 @@
+# Verifying Reward-Scale Parity
+
+**If you consume Bucket Brigade outside this repo — a fork, a re-binding, a
+re-implementation, or an external evaluation harness — run the parity check
+before scoring anything.**
+
+## Why
+
+PR #432 documented the motivating incident: a downstream harness ran a full
+study of this benchmark and drew conclusions from numbers that were **~7x**
+larger than repo-native values — a differently-weighted reward
+configuration. Nothing failed loudly; the mismatch was only exposed later by
+a dedicated repo-side oracle. Results about Bucket Brigade produced
+off-scale are worse than no results.
+
+The parity check converts that class of silent config mismatch into an
+immediate, loud, seconds-cheap failure.
+
+## What it checks
+
+1. **Reward scale (statistical)** — rolls out a few hundred uniform-random
+   episodes against your installed env and compares the measured per-step
+   team reward to the canonical reference
+   (`bucket_brigade.baselines.SCENARIO_RANDOM_BASELINES`, derived at n=1000
+   episodes per scenario under issue #237). Tolerance is derived from the
+   committed measurement CI, not a made-up epsilon.
+2. **Scenario parameters (fingerprint)** — hashes the resolved `Scenario`
+   dataclass and compares against the pinned manifest fingerprint. This
+   catches parameter drift even when the reward scale happens to coincide.
+
+## How to run
+
+Seconds-cheap (a few hundred pure env episodes, no training, no Nash
+computation) — safe to run locally per the CLAUDE.md compute guidelines.
+
+```bash
+# One scenario:
+python -m bucket_brigade.baselines.parity --scenario-id rest_trap-v1
+
+# Every manifest scenario (~20 seconds):
+python -m bucket_brigade.baselines.parity --all
+
+# Tighter check / machine-readable output:
+python -m bucket_brigade.baselines.parity --scenario-id default-v1 \
+    --episodes 2000 --json
+```
+
+Pass looks like:
+
+```
+PARITY OK   rest_trap-v1: observed per-step random team reward 301.07 vs
+expected 302.87 — observed/expected ratio = 0.994; |diff| 1.80 <= tolerance
+11.91 (z=3, n=500)
+```
+
+A #432-class mismatch looks like (non-zero exit code):
+
+```
+PARITY FAIL default-v1: observed per-step random team reward 1725.71 vs
+expected 251.23 — observed/expected ratio = 6.869; |diff| 1474.48 > tolerance
+17.93 (z=3, n=500). Your build/binding is likely on a different reward scale
+than the canonical scenario (see docs/PARITY.md and PR #432 for the
+motivating 7x incident).
+```
+
+Exit codes: `0` all checks passed, `1` parity or fingerprint mismatch,
+`2` usage error (e.g. unknown scenario ID).
+
+## The reference manifest
+
+```bash
+python -m bucket_brigade.baselines.parity --manifest > parity_manifest.json
+```
+
+The manifest is keyed by **frozen scenario ID**
+(`bucket_brigade/envs/registry.py`; e.g. `rest_trap-v1`) and carries, per
+scenario: the canonical uniform-random per-step team reward, its n=1000 95%
+bootstrap CI, and the scenario fingerprint. A top-level
+`measurement_convention` block records exactly how the reference numbers
+were measured. Drift guards in `tests/test_parity.py` keep the manifest
+aligned with `SCENARIO_RANDOM_BASELINES` and `SCENARIO_VERSIONS`.
+
+## For re-implementations (no Python `Scenario` available)
+
+Reproduce the measurement convention from the manifest and compare your own
+measurement against `random_per_step_team`:
+
+- Policy: uniform random over `MultiDiscrete([num_houses, 2, 2])`
+  (`[house, mode, signal]`), sampled independently per agent per step,
+  `num_agents = 4`.
+- Per-step team reward: total episode team reward (summed over all agents
+  and all steps) divided by the number of nights actually played
+  (`env.night` at termination — episodes end naturally via the
+  `min_nights` + no-active-fire rule, **not** at a fixed night count).
+- A few hundred episodes puts your standard error well inside the
+  manifest CI; anything like a 2x (let alone 7x) ratio is unmissable.
+
+The fingerprint check additionally requires constructing the Python
+`Scenario` (`bucket_brigade.baselines.parity.scenario_fingerprint`); pure
+re-implementations should instead verify scenario parameters field-by-field
+against `definitions/scenarios.json` / `bucket-brigade-core/src/scenarios.rs`.
+
+## Reporting results
+
+When publishing numbers about this benchmark, cite the **frozen scenario ID**
+(e.g. `rest_trap-v1`, never just "rest_trap") and the **manifest version**
+(`manifest_version` in the manifest JSON, currently 1), and state that the
+parity check passed on the build that produced your results.

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,334 @@
+"""Tests for the reward-scale parity check (issue #437).
+
+Three families of guarantees:
+
+1. **Drift guards**: the parity manifest is keyed by frozen scenario IDs
+   and generated from the canonical sources, so its keys/values must stay
+   aligned with ``SCENARIO_RANDOM_BASELINES`` and ``SCENARIO_VERSIONS``
+   (same pattern as ``tests/test_baselines_constants.py``), and the pinned
+   ``SCENARIO_FINGERPRINTS`` must match hashes recomputed from the live
+   registry — a scenario-parameter change fails here and forces the
+   registry version-bump decision.
+
+2. **Falsification** (the #432-class scenario): a 7x scaling of every
+   reward/cost weight must make the CLI exit non-zero with the
+   observed/expected ratio in the failure output.
+
+3. **Fingerprint sensitivity**: a single-field scenario parameter change
+   must flip the fingerprint verdict even when run against an otherwise
+   healthy env.
+
+Rollouts here are deliberately tiny (tens to low hundreds of pure-Python
+env episodes, fixed seeds — deterministic and seconds-cheap; safe per the
+CLAUDE.md compute guidelines).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+
+import pytest
+
+from bucket_brigade.baselines import SCENARIO_RANDOM_BASELINES
+from bucket_brigade.baselines import parity
+from bucket_brigade.baselines.parity import (
+    REFERENCE_CI95,
+    SCENARIO_FINGERPRINTS,
+    build_manifest,
+    check_scenario,
+    main,
+    scenario_fingerprint,
+)
+from bucket_brigade.envs.registry import (
+    SCENARIO_VERSIONS,
+    get_scenario_by_id,
+    parse_scenario_id,
+)
+from bucket_brigade.envs.scenarios_generated import Scenario
+
+
+def _scale_reward_weights(scenario: Scenario, factor: float) -> Scenario:
+    """Scale every reward/penalty/cost weight by ``factor``.
+
+    Fire dynamics and topology are untouched, so trajectories are
+    identical and the per-step team reward scales by exactly ``factor`` —
+    the cleanest model of the PR #432 "differently-weighted reward
+    configuration" incident.
+    """
+    return dataclasses.replace(
+        scenario,
+        team_reward_house_survives=scenario.team_reward_house_survives * factor,
+        team_penalty_house_burns=scenario.team_penalty_house_burns * factor,
+        reward_own_house_survives=[
+            v * factor for v in scenario.reward_own_house_survives
+        ],
+        reward_other_house_survives=[
+            v * factor for v in scenario.reward_other_house_survives
+        ],
+        penalty_own_house_burns=[v * factor for v in scenario.penalty_own_house_burns],
+        penalty_other_house_burns=[
+            v * factor for v in scenario.penalty_other_house_burns
+        ],
+        cost_to_work_one_night=scenario.cost_to_work_one_night * factor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest drift guards
+# ---------------------------------------------------------------------------
+
+
+class TestManifestDriftGuards:
+    def test_manifest_ids_are_frozen_registry_ids(self) -> None:
+        """Every parity entry must be keyed by an ID in SCENARIO_VERSIONS."""
+        unknown = sorted(set(REFERENCE_CI95) - set(SCENARIO_VERSIONS))
+        assert not unknown, (
+            f"Parity manifest references scenario IDs absent from the frozen "
+            f"registry: {unknown}. The manifest must be keyed by "
+            "SCENARIO_VERSIONS IDs."
+        )
+
+    def test_manifest_covers_every_canonical_random_baseline(self) -> None:
+        """Base names must be exactly the SCENARIO_RANDOM_BASELINES keys.
+
+        One parity entry per canonical random baseline — no extras, no
+        gaps. (``easy-v1`` was added to the registry by #437 to close the
+        one gap; ``v2_minimal-v1`` has no canonical random baseline and is
+        correctly absent.)
+        """
+        manifest_bases = {parse_scenario_id(sid)[0] for sid in REFERENCE_CI95}
+        assert manifest_bases == set(SCENARIO_RANDOM_BASELINES), (
+            "Parity manifest base names diverge from SCENARIO_RANDOM_BASELINES: "
+            f"missing={sorted(set(SCENARIO_RANDOM_BASELINES) - manifest_bases)}, "
+            f"extra={sorted(manifest_bases - set(SCENARIO_RANDOM_BASELINES))}."
+        )
+
+    def test_manifest_values_mirror_scenario_random_baselines(self) -> None:
+        """Manifest baselines must equal the single-source-of-truth table."""
+        manifest = build_manifest()
+        scenarios = manifest["scenarios"]
+        assert isinstance(scenarios, dict)
+        for scenario_id, entry in scenarios.items():
+            base = entry["base_name"]
+            assert entry["random_per_step_team"] == SCENARIO_RANDOM_BASELINES[base], (
+                f"{scenario_id}: manifest baseline "
+                f"{entry['random_per_step_team']!r} disagrees with "
+                f"SCENARIO_RANDOM_BASELINES[{base!r}] = "
+                f"{SCENARIO_RANDOM_BASELINES[base]!r}."
+            )
+
+    def test_reference_ci_contains_canonical_mean(self) -> None:
+        """Each committed n=1000 CI must bracket its canonical mean —
+        catches transcription errors in the lifted CI endpoints."""
+        for scenario_id, (lo, hi) in REFERENCE_CI95.items():
+            base, _ = parse_scenario_id(scenario_id)
+            mean = SCENARIO_RANDOM_BASELINES[base]
+            assert lo < hi, f"{scenario_id}: degenerate CI [{lo}, {hi}]"
+            assert lo <= mean <= hi, (
+                f"{scenario_id}: canonical mean {mean} outside the committed "
+                f"reference CI [{lo}, {hi}] — transcription error in "
+                "REFERENCE_CI95?"
+            )
+
+    def test_pinned_fingerprints_match_live_registry(self) -> None:
+        """Recompute every pinned fingerprint from the live registry.
+
+        A mismatch means a frozen scenario's parameters drifted: per the
+        registry version-bump policy that requires a NEW ``-vN`` ID, not a
+        silent mutation of the old one.
+        """
+        assert set(SCENARIO_FINGERPRINTS) == set(REFERENCE_CI95)
+        for scenario_id, pinned in SCENARIO_FINGERPRINTS.items():
+            live = scenario_fingerprint(get_scenario_by_id(scenario_id))
+            assert live == pinned, (
+                f"{scenario_id}: live scenario fingerprint {live} != pinned "
+                f"{pinned}. Frozen scenario parameters changed — this "
+                "requires a new -vN registry entry (see "
+                "bucket_brigade/envs/registry.py version-bump policy), not "
+                "an in-place edit."
+            )
+
+    def test_manifest_is_json_serializable_with_convention(self) -> None:
+        manifest = build_manifest()
+        payload = json.loads(json.dumps(manifest))
+        assert payload["manifest_version"] == parity.MANIFEST_VERSION
+        convention = payload["measurement_convention"]
+        assert convention["policy"] == "uniform_random"
+        assert convention["num_agents"] == 4
+        assert convention["n_episodes"] == 1000
+        assert "MultiDiscrete" in convention["sampler"]
+        assert "env.night" in convention["per_step_normalization"]
+        assert len(payload["scenarios"]) == len(SCENARIO_RANDOM_BASELINES)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint sensitivity
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprint:
+    def test_fingerprint_is_deterministic(self) -> None:
+        a = scenario_fingerprint(get_scenario_by_id("default-v1"))
+        b = scenario_fingerprint(get_scenario_by_id("default-v1"))
+        assert a == b
+        assert a.startswith("sha256:")
+
+    def test_fingerprint_catches_single_field_change(self) -> None:
+        """Acceptance criterion: a single-field parameter change flips the
+        fingerprint (here the #432-adjacent knob, a team-reward weight)."""
+        base = get_scenario_by_id("default-v1")
+        perturbed = dataclasses.replace(
+            base,
+            team_reward_house_survives=base.team_reward_house_survives + 1.0,
+        )
+        assert scenario_fingerprint(perturbed) != scenario_fingerprint(base)
+
+    def test_check_scenario_reports_fingerprint_mismatch(self) -> None:
+        """A parameter change that barely moves the reward scale must still
+        fail the check via the fingerprint verdict."""
+        base = get_scenario_by_id("default-v1")
+        perturbed = dataclasses.replace(base, min_nights=base.min_nights)
+        # Sanity: identical scenario passes the fingerprint side.
+        result = check_scenario("default-v1", n_episodes=10, seed=0, scenario=perturbed)
+        assert result.fingerprint_ok
+
+        drifted = dataclasses.replace(
+            base, cost_to_work_one_night=base.cost_to_work_one_night + 0.01
+        )
+        result = check_scenario("default-v1", n_episodes=10, seed=0, scenario=drifted)
+        assert not result.fingerprint_ok
+        assert not result.passed
+        assert "FINGERPRINT MISMATCH" in result.summary()
+
+
+# ---------------------------------------------------------------------------
+# Statistical parity check
+# ---------------------------------------------------------------------------
+
+
+class TestParityCheck:
+    def test_passes_on_repo_native_env_all_manifest_scenarios(self) -> None:
+        """Acceptance criterion: the check passes on the repo-native env for
+        every manifest scenario, at the CLI defaults (n=500, seed=42) —
+        deterministic, ~20s of pure env stepping for the full sweep.
+        (Smaller n is NOT safe here: heavy-tailed scenarios like ``hard``
+        can legitimately sit >3 combined SEs out at n=150.)"""
+        failures = []
+        for scenario_id in sorted(REFERENCE_CI95):
+            result = check_scenario(scenario_id, n_episodes=500, seed=42)
+            if not result.passed:
+                failures.append(result.summary())
+        assert not failures, "Repo-native parity check failed:\n" + "\n".join(failures)
+
+    def test_fails_on_7x_reward_scale_with_ratio_in_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Acceptance criterion (falsification): inject the PR #432-style 7x
+        reward scaling and assert the CLI exits non-zero with the
+        observed/expected ratio in the error output."""
+        scaled = _scale_reward_weights(get_scenario_by_id("default-v1"), 7.0)
+        monkeypatch.setattr(parity, "get_scenario_by_id", lambda sid, **kw: scaled)
+
+        exit_code = main(["--scenario-id", "default-v1", "--episodes", "60"])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert "PARITY FAIL" in captured.out
+        assert "observed/expected ratio" in captured.out
+        # stderr carries the machine-grep-able failure roll-up with the
+        # ratio; a ~7x scale error must be unmissable in it. (The ratio is
+        # observed/canonical-expected, so at small n it is 7x the run's own
+        # sampling wobble around 1.0 — bound it rather than pin it.)
+        match = re.search(r"observed/expected = (-?\d+\.\d+)", captured.err)
+        assert match is not None, f"no ratio in stderr: {captured.err!r}"
+        assert 6.0 < float(match.group(1)) < 8.0
+
+    def test_check_scenario_scales_with_injected_factor(self) -> None:
+        """Reward-weight scaling leaves trajectories untouched (dynamics
+        depend only on probabilities/actions), so the observed value scales
+        by ~7x against the same-seed unscaled run. Not *exactly* 7x: the
+        env's flat ``+0.5`` rest reward is hardcoded in
+        ``BucketBrigadeEnv._compute_rewards``, not a scenario weight, so it
+        stays at 1x (a sub-1% effect on ``default``)."""
+        scaled = _scale_reward_weights(get_scenario_by_id("default-v1"), 7.0)
+        result = check_scenario("default-v1", n_episodes=60, seed=42, scenario=scaled)
+        unscaled = check_scenario(
+            "default-v1",
+            n_episodes=60,
+            seed=42,
+            scenario=get_scenario_by_id("default-v1"),
+        )
+        assert not result.reward_ok
+        assert not result.passed
+        assert result.observed == pytest.approx(7.0 * unscaled.observed, rel=0.02)
+        # The scaled scenario also trips the fingerprint check.
+        assert not result.fingerprint_ok
+
+    def test_unknown_scenario_id_raises_keyerror(self) -> None:
+        with pytest.raises(KeyError, match="not in the parity manifest"):
+            check_scenario("no_such_scenario-v1", n_episodes=2)
+
+    def test_v2_minimal_is_not_in_manifest(self) -> None:
+        """v2_minimal-v1 is a frozen ID without a canonical random baseline;
+        it must be rejected rather than checked against a wrong yardstick."""
+        with pytest.raises(KeyError):
+            check_scenario("v2_minimal-v1", n_episodes=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_manifest_flag_emits_valid_json(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert main(["--manifest"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["manifest_version"] == parity.MANIFEST_VERSION
+        assert "rest_trap-v1" in payload["scenarios"]
+        entry = payload["scenarios"]["rest_trap-v1"]
+        assert entry["random_per_step_team"] == SCENARIO_RANDOM_BASELINES["rest_trap"]
+        assert entry["scenario_fingerprint"] == SCENARIO_FINGERPRINTS["rest_trap-v1"]
+
+    def test_single_scenario_pass_exit_zero(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert (
+            main(["--scenario-id", "trivial_cooperation-v1", "--episodes", "30"]) == 0
+        )
+        assert "PARITY OK" in capsys.readouterr().out
+
+    def test_json_output_shape(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert (
+            main(
+                [
+                    "--scenario-id",
+                    "trivial_cooperation-v1",
+                    "--episodes",
+                    "30",
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        results = json.loads(capsys.readouterr().out)
+        assert isinstance(results, list) and len(results) == 1
+        record = results[0]
+        assert record["scenario_id"] == "trivial_cooperation-v1"
+        assert record["passed"] is True
+        assert {"expected", "observed", "ratio", "tolerance", "n_episodes"} <= set(
+            record
+        )
+
+    def test_unknown_id_exits_2(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["--scenario-id", "bogus-v1", "--episodes", "5"]) == 2
+        assert "not in the parity manifest" in capsys.readouterr().err
+
+    def test_requires_target_selection(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            main([])
+        assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary

Packages the existing canonical numbers (`SCENARIO_RANDOM_BASELINES`, frozen registry IDs, the committed issue #237 measurement CIs) as an executable reward-scale parity check, so a PR #432-class config mismatch (a downstream harness scored ~7x off the canonical reward scale and only a dedicated repo-side oracle caught it) fails loudly in seconds instead of silently invalidating a study. Purely additive; no new measurement.

## Changes

- **`bucket_brigade/baselines/parity.py`** (new):
  - `build_manifest()` — machine-readable reference manifest keyed by frozen scenario ID, carrying per scenario: the canonical uniform-random per-step team reward (mirrored from `SCENARIO_RANDOM_BASELINES` by construction), the committed n=1000 95% bootstrap CI (lifted from the issue #237 derivation logs into `REFERENCE_CI95`), and a pinned sha256 scenario fingerprint; plus a top-level measurement-convention block (sampler dims, per-step normalization, n, seeds, source commit).
  - `check_scenario()` / CLI `python -m bucket_brigade.baselines.parity` — rolls out a few hundred uniform-random episodes (rollout loop **shared** with `per_cell.py` so the check and the calibration path cannot drift) and compares against the manifest. Tolerance = `max(z * sqrt(SE_ref^2 + SE_obs^2), 0.05)` with `SE_ref` recovered from the committed CI; `--episodes` shrinks the observed side (the issue's false-alarm mitigation). Exits non-zero with the observed/expected **ratio** in the error.
  - `scenario_fingerprint()` + pinned `SCENARIO_FINGERPRINTS` — sha256 over the canonical JSON of the resolved `Scenario` dataclass; catches parameter drift even when the reward scale coincides.
- **`bucket_brigade/envs/registry.py`**: adds `easy-v1` (purely additive `-v1` entry, explicitly allowed without a version bump per the registry policy) so every scenario with a canonical random baseline has a frozen ID the manifest can key on.
- **`tests/test_parity.py`** (new): drift guards + falsification + fingerprint sensitivity (details below).
- **`docs/PARITY.md`** (new) + README pointer + `baselines/__init__.py` docstring pointer.

## Sample invocation

```
$ python -m bucket_brigade.baselines.parity --all        # ~19s, exit 0
PARITY OK   rest_trap-v1: observed per-step random team reward 301.07 vs expected 302.87 — observed/expected ratio = 0.994; |diff| 1.80 <= tolerance 11.91 (z=3, n=500)
... (14/14 OK)

# Under an injected 7x reward-weight scaling (exit 1):
PARITY FAIL default-v1: observed ... — observed/expected ratio = 6.9xx; |diff| ... > tolerance ... Your build/binding is likely on a different reward scale ...
```

`--manifest` dumps the machine-readable reference manifest as JSON; `--json` emits per-scenario results as JSON.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Manifest keyed by frozen scenario ID, generated from / drift-guarded against `SCENARIO_RANDOM_BASELINES` and `SCENARIO_VERSIONS` | ✅ | Manifest values come straight from `SCENARIO_RANDOM_BASELINES` by construction; `TestManifestDriftGuards` asserts key alignment with `SCENARIO_VERSIONS` + `SCENARIO_RANDOM_BASELINES`, CI-brackets-mean, and pinned-fingerprints-match-live-registry |
| CLI passes on repo-native env for all manifest scenarios; demonstrably fails with the scale ratio when reward weights are perturbed (7x injection asserts non-zero exit) | ✅ | `test_passes_on_repo_native_env_all_manifest_scenarios` (all 14 at CLI defaults n=500/seed=42, deterministic); `test_fails_on_7x_reward_scale_with_ratio_in_error` injects a 7x reward-weight scaling via monkeypatch, asserts `main()` returns non-zero and greps the observed/expected ratio (bounded 6..8) from stderr; also verified manually via CLI (exit 0, 14/14 OK, ~19s) |
| Fingerprint check catches a single-field scenario parameter change (tested) | ✅ | `test_fingerprint_catches_single_field_change` (team-reward weight +1.0) and `test_check_scenario_reports_fingerprint_mismatch` (cost +0.01 flips the verdict even when rollouts are omitted from judgment) |
| Docs section tells external consumers how and when to run it | ✅ | `docs/PARITY.md` (when/how, sample pass/fail output, re-implementation convention, cite scenario ID + manifest version) + README Scenarios-section pointer |

## Test Plan

- `pytest tests/test_parity.py tests/test_baselines_constants.py tests/test_env_registry.py` — 91 passed.
- Full suite `pytest tests/ --ignore=tests/test_code_generation.py` — **922 passed, 61 skipped, 4 failed**; all 4 failures (`test_evolution.py` x2, `test_launch_ppo_baselines.py`, `test_launch_tier1_sweep.py`) reproduce identically on `main` with the same venv — pre-existing, unrelated. (`tests/test_code_generation.py` has a pre-existing collection error on main too: `bucket_brigade.agents.archetypes_generated` is not generated in this checkout.)
- `ruff format --check` + `ruff check` clean on all touched files.
- Manual CLI runs: `--all` (exit 0, 19s), `--manifest` (valid JSON).

### Note for reviewer

One interesting find while writing the falsification test: scaling every *scenario* reward/cost weight by 7 scales the measured per-step team reward by ~7 but not exactly — `BucketBrigadeEnv._compute_rewards` has a hardcoded `+0.5` rest reward that is not a scenario weight (sub-1% effect). The test documents this and bounds the ratio instead of pinning it.

Closes #437