### PR TITLE
docs(engine): document beta inertness in bernoulli mode; add engine-level regression pin

### DIFF
--- a/bucket-brigade-core/src/engine/core.rs
+++ b/bucket-brigade-core/src/engine/core.rs
@@ -272,6 +272,18 @@ impl BucketBrigade {
 
         // 5. Spread phase
         // Fires spread to neighbors (visible next turn)
+        //
+        // Phase-order consequence (issue #458): in the default "bernoulli"
+        // extinguish mode, phase 4 has already ruined every still-BURNING
+        // house, so spread_fires never sees a BURNING source and
+        // `prob_fire_spreads_to_neighbor` (β) is dynamics-inert — it never
+        // gates a spread and draws zero RNG. Only "continuous" mode
+        // (#253), whose burn-out returns early, makes fire spread live.
+        // β still reaches agents as scenario_info[0] (observation.rs), so
+        // it is not dead code. Reordering these phases would change the
+        // dynamics of every bernoulli scenario and invalidate all
+        // committed baselines/NE artifacts; the behavior change is
+        // deliberately deferred — see issue #458.
         self.spread_fires();
 
         // 6. Spontaneous ignition phase

--- a/bucket-brigade-core/src/engine/observation.rs
+++ b/bucket-brigade-core/src/engine/observation.rs
@@ -34,6 +34,12 @@ impl BucketBrigade {
             houses: self.houses.clone(),
             last_actions: self.last_actions.clone(),
             scenario_info: vec![
+                // NOTE (issue #458): β is dynamics-inert in "bernoulli"
+                // extinguish mode (see engine/phases.rs::spread_fires) but
+                // it is LIVE here as a network input — every trained
+                // policy sees it as scenario_info[0]. Do not remove it as
+                // "dead code"; dropping or reordering this entry would
+                // change the observation layout for every trained policy.
                 self.scenario.prob_fire_spreads_to_neighbor,
                 self.scenario.prob_solo_agent_extinguishes_fire,
                 self.scenario.team_reward_house_survives,

--- a/bucket-brigade-core/src/engine/phases.rs
+++ b/bucket-brigade-core/src/engine/phases.rs
@@ -99,6 +99,19 @@ impl BucketBrigade {
     }
 
     pub(super) fn spread_fires(&mut self) {
+        // β-inertness (issue #458): in the default "bernoulli" extinguish
+        // mode this phase is a structural no-op. `burn_out_houses` runs
+        // before this phase in the step order (`engine/core.rs`) and
+        // bernoulli burn-out ruins every still-BURNING house, so the
+        // `houses[house_idx] != 1` guard below skips every house:
+        // `prob_fire_spreads_to_neighbor` never gates a spread and this
+        // phase draws zero RNG (cross-β trajectories are bit-identical
+        // under a shared seed — pinned by tests/test_beta_inertness.py).
+        // Fire spread is only live in "continuous" extinguish mode
+        // (#253), where burn-out returns early and fires persist into
+        // this phase. Do NOT "clean up" β as dead code: it is exposed to
+        // agents as scenario_info[0] (`engine/observation.rs`).
+        //
         // Issue #254: ring length is now `scenario.num_houses` rather than a
         // hardcoded 10. The neighbor wraparound modulo also tracks the
         // scenario value so 2-house and other small-ring topologies wrap
@@ -138,7 +151,11 @@ impl BucketBrigade {
         //   * Bernoulli mode (pre-#253 default): every BURNING house that
         //     wasn't extinguished this step transitions to RUINED. Fires
         //     last exactly one step under the Bernoulli outcome — the
-        //     per-step coin flip is make-or-break.
+        //     per-step coin flip is make-or-break. Structural consequence
+        //     (issue #458): because this phase runs before `spread_fires`,
+        //     no house is ever BURNING when the spread phase executes, so
+        //     `prob_fire_spreads_to_neighbor` is dynamics-inert in this
+        //     mode (see the note on `spread_fires` above).
         //
         //   * Continuous mode: fires persist across steps because the
         //     point of the accumulator is to spread suppression credit

--- a/bucket-brigade-core/src/scenarios.rs
+++ b/bucket-brigade-core/src/scenarios.rs
@@ -371,7 +371,26 @@ pub struct Scenario {
     pub num_houses: u8,
 
     // Fire dynamics
-    pub prob_fire_spreads_to_neighbor: f32, // Probability fire spreads to adjacent house
+    //
+    // NOTE on `prob_fire_spreads_to_neighbor` (β), issue #458: in the
+    // default `"bernoulli"` extinguish mode this parameter is
+    // **dynamics-inert**. The step order in `engine/core.rs` runs the
+    // burn-out phase before the spread phase, and bernoulli burn-out ruins
+    // every still-BURNING house, so `spread_fires` never sees a BURNING
+    // source — β never gates a spread and draws zero RNG (cross-β
+    // trajectories are bit-identical under a shared seed; pinned by
+    // `tests/test_beta_inertness.py`). β only shapes dynamics in the
+    // `"continuous"` extinguish mode (#253), whose burn-out returns early.
+    //
+    // β is NOT dead code, however: it is exposed to every agent as
+    // `scenario_info[0]` (`engine/observation.rs`), so different β values
+    // produce different network inputs for trained policies even in
+    // bernoulli mode. We deliberately do NOT warn when a bernoulli
+    // scenario sets a non-default β — every built-in scenario is
+    // bernoulli-mode with a meaningful-looking β, so a construction-time
+    // warning would fire on all of them. Treat β in bernoulli scenarios
+    // as an observation feature, not a dynamics knob.
+    pub prob_fire_spreads_to_neighbor: f32, // Probability fire spreads to adjacent house (dynamics-inert in bernoulli mode — see note above / #458)
     pub prob_solo_agent_extinguishes_fire: f32, // Probability one agent extinguishes fire
     pub prob_house_catches_fire: f32,       // Probability house catches fire each night
 

--- a/bucket_brigade/envs/bucket_brigade_env.py
+++ b/bucket_brigade/envs/bucket_brigade_env.py
@@ -250,6 +250,12 @@ class BucketBrigadeEnv:
 
         # 5. Spread phase
         # Fires spread to neighbors (visible next turn)
+        # NOTE (issue #458): in the default "bernoulli" extinguish mode,
+        # phase 4 has already ruined every still-burning house, so this
+        # phase is a structural no-op and prob_fire_spreads_to_neighbor
+        # (beta) is dynamics-inert (never gates a spread, draws zero RNG).
+        # Only "continuous" mode (#253) makes fire spread live. Mirrors
+        # the Rust step order in engine/core.rs.
         self._spread_fires()
 
         # 6. Spontaneous ignition phase
@@ -507,6 +513,17 @@ class BucketBrigadeEnv:
         scenario value so 2-house and other small-ring topologies wrap
         correctly. Mirrors the Rust ``engine/phases.rs::spread_fires``
         behavior.
+
+        Beta-inertness (issue #458): in the default ``"bernoulli"``
+        extinguish mode this phase is a structural no-op —
+        ``_burn_out_houses`` runs first and ruins every still-BURNING
+        house, so the BURNING guard below skips every house and
+        ``prob_fire_spreads_to_neighbor`` never gates a spread (zero RNG
+        draws; cross-beta trajectories are bit-identical under a shared
+        seed, pinned by ``tests/test_beta_inertness.py``). Fire spread is
+        only live in ``"continuous"`` extinguish mode (#253). Do NOT
+        remove beta as dead code: it reaches agents as
+        ``scenario_info[0]`` in observations.
         """
         # Burning houses try to ignite their safe neighbors
         for house_idx in range(self.num_houses):

--- a/bucket_brigade/envs/scenarios_generated.py
+++ b/bucket_brigade/envs/scenarios_generated.py
@@ -37,7 +37,16 @@ class Scenario:
     """
 
     # Fire dynamics
-    prob_fire_spreads_to_neighbor: float  # Probability fire spreads to adjacent house
+    #
+    # NOTE (issue #458): ``prob_fire_spreads_to_neighbor`` (beta) is
+    # dynamics-inert in the default ``"bernoulli"`` extinguish mode —
+    # burn-out runs before spread in the step order, so no house is
+    # ever BURNING when the spread phase executes and beta never gates
+    # a spread (zero RNG draws). It only shapes dynamics in
+    # ``"continuous"`` extinguish mode (#253). It is NOT dead code:
+    # agents observe it as ``scenario_info[0]`` (network input). See
+    # bucket-brigade-core/src/scenarios.rs for the canonical note.
+    prob_fire_spreads_to_neighbor: float  # Probability fire spreads to adjacent house (dynamics-inert in bernoulli mode, #458)
     prob_solo_agent_extinguishes_fire: float  # Probability one agent extinguishes fire
     prob_house_catches_fire: float  # Probability house catches fire each night
 

--- a/definitions/scenarios.json
+++ b/definitions/scenarios.json
@@ -1,6 +1,7 @@
 {
   "version": "2.0",
   "note": "Parameter names match Rust implementation (bucket-brigade-core/src/scenarios.rs)",
+  "beta_inertness_note": "Issue #458: prob_fire_spreads_to_neighbor (beta) is dynamics-inert in the default 'bernoulli' extinguish mode — the engine's burn-out phase ruins every still-burning house before the spread phase runs, so beta never gates a spread (same seed + different beta gives bit-identical trajectories; see tests/test_beta_inertness.py). Beta only shapes dynamics when extinguish_mode is 'continuous' (#253). It is NOT dead: agents observe it as scenario_info[0], so it perturbs trained-policy inputs. Do not sweep beta as a dynamics axis in bernoulli-mode grids.",
   "scenarios": {
     "default": {
       "prob_fire_spreads_to_neighbor": 0.25,

--- a/scripts/generate_python.py
+++ b/scripts/generate_python.py
@@ -145,7 +145,16 @@ def generate_scenarios(json_path: Path, output_path: Path):
         """
 
         # Fire dynamics
-        prob_fire_spreads_to_neighbor: float  # Probability fire spreads to adjacent house
+        #
+        # NOTE (issue #458): ``prob_fire_spreads_to_neighbor`` (beta) is
+        # dynamics-inert in the default ``"bernoulli"`` extinguish mode —
+        # burn-out runs before spread in the step order, so no house is
+        # ever BURNING when the spread phase executes and beta never gates
+        # a spread (zero RNG draws). It only shapes dynamics in
+        # ``"continuous"`` extinguish mode (#253). It is NOT dead code:
+        # agents observe it as ``scenario_info[0]`` (network input). See
+        # bucket-brigade-core/src/scenarios.rs for the canonical note.
+        prob_fire_spreads_to_neighbor: float  # Probability fire spreads to adjacent house (dynamics-inert in bernoulli mode, #458)
         prob_solo_agent_extinguishes_fire: float  # Probability one agent extinguishes fire
         prob_house_catches_fire: float  # Probability house catches fire each night
 

--- a/tests/test_beta_inertness.py
+++ b/tests/test_beta_inertness.py
@@ -1,0 +1,209 @@
+"""Regression tests pinning beta-inertness in bernoulli extinguish mode (issue #458).
+
+Mechanism (see ``bucket-brigade-core/src/engine/core.rs`` step order and
+``engine/phases.rs::spread_fires``): in the default ``"bernoulli"``
+extinguish mode the burn-out phase runs before the spread phase and ruins
+every still-BURNING house, so ``spread_fires`` never sees a BURNING source.
+``prob_fire_spreads_to_neighbor`` (beta) therefore never gates a spread and
+draws zero RNG — two rollouts differing only in beta are bit-identical
+under a shared seed.
+
+These tests pin three facts:
+
+1. **Bernoulli inertness (Rust core)**: same seed, different beta =>
+   bit-identical house trajectories and rewards.
+2. **Bernoulli inertness (Python env)**: the pure-Python mirror engine has
+   the same phase order and the same inertness.
+3. **Continuous-mode liveness (Rust core)**: in ``extinguish_mode=
+   "continuous"`` (#253) fires persist into the spread phase, so beta DOES
+   change the dynamics — guarding against a future refactor that makes
+   beta inert everywhere.
+
+Plus the reason beta must not be deleted as "dead code": it is a live
+observation feature (``scenario_info[0]``), so different beta values
+perturb trained-policy network inputs even in bernoulli mode.
+
+Artifact-level pins of the same fact (bit-identical cross-beta phase-diagram
+columns) live in ``tests/test_beta_residuals.py`` / PR #450; this file is
+the engine-level pin.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bucket_brigade.envs import BucketBrigadeEnv
+from bucket_brigade.envs.scenarios_generated import Scenario
+
+pytest.importorskip("bucket_brigade_core")
+import bucket_brigade_core  # noqa: E402
+
+SEED = 20260701
+NUM_AGENTS = 4
+NUM_STEPS = 20
+
+
+def _rust_scenario(beta: float, **overrides) -> "bucket_brigade_core.Scenario":
+    """Rust core scenario with lively fire dynamics and configurable beta."""
+    kwargs = dict(
+        prob_fire_spreads_to_neighbor=beta,
+        prob_solo_agent_extinguishes_fire=0.5,
+        prob_house_catches_fire=0.3,
+        team_reward_house_survives=10.0,
+        team_penalty_house_burns=10.0,
+        cost_to_work_one_night=0.5,
+        min_nights=12,
+        reward_own_house_survives=1.0,
+        reward_other_house_survives=0.0,
+        penalty_own_house_burns=2.0,
+        penalty_other_house_burns=0.0,
+    )
+    kwargs.update(overrides)
+    return bucket_brigade_core.Scenario(**kwargs)
+
+
+def _python_scenario(beta: float) -> Scenario:
+    return Scenario(
+        prob_fire_spreads_to_neighbor=beta,
+        prob_solo_agent_extinguishes_fire=0.5,
+        prob_house_catches_fire=0.3,
+        team_reward_house_survives=10.0,
+        team_penalty_house_burns=10.0,
+        reward_own_house_survives=1.0,
+        reward_other_house_survives=0.0,
+        penalty_own_house_burns=2.0,
+        penalty_other_house_burns=0.0,
+        cost_to_work_one_night=0.5,
+        min_nights=12,
+        num_agents=NUM_AGENTS,
+    )
+
+
+def _fixed_actions(step: int) -> list[list[int]]:
+    """Deterministic mixed work/rest action schedule (same for both envs)."""
+    return [[(step + i) % 10, (step + i) % 2, i % 2] for i in range(NUM_AGENTS)]
+
+
+def _rollout_rust(scenario) -> tuple[list[list[int]], list[list[float]]]:
+    env = bucket_brigade_core.BucketBrigade(scenario, NUM_AGENTS, SEED)
+    houses_trace: list[list[int]] = []
+    rewards_trace: list[list[float]] = []
+    for step in range(NUM_STEPS):
+        rewards, done, _info = env.step(_fixed_actions(step))
+        houses_trace.append(list(env.get_current_state().houses))
+        rewards_trace.append(list(rewards))
+        if done:
+            break
+    return houses_trace, rewards_trace
+
+
+def _rollout_python(scenario: Scenario) -> tuple[list[list[int]], list[list[float]]]:
+    env = BucketBrigadeEnv(scenario=scenario)
+    env.reset(seed=SEED)
+    houses_trace: list[list[int]] = []
+    rewards_trace: list[list[float]] = []
+    for step in range(NUM_STEPS):
+        if env.done:
+            break
+        actions = np.array(_fixed_actions(step), dtype=np.int8)
+        _obs, rewards, dones, _info = env.step(actions)
+        houses_trace.append(env.houses.tolist())
+        rewards_trace.append(rewards.tolist())
+        if bool(np.all(dones)):
+            break
+    return houses_trace, rewards_trace
+
+
+class TestBernoulliBetaInertness:
+    """Same seed + different beta => bit-identical rollouts (bernoulli mode)."""
+
+    def test_rust_core_trajectories_bit_identical_across_beta(self):
+        houses_lo, rewards_lo = _rollout_rust(_rust_scenario(beta=0.05))
+        houses_hi, rewards_hi = _rollout_rust(_rust_scenario(beta=0.95))
+
+        # The rollout must exercise fire dynamics for the pin to mean
+        # anything: at least one house must burn (become RUINED) somewhere.
+        assert any(2 in houses for houses in houses_lo), (
+            "Rollout never produced a ruined house; the inertness pin is vacuous"
+        )
+        assert houses_lo == houses_hi, (
+            "beta changed bernoulli-mode house dynamics — the #458 phase-order "
+            "inertness no longer holds (burn-out no longer shields the spread "
+            "phase). This is a registry-version-level behavior change: every "
+            "committed baseline/NE artifact would be invalidated. See issue #458."
+        )
+        assert rewards_lo == rewards_hi, (
+            "beta changed bernoulli-mode rewards despite identical house "
+            "trajectories — see issue #458"
+        )
+
+    def test_python_env_trajectories_bit_identical_across_beta(self):
+        houses_lo, rewards_lo = _rollout_python(_python_scenario(beta=0.05))
+        houses_hi, rewards_hi = _rollout_python(_python_scenario(beta=0.95))
+
+        assert any(2 in houses for houses in houses_lo), (
+            "Rollout never produced a ruined house; the inertness pin is vacuous"
+        )
+        assert houses_lo == houses_hi, (
+            "beta changed the Python env's bernoulli-mode house dynamics — "
+            "phase-order inertness (issue #458) no longer holds"
+        )
+        assert rewards_lo == rewards_hi
+
+
+class TestContinuousModeBetaLiveness:
+    """Counterexample: beta IS live in continuous extinguish mode (#253).
+
+    With ``extinguish_mode="continuous"`` burn-out returns early, fires
+    persist into the spread phase, and beta gates real spread events. All
+    agents rest so no fire is ever extinguished; with beta=1.0 every fire
+    ignites its safe neighbors while with beta=0.0 none do, so house
+    trajectories must diverge once any fire ignites.
+    """
+
+    def test_rust_core_beta_changes_continuous_mode_dynamics(self):
+        def rollout(beta: float) -> list[list[int]]:
+            scenario = _rust_scenario(
+                beta=beta,
+                extinguish_mode="continuous",
+                suppression_per_worker=0.5,
+            )
+            env = bucket_brigade_core.BucketBrigade(scenario, NUM_AGENTS, SEED)
+            all_rest = [[0, 0, 0] for _ in range(NUM_AGENTS)]
+            trace = []
+            for _ in range(NUM_STEPS):
+                _rewards, done, _info = env.step(all_rest)
+                trace.append(list(env.get_current_state().houses))
+                if done:
+                    break
+            return trace
+
+        houses_none = rollout(beta=0.0)
+        houses_full = rollout(beta=1.0)
+        assert houses_none != houses_full, (
+            "beta had no effect even in continuous extinguish mode — fire "
+            "spread appears to be dead everywhere, not just in bernoulli "
+            "mode (issue #458 documents bernoulli-only inertness)"
+        )
+
+
+class TestBetaIsALiveObservationFeature:
+    """Beta must not be removed as dead code: agents observe it directly."""
+
+    def test_scenario_info_slot0_carries_beta(self):
+        for beta in (0.05, 0.95):
+            env = bucket_brigade_core.BucketBrigade(
+                _rust_scenario(beta=beta), NUM_AGENTS, SEED
+            )
+            obs = env.get_observation(0)
+            assert obs.scenario_info[0] == pytest.approx(beta), (
+                "scenario_info[0] no longer carries "
+                "prob_fire_spreads_to_neighbor — trained-policy observation "
+                "layouts depend on this slot (issue #458)"
+            )
+
+    def test_python_env_observation_carries_beta(self):
+        env = BucketBrigadeEnv(scenario=_python_scenario(beta=0.7))
+        obs = env.reset(seed=SEED)
+        assert obs["scenario_info"][0] == pytest.approx(0.7)

--- a/web/src/utils/browserEngine.ts
+++ b/web/src/utils/browserEngine.ts
@@ -10,7 +10,14 @@ export type HouseState = 0 | 1 | 2; // SAFE, BURNING, RUINED
 
 export interface Scenario {
   // Fire dynamics
-  prob_fire_spreads_to_neighbor: number; // Probability fire spreads to adjacent house
+  //
+  // NOTE (issue #458): prob_fire_spreads_to_neighbor (beta) is
+  // dynamics-inert in this engine — burn_out_houses runs before
+  // spread_fires in the step order and ruins every still-BURNING house,
+  // so beta never gates a spread. (The Rust core's "continuous"
+  // extinguish mode, where beta is live, is not implemented here.)
+  // Beta is NOT dead code: agents observe it as scenario_info[0].
+  prob_fire_spreads_to_neighbor: number; // Probability fire spreads to adjacent house (dynamics-inert, see #458)
   prob_solo_agent_extinguishes_fire: number; // Probability one agent extinguishes fire
   prob_house_catches_fire: number; // Probability house catches fire each night
 
@@ -212,6 +219,11 @@ export class BrowserBucketBrigade {
 
     // 5. Spread phase
     // Fires spread to neighbors (visible next turn)
+    // NOTE (issue #458): phase 4 has already ruined every still-BURNING
+    // house (this engine is bernoulli-only), so this phase is a
+    // structural no-op and prob_fire_spreads_to_neighbor never gates a
+    // spread. Kept for step-order parity with the Rust core, where the
+    // "continuous" extinguish mode makes fire spread live.
     this.spread_fires();
 
     // 6. Spontaneous ignition phase
@@ -254,6 +266,11 @@ export class BrowserBucketBrigade {
   }
 
   private spread_fires(): void {
+    // Beta-inertness (issue #458): burn_out_houses runs before this phase
+    // and ruins every still-BURNING house, so the `!== 1` guard below
+    // skips every house and prob_fire_spreads_to_neighbor never gates a
+    // spread (zero RNG draws). Mirrors the Rust core's bernoulli-mode
+    // behavior (engine/phases.rs::spread_fires).
     const new_houses = [...this.houses];
 
     for (let house_idx = 0; house_idx < 10; house_idx++) {

--- a/web/src/utils/schemas.ts
+++ b/web/src/utils/schemas.ts
@@ -18,7 +18,12 @@ const PerAgentReward = z.union([z.number(), z.array(z.number())]);
 
 export const ScenarioSchema = z.object({
   // Fire dynamics
-  prob_fire_spreads_to_neighbor: z.number().min(0).max(1), // Probability fire spreads to adjacent house
+  // NOTE (issue #458): prob_fire_spreads_to_neighbor (beta) is
+  // dynamics-inert in the default "bernoulli" extinguish mode (burn-out
+  // ruins every burning house before the spread phase runs); it only
+  // shapes dynamics in the Rust core's "continuous" mode. It is still a
+  // live observation feature (scenario_info[0]).
+  prob_fire_spreads_to_neighbor: z.number().min(0).max(1), // Probability fire spreads to adjacent house (dynamics-inert in bernoulli mode, #458)
   prob_solo_agent_extinguishes_fire: z.number().min(0).max(2), // Probability one agent extinguishes fire
   prob_house_catches_fire: z.number().min(0).max(1), // Probability house catches fire each night
 


### PR DESCRIPTION
## Summary

`prob_fire_spreads_to_neighbor` (β) is dynamics-inert in the default `"bernoulli"` extinguish mode: the step order (`engine/core.rs`) runs burn-out before spread, bernoulli burn-out ruins every still-BURNING house, so `spread_fires` never sees a BURNING source — β never gates a spread and draws zero RNG. Cross-β rollouts under a shared seed are bit-identical.

This PR takes the **document + defer** path from the issue's "possible directions" list: it documents the inertness at every code site across all three engines, records why β must NOT be removed as dead code (it is a live observation feature, `scenario_info[0]`), and pins the behavior with an engine-level regression test.

### Why the behavior change is deferred

Reordering phases (spread before burn-out) or making spread act on a pre-burn-out snapshot would change the dynamics of **every** bernoulli-mode scenario — a registry-version event invalidating all committed baselines, NE artifacts, and frozen fingerprints. Substantial prior work already accommodates the inertness as a known property: #442/PR #450 collapsed the sweep β-axis and verified β-inertness bit-exactly on committed profiles, the paper documents it with exact-by-construction caveats, and the phase-diagram runbook carries the replication-pair caveat. Removing the field would likewise be a breaking schema change across the codegen chain (definitions JSON → Python/TS generators) and every committed scenario JSON. If a live-β bernoulli variant is wanted later, it should be an explicit design decision with a version bump — tracked via this issue's record, not smuggled in here. (Downstream rjwalters/thrust#289 should consume the documented status: β is not a dynamics axis in bernoulli grids.)

### Why no runtime warning on non-default β in bernoulli scenarios

Every built-in scenario is bernoulli-mode with a meaningful-looking β (0.05–0.9), so a construction-time warning would fire on all of them and train users to ignore it. β in bernoulli scenarios is an observation feature, not a dynamics knob; this rationale is recorded in the `scenarios.rs` field doc.

## Changes

- **Rust core** (`bucket-brigade-core/src/`):
  - `engine/core.rs`: phase-order consequence note at the spread phase in `step()` (also covers `step_two_phase`, which documents itself as the same body)
  - `engine/phases.rs`: `spread_fires` structural no-op note; `burn_out_houses` bernoulli-bullet consequence note
  - `scenarios.rs`: `prob_fire_spreads_to_neighbor` field doc — inertness mechanism, observation liveness, and the no-warning rationale
  - `engine/observation.rs`: `scenario_info[0]` liveness note so nobody "cleans up" β as fully dead
- **Python env**: `bucket_brigade/envs/bucket_brigade_env.py` step-order note + `_spread_fires` docstring; `scripts/generate_python.py` field-doc template + regenerated `bucket_brigade/envs/scenarios_generated.py` (regeneration verified byte-clean apart from the note)
- **TS browser engine**: `web/src/utils/browserEngine.ts` interface field doc, step-order note, `spread_fires` note (this engine is bernoulli-only, so β is always inert there); `web/src/utils/schemas.ts` field doc
- **Schema docs**: `definitions/scenarios.json` top-level `beta_inertness_note` (consumers only read the `scenarios` key; verified via `tests/test_code_generation.py`)
- **Regression test**: `tests/test_beta_inertness.py` (new) — engine-level pin complementing the artifact-level pin in `tests/test_beta_residuals.py` (PR #450, which checks committed phase-diagram profiles rather than raw engine trajectories):
  1. Rust core, bernoulli: same seed, β=0.05 vs 0.95 → bit-identical houses + rewards (with a non-vacuity guard that the rollout actually burned houses)
  2. Python env: same pin
  3. Rust core, continuous mode (#253): β=0.0 vs 1.0 → trajectories diverge (liveness counterexample guarding against future all-mode inertness)
  4. `scenario_info[0]` carries β in both engines (observation-liveness pin)

## Acceptance Criteria Verification

The issue asked for a design decision among three directions:

| Direction from issue | Decision | Verification |
|-----------|--------|--------------|
| Reorder phases (spread before burn-out) | Deferred, with rationale | Documented in `core.rs` comment + this PR; would invalidate all committed calibration artifacts |
| Document β as continuous-mode-only and drop from bernoulli grids | ✅ Chosen | Notes at all engine code sites + `definitions/scenarios.json`; β-axis already collapsed in sweeps by PR #450 |
| Spread on pre-burn-out snapshot | Deferred (same artifact-invalidation blast radius) | Documented in this PR |
| (implicit) prevent silent recurrence | ✅ | `tests/test_beta_inertness.py` pins the inertness mechanically; any phase-order change now fails loudly with a message referencing #458 |

## Test Plan

- `pytest tests/test_beta_inertness.py` — 5 passed
- `pytest tests/test_code_generation.py tests/test_continuous_extinguish.py tests/test_beta_residuals.py tests/test_environment.py` — 142 passed, 4 skipped
- `cargo test` (bucket-brigade-core) — 174 passed
- `cargo fmt` / `cargo check` clean; `cargo clippy` — only the 2 pre-existing warnings (verified identical on stashed baseline)
- `ruff format` + `ruff check` clean on all touched Python files
- TS changes are comments only (no web toolchain installed locally; nothing type-affecting changed)

Closes #458