### PR TITLE
feat(nash): add --seed-profiles hook to compute_nash.py for seeded DO retries

### DIFF
--- a/experiments/nash/seeds/rest_trap_battery_seeds.json
+++ b/experiments/nash/seeds/rest_trap_battery_seeds.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "specialist_owned_house_firefighter",
+    "description": "Genome mapping of the scripted battery winner 'specialist' (owned-house firefighter x4, 386.60/step, PR #440). Rests unless own house is burning: work intent = 0.2 base + 0.5 own_house_priority bonus = 0.7 > 0.5 signal threshold when own house burns, 0.2 otherwise (altruism 0 means never works off-signal). own_house_priority=1.0 dominates house choice so it targets its own house.",
+    "source": "experiments/p3_specialization/scripted_battery/rest_trap.json (winner: specialist)",
+    "genome": [1.0, 0.2, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  },
+  {
+    "name": "firefighter_any_full_work",
+    "description": "Genome mapping of battery member 'firefighter[any,work=1.00]x4' (384.19/step). Always works (work_tendency=1.0, honesty=1.0), prefers burning houses and burning neighbors over own house.",
+    "source": "experiments/p3_specialization/scripted_battery/rest_trap.json",
+    "genome": [1.0, 1.0, 0.8, 0.3, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+  },
+  {
+    "name": "conditional_firefighter_fire_responsive",
+    "description": "Fire-responsive variant: base work intent 0, but risk_aversion=1.0 scales intent with the burning fraction and altruism=1.0 converts off-signal intent into work probability. Approximates 'work only when fires exist somewhere'.",
+    "source": "diversity seed (approximates firefighter[any] conditional behavior)",
+    "genome": [1.0, 0.0, 0.8, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+  },
+  {
+    "name": "always_rest",
+    "description": "Genome mapping of battery member 'always_rest' (288.55/step). Work intent = 0 * (1 - rest_bias=1.0) = 0; signal rest; off-signal work probability = intent * altruism = 0. Never works.",
+    "source": "experiments/p3_specialization/scripted_battery/rest_trap.json",
+    "genome": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+  },
+  {
+    "name": "uniform_random",
+    "description": "Genome mapping of battery baseline 'uniform' (305.56/step). exploration_rate=1.0 overrides house and mode choice with uniform random every night.",
+    "source": "experiments/p3_specialization/scripted_battery/rest_trap.json",
+    "genome": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 0.5, 0.5]
+  }
+]

--- a/experiments/scripts/compute_nash.py
+++ b/experiments/scripts/compute_nash.py
@@ -33,6 +33,60 @@ from bucket_brigade.agents.archetypes import (
 )
 
 
+# Default initial pool used by DoubleOracle.solve() when no seeds are given.
+# Kept in sync with bucket_brigade/equilibrium/double_oracle.py (solve()).
+DEFAULT_ARCHETYPE_POOL = [
+    ("firefighter", FIREFIGHTER_PARAMS),
+    ("free_rider", FREE_RIDER_PARAMS),
+    ("hero", HERO_PARAMS),
+    ("coordinator", COORDINATOR_PARAMS),
+]
+
+GENOME_LENGTH = 10
+
+
+def load_seed_profiles(path: Path) -> list[tuple[str, np.ndarray]]:
+    """Load seed strategy profiles from a JSON file (issue #445).
+
+    Expected format: a JSON list of objects, each with a ``name`` (str)
+    and a ``genome`` (list of 10 floats in [0, 1]):
+
+        [
+          {"name": "specialist_owned_ff", "genome": [1.0, 0.2, ...]},
+          ...
+        ]
+
+    Returns a list of (name, genome) tuples. Raises ValueError on
+    malformed entries so a bad seeds file fails fast before compute.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    if not isinstance(data, list) or not data:
+        raise ValueError(f"Seed profiles file {path} must be a non-empty JSON list")
+
+    profiles: list[tuple[str, np.ndarray]] = []
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict) or "name" not in entry or "genome" not in entry:
+            raise ValueError(
+                f"Seed profile entry {i} in {path} must be an object with "
+                f"'name' and 'genome' keys, got: {entry!r}"
+            )
+        genome = np.asarray(entry["genome"], dtype=np.float64)
+        if genome.shape != (GENOME_LENGTH,):
+            raise ValueError(
+                f"Seed profile '{entry['name']}' must have a genome of length "
+                f"{GENOME_LENGTH}, got shape {genome.shape}"
+            )
+        if np.any(genome < 0.0) or np.any(genome > 1.0):
+            raise ValueError(
+                f"Seed profile '{entry['name']}' has genome values outside [0, 1]"
+            )
+        profiles.append((str(entry["name"]), genome))
+
+    return profiles
+
+
 def classify_strategy(strategy: np.ndarray) -> str:
     """Classify a strategy into an archetype category."""
     # Extract key parameters
@@ -80,6 +134,7 @@ def compute_nash_equilibrium(
     max_iterations: int = 50,
     epsilon: float = 0.01,
     seed: Optional[int] = 42,
+    seed_profiles_path: Optional[Path] = None,
     verbose: bool = True,
 ):
     """Compute Nash equilibrium using Double Oracle algorithm."""
@@ -105,6 +160,29 @@ def compute_nash_equilibrium(
     print(f"  Seed: {seed}")
     print()
 
+    # Build the initial strategy pool (issue #445: optional seeding).
+    # When --seed-profiles is given, the initial restart population is the
+    # default archetype pool PLUS the seed genomes from the JSON file.
+    # When absent, behavior is identical to the pre-#445 script (the solver
+    # falls back to its own default archetype pool).
+    initial_strategies = None
+    seed_profile_names: list[str] = []
+    if seed_profiles_path is not None:
+        seeds = load_seed_profiles(seed_profiles_path)
+        seed_profile_names = [name for name, _ in seeds]
+        named_pool = list(DEFAULT_ARCHETYPE_POOL) + seeds
+        initial_strategies = [g.copy() for _, g in named_pool]
+
+        print("=" * 80)
+        print(f"Seeded Initial Strategy Pool ({len(named_pool)} strategies)")
+        print("=" * 80)
+        print(f"Seed profiles file: {seed_profiles_path}")
+        for i, (name, genome) in enumerate(named_pool):
+            origin = "archetype" if i < len(DEFAULT_ARCHETYPE_POOL) else "SEED"
+            genome_str = ", ".join(f"{v:.3f}" for v in genome)
+            print(f"  [{i}] ({origin}) {name}: [{genome_str}]")
+        print()
+
     # Create output directory
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -125,7 +203,7 @@ def compute_nash_equilibrium(
 
     # Solve for Nash equilibrium
     start_time = time.time()
-    equilibrium = solver.solve()
+    equilibrium = solver.solve(initial_strategies=initial_strategies)
     elapsed_time = time.time() - start_time
 
     print()
@@ -253,6 +331,12 @@ def compute_nash_equilibrium(
             "max_iterations": max_iterations,
             "epsilon": epsilon,
             "seed": seed,
+            "seed_profiles": {
+                "file": str(seed_profiles_path),
+                "names": seed_profile_names,
+            }
+            if seed_profiles_path is not None
+            else None,
         },
         "equilibrium": {
             "type": equilibrium_type,
@@ -306,6 +390,17 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument(
+        "--seed-profiles",
+        type=Path,
+        default=None,
+        help=(
+            "JSON file of seed strategy profiles to inject into the initial "
+            "Double Oracle strategy pool (issue #445). Format: list of "
+            '{"name": str, "genome": [10 floats in 0..1]} objects. Seeds are '
+            "appended to the default archetype pool."
+        ),
+    )
+    parser.add_argument(
         "--output-dir", type=Path, default=None, help="Output directory"
     )
     parser.add_argument(
@@ -335,6 +430,7 @@ def main():
         max_iterations=args.max_iterations,
         epsilon=args.epsilon,
         seed=args.seed,
+        seed_profiles_path=args.seed_profiles,
         verbose=not args.quiet,
     )
 


### PR DESCRIPTION
## Summary

Adds the minimal seeding mechanism needed for issue #445's seeded double-oracle retry of `rest_trap`: a `--seed-profiles <json>` flag on `experiments/scripts/compute_nash.py` that injects named 10-dim genomes into the initial Double Oracle strategy pool, plus the committed seed file mapping the PR #440 scripted-battery winners onto heuristic genomes.

This PR contains ONLY the seeding hook (launch infrastructure for #445). The remote seeded run is launched from this branch on alc-9; the analysis/results (exploitability bound, post-#240 artifact, anchor reconciliation) land in a follow-up PR per the issue plan, so this PR does not close #445.

## Changes

- `experiments/scripts/compute_nash.py`:
  - `--seed-profiles <json>` CLI flag; loads a JSON list of `{"name", "genome"}` objects with fail-fast validation (length-10, values in [0,1]).
  - When given, the initial pool = default 4-archetype pool + seed genomes, passed via the existing `DoubleOracle.solve(initial_strategies=...)` parameter (same code path `compute_nash_v2.py` already uses in production).
  - The seeded pool is enumerated in the log (index, origin, name, genome) and recorded in `equilibrium.json` under `algorithm.seed_profiles` for provenance.
  - Without the flag, behavior is byte-identical to before (`solve()` still receives `None`).
- `experiments/nash/seeds/rest_trap_battery_seeds.json`: genome mappings of the battery winners — `specialist_owned_house_firefighter` (386.60/step anchor), `firefighter_any_full_work`, `conditional_firefighter_fire_responsive`, `always_rest`, `uniform_random`. Hero/firefighter archetypes for the #442 hero/FF mixture basins are already in the default pool.

## Acceptance Criteria Verification

The issue's acceptance criteria belong to the full run+analysis cycle; this PR covers the enabling hook:

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Seeding mechanism exists for the DO retry | Done | `--seed-profiles` flag wired end-to-end; stub test verifies solve() receives the 9-strategy pool |
| Seeds map battery winners onto DO profile format | Done | Seed file documents each genome mapping against HeuristicAgent semantics (work-intent/signal/mode thresholds) |
| No behavior change without the flag | Done | Stub test asserts `initial_strategies is None` and `algorithm.seed_profiles is null` when flag absent |

## Test Plan

- `ruff check` + `ruff format --check` pass on the edited script.
- Loader unit test: parses the committed seed file into 5 named genomes.
- Stub test (DoubleOracle stubbed out): seeded pool enumeration printed (4 archetypes + 5 seeds), solver receives 9 strategies with the specialist genome at index 4, `equilibrium.json` carries the `seed_profiles` provenance block, and the no-flag path is unchanged.
- End-to-end tiny-budget run (`rest_trap --simulations 20 --max-iterations 1 --seed-profiles ...`) exercised locally; the remote launch on alc-9 (verified log enumeration + iteration 1) is the production validation.

Part of #445 (launch-enabling hook; the run results PR will close the issue).