### PR TITLE
fix(artifacts): regenerate v1 phase_diagram_ppo recalibrated verdict for reproducibility

### DIFF
--- a/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict.json
+++ b/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict.json
@@ -17,7 +17,7 @@
       "cell_specialist_homogeneous": -86.3310368872549,
       "cell_specialist_ne": null,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -35,7 +35,7 @@
       "cell_specialist_homogeneous": -86.3310368872549,
       "cell_specialist_ne": null,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -53,7 +53,7 @@
       "cell_specialist_homogeneous": -28.376003772893775,
       "cell_specialist_ne": -69.00925641672053,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -71,7 +71,7 @@
       "cell_specialist_homogeneous": 31.97455147004955,
       "cell_specialist_ne": -10.883405113930186,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -89,7 +89,7 @@
       "cell_specialist_homogeneous": -86.3310368872549,
       "cell_specialist_ne": null,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -107,7 +107,7 @@
       "cell_specialist_homogeneous": -28.376003772893775,
       "cell_specialist_ne": -69.00925641672053,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     },
     {
@@ -125,7 +125,7 @@
       "cell_specialist_homogeneous": 31.97455147004955,
       "cell_specialist_ne": -10.883405113930186,
       "old_baseline_random": -87.72,
-      "old_baseline_specialist": -22.07,
+      "old_baseline_specialist": -28.38,
       "baseline_source": "per_cell"
     }
   ]

--- a/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict.md
+++ b/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict.md
@@ -5,7 +5,9 @@ Random / Specialist baselines from
 `experiments/nash/phase_diagram/per_cell_baselines.json`. Columns:
 
 * `OLD gap_closed`: original #360 metric — every cell scored against the
-  single canonical MINSPEC_RANDOM = -87.72 / MINSPEC_SPECIALIST = -22.07.
+  single canonical MINSPEC_RANDOM / MINSPEC_SPECIALIST constants (current
+  values: -87.72 / -28.38; the historical n=50 MINSPEC_SPECIALIST was
+  -22.07 prior to the issue #416 n=10k re-derivation).
 * `NEW gap_closed_homogeneous`: per-cell Random→SpecialistPolicy×4 (apples-
   to-apples drop-in for the MINSPEC tradition).
 * `NEW gap_closed_ne`: per-cell Random→1×Hero+3×Firefighter (the heterogeneous

--- a/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict_notes.md
+++ b/experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict_notes.md
@@ -1,0 +1,56 @@
+# Notes — recalibrated_verdict.{json,md} (v1, n=4 sweep)
+
+## Regenerated for reproducibility (issue #461)
+
+The committed `recalibrated_verdict.{json,md}` were originally generated
+before the issue #416 re-derivation of `MINSPEC_SPECIALIST` (−22.07 n=50 →
+−28.38 n=10k) landed in `bucket_brigade/baselines`, so re-running
+`experiments/scripts/recalibrate_phase_diagram_ppo.py` with its defaults
+produced a diff (every row's `old_baseline_specialist` metadata field, plus
+the md header wording). Issue #461 regenerated both artifacts from the
+committed per-seed `cell_*/seed_*/summary.json` files using the current
+script — a pure local re-aggregation, no training re-runs. The artifacts now
+reproduce byte-for-byte from the script (verified by running it twice and
+`cmp`-ing).
+
+**Nothing numeric changed.** The regeneration touched only:
+
+- `old_baseline_specialist`: −22.07 → −28.38 (metadata stamp of the
+  *current* canonical constant, see caveat below), and
+- the md header paragraph, which now spells out the #416 constant history.
+
+All `old_gap_closed_*`, `gap_closed_homogeneous_*`, and `gap_closed_ne_*`
+values, the per-cell baselines, and the ordering-check rankings are
+unchanged, so no conclusions drawn from this table shift.
+
+## Caveat: the OLD gap_closed column is a frozen historical metric
+
+The `OLD gap_closed` column is read **verbatim** from the per-seed
+`summary.json` files, which were written at training time (#360 sweep,
+pre-#416) against the historical `MINSPEC_SPECIALIST = −22.07` (denominator
+65.65). It is *not* recomputed by the script. Verification: for
+`b0.10_k0.10_c0.50`, `trailing5_team_mean_mean = −98.269` gives
+`(−98.269 + 87.72) / 65.65 = −0.16069`, matching the stored
+`old_gap_closed_mean` exactly; the canonical 59.34 denominator would give
+−0.17777.
+
+The `old_baseline_random` / `old_baseline_specialist` fields, by contrast,
+are stamped from the *current* `bucket_brigade.baselines` constants at
+regeneration time. So in this v1 artifact the OLD column's actual historical
+denominator (65.65) differs from the stamped constant (−28.38 → 59.34). This
+is deliberate: the OLD column exists as the original #360 point of
+comparison, and per the #434/#438 precedent the superseded constant is not
+baked back into the tool to force the stamp to match. Treat the OLD column
+as historical context only; the load-bearing columns are the per-cell
+`gap_closed_homogeneous` / `gap_closed_ne` ones, which never depended on the
+MINSPEC constants (`baseline_source = "per_cell"` on every row).
+
+## Status: superseded by the v2 (n=20) sweep for the paper
+
+All current downstream consumers — the workshop paper figure
+(`paper/anvil_pub.bb-workshop.*/figures/src/recalibrated_heatmap.py`),
+`experiments/nash/phase_diagram/entropy_vs_trainability.py`, and
+`experiments/nash/phase_diagram/noise_buydown_precision.py` — read the
+**v2** root (`experiments/p3_specialization/phase_diagram_ppo_v2/`, n=20
+seeds, #420/#443), whose verdict artifacts reproduce byte-for-byte on their
+own. This v1 (n=4) table is retained as the #360/#413 artifact trail.


### PR DESCRIPTION
## Summary

The committed v1 `experiments/p3_specialization/phase_diagram_ppo/recalibrated_verdict.{json,md}` did not reproduce from `experiments/scripts/recalibrate_phase_diagram_ppo.py`: they were generated before the #416 re-derivation of `MINSPEC_SPECIALIST` (−22.07 n=50 → −28.38 n=10k), so a re-run diffed on every row's `old_baseline_specialist` field and the md header. This PR takes the issue's first suggested option — regenerate and commit from current inputs — matching the #438 precedent of a faithful recompute with the canonical constant rather than baking a superseded constant into the artifact (the stale-reference bug class #434 fixed). A companion `recalibrated_verdict_notes.md` documents the constant-drift provenance.

## Changes

- **`recalibrated_verdict.json`**: regenerated via the script's defaults from the committed per-seed `cell_*/seed_*/summary.json` files (pure local re-aggregation, no training). Only change: `old_baseline_specialist` metadata stamp −22.07 → −28.38 on all 7 rows.
- **`recalibrated_verdict.md`**: regenerated; only change is the header paragraph, which now spells out the #416 constant history (this wording already lives in the script from #417).
- **`recalibrated_verdict_notes.md`** (new): documents (1) the #461 regeneration and that nothing numeric changed, (2) the frozen-historical semantics of the `OLD gap_closed` column — read verbatim from training-time summaries computed with the pre-#416 65.65 denominator, arithmetic-verified against `trailing5_team_mean_mean` — versus the current-constant metadata stamp, and (3) v1's superseded-by-v2 status (all live consumers — paper v8 figure script, `entropy_vs_trainability.py`, `noise_buydown_precision.py` — read the v2 root).

## What did NOT change

- All `old_gap_closed_*`, `gap_closed_homogeneous_*`, `gap_closed_ne_*` values, per-cell baselines, and the ordering-check rankings — **no verdict or ranking flips** (the NEW columns never depended on MINSPEC constants; `baseline_source = "per_cell"` on every row).
- `phase_diagram_ppo_v2/` artifacts (already reproduce byte-for-byte; verified untouched).
- The script itself — changing its schema/aggregation would break v2's existing byte-for-byte reproducibility.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| v1 artifacts reproduce from the script | ✅ | Ran the script twice post-regeneration; `cmp` reports both outputs byte-identical to the committed files |
| v2 artifacts unaffected | ✅ | `git status experiments/p3_specialization/phase_diagram_ppo_v2/` clean after runs |
| No silent numeric drift | ✅ | Diff inspected: only `old_baseline_specialist` fields + md header paragraph; gap columns bit-identical |
| Provenance documented | ✅ | New `recalibrated_verdict_notes.md` (follows `tier1_verdict_notes.md` precedent), incl. arithmetic proof the OLD column uses the 65.65 denominator |

## Test Plan

- `experiments/scripts/recalibrate_phase_diagram_ppo.py` run twice; outputs byte-identical (`cmp`) and match the committed artifacts.
- `pytest tests/test_baselines_constants.py` → 11 passed (drift guards on the MINSPEC constants).
- `ruff format --check` + `ruff check` clean on the (untouched) recalibrate script; no Python files modified.

Closes #461