### PR TITLE
fix(release): re-sync manifest sha256s for 4 phase-diagram cells overwritten by #420 + add bundle integrity test

### DIFF
--- a/bucket_brigade/baselines/release/freeze.py
+++ b/bucket_brigade/baselines/release/freeze.py
@@ -85,8 +85,15 @@ from .manifest import (
 # real release (the version controls the per-release HF cache subdir
 # in :mod:`.paths`). 0.1.0 -> 0.1.1: annotation-only manifest update for
 # the (kappa=0.90, c=0.50) phase-diagram cells (#459/#466); artifact
-# bytes unchanged.
-DEFAULT_RELEASE_VERSION: str = "0.1.1"
+# bytes unchanged. 0.1.1 -> 0.1.2: manifest-only hash re-sync (#470)
+# for the 4 (c=0.50) phase-diagram cells that #420's full-grid
+# regeneration rewrote after the 0.1.0 freeze; shipped bytes unchanged
+# since #420. NOTE: re-running this freeze script regenerates those
+# cells from the preview sources (restoring the source_parameters /
+# swept_parameters blocks #420 dropped) and clears the full-grid cells
+# #420 added to local/nash/phase_diagram/ — review issue #470 before
+# re-freezing.
+DEFAULT_RELEASE_VERSION: str = "0.1.2"
 
 
 # Default subdirectory layout inside the release bundle. Mirrors the

--- a/bucket_brigade/baselines/release/local/manifest.json
+++ b/bucket_brigade/baselines/release/local/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_version": "0.1.1",
+  "release_version": "0.1.2",
   "release_date": "2026-06-08",
   "source_commit": "9adf1d3a",
   "huggingface_repo": "rjwalters/bucket-brigade-baselines",
@@ -73,36 +73,36 @@
       "name": "phase_diagram_b0.50_k0.50_c0.50",
       "filename": "nash/phase_diagram/b0.50_k0.50_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
-      "sha256": "8f8f5357e6956988db59bfd0526fef4d319b5c6eb00aaf4a1351105383ffbc45",
-      "size_bytes": 1813,
-      "notes": "Phase-diagram cell b0.50_k0.50_c0.50 from alc-2; best converged NE for the (\u03b2, \u03ba, c) point."
+      "sha256": "8800300a10e5dccb2b6568954bb41692fea77d12af62279ee932774713e046a8",
+      "size_bytes": 1561,
+      "notes": "Phase-diagram cell b0.50_k0.50_c0.50 from alc-2; best converged NE for the (\u03b2, \u03ba, c) point. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
     },
     {
       "kind": "nash",
       "name": "phase_diagram_b0.50_k0.90_c0.50",
       "filename": "nash/phase_diagram/b0.50_k0.90_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
-      "sha256": "c8804d73c4f3c935dffb6ef3d40c1437f58655fd512cfad5bd83ecafc6a6aaa2",
-      "size_bytes": 1834,
-      "notes": "Phase-diagram cell b0.50_k0.90_c0.50 from alc-2; best converged NE for the (\u03b2, \u03ba, c) point. Anchor update (#459/#466): this solver-selected profile (hero|FF|FF|FF, solver team_payoff 72.0095, winner's-curse-biased) is an epsilon-NE at epsilon=50, but the FF|hero|hero|FF profile frozen at b0.10_k0.90_c0.50.json (beta-inert, same game) is also an epsilon-NE and decisively better (CRN paired +9.55 +/- 2.73/episode; CRN team payoff 55.36 +/- 3.44 vs 45.80 +/- 3.58). Cite b0.10_k0.90_c0.50.json as this cell's NE anchor; this file is retained unchanged as the historical solver record. See experiments/nash/phase_diagram/exploitability/RESULTS.md."
+      "sha256": "97146cdcc976dbbad2d6891371d26b16171827f8d8dce0b58ed4c040fc91bbab",
+      "size_bytes": 1582,
+      "notes": "Phase-diagram cell b0.50_k0.90_c0.50 from alc-2; best converged NE for the (\u03b2, \u03ba, c) point. Anchor update (#459/#466): this solver-selected profile (hero|FF|FF|FF, solver team_payoff 72.0095, winner's-curse-biased) is an epsilon-NE at epsilon=50, but the FF|hero|hero|FF profile frozen at b0.10_k0.90_c0.50.json (beta-inert, same game) is also an epsilon-NE and decisively better (CRN paired +9.55 +/- 2.73/episode; CRN team payoff 55.36 +/- 3.44 vs 45.80 +/- 3.58). Cite b0.10_k0.90_c0.50.json as this cell's NE anchor; this file is retained unchanged as the historical solver record. See experiments/nash/phase_diagram/exploitability/RESULTS.md. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
     },
     {
       "kind": "nash",
       "name": "phase_diagram_b0.90_k0.50_c0.50",
       "filename": "nash/phase_diagram/b0.90_k0.50_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
-      "sha256": "3793d230ac9fdec556d2385a60d73946ac6259acc874915b99d1db2b70ca1987",
-      "size_bytes": 1813,
-      "notes": "Phase-diagram cell b0.90_k0.50_c0.50 from alc-6; best converged NE for the (\u03b2, \u03ba, c) point."
+      "sha256": "8800300a10e5dccb2b6568954bb41692fea77d12af62279ee932774713e046a8",
+      "size_bytes": 1561,
+      "notes": "Phase-diagram cell b0.90_k0.50_c0.50 from alc-6; best converged NE for the (\u03b2, \u03ba, c) point. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
     },
     {
       "kind": "nash",
       "name": "phase_diagram_b0.90_k0.90_c0.50",
       "filename": "nash/phase_diagram/b0.90_k0.90_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
-      "sha256": "e24855c14bd8710972dd53358265606a689977d29291f6f86d71382f3b61b1ef",
-      "size_bytes": 1834,
-      "notes": "Phase-diagram cell b0.90_k0.90_c0.50 from alc-6; best converged NE for the (\u03b2, \u03ba, c) point. Anchor update (#459/#466): this solver-selected profile (hero|FF|FF|FF, solver team_payoff 72.0095, winner's-curse-biased) is an epsilon-NE at epsilon=50, but the FF|hero|hero|FF profile frozen at b0.10_k0.90_c0.50.json (beta-inert, same game) is also an epsilon-NE and decisively better (CRN paired +9.55 +/- 2.73/episode; CRN team payoff 55.36 +/- 3.44 vs 45.80 +/- 3.58). Cite b0.10_k0.90_c0.50.json as this cell's NE anchor; this file is retained unchanged as the historical solver record. See experiments/nash/phase_diagram/exploitability/RESULTS.md."
+      "sha256": "97146cdcc976dbbad2d6891371d26b16171827f8d8dce0b58ed4c040fc91bbab",
+      "size_bytes": 1582,
+      "notes": "Phase-diagram cell b0.90_k0.90_c0.50 from alc-6; best converged NE for the (\u03b2, \u03ba, c) point. Anchor update (#459/#466): this solver-selected profile (hero|FF|FF|FF, solver team_payoff 72.0095, winner's-curse-biased) is an epsilon-NE at epsilon=50, but the FF|hero|hero|FF profile frozen at b0.10_k0.90_c0.50.json (beta-inert, same game) is also an epsilon-NE and decisively better (CRN paired +9.55 +/- 2.73/episode; CRN team payoff 55.36 +/- 3.44 vs 45.80 +/- 3.58). Cite b0.10_k0.90_c0.50.json as this cell's NE anchor; this file is retained unchanged as the historical solver record. See experiments/nash/phase_diagram/exploitability/RESULTS.md. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
     }
   ],
   "extra": {

--- a/tests/test_release_bundle_integrity.py
+++ b/tests/test_release_bundle_integrity.py
@@ -1,0 +1,84 @@
+"""Integrity check: shipped release bundle bytes match the manifest (issue #470).
+
+Validates every artifact catalogued in the wheel-shipped
+``bucket_brigade/baselines/release/local/manifest.json`` against the
+**tracked bytes** in the repo: each file must exist, its SHA-256 must
+equal the manifest ``sha256``, and its size must equal ``size_bytes``.
+
+Why this exists
+---------------
+
+The manifest was frozen in #401 (release 0.1.0). PR #420's full-grid
+phase-diagram regeneration then overwrote 4 genome files inside the
+shipped ``local/`` bundle without re-freezing, leaving the manifest's
+integrity hashes silently false until issue #470 caught it during the
+PR #469 evaluation. The pre-existing manifest tests
+(``tests/test_release_manifest.py``) are schema-level only, so the
+drift went undetected.
+
+This test hashes the actual bundle (11 small JSON files, so it is
+fast and unmarked) and makes any future post-freeze overwrite fail CI
+loudly. Legitimate artifact changes must go through a re-freeze
+(``python -m bucket_brigade.baselines.release.freeze``) or a manifest
+round-trip repair (see #470) — never a bare file overwrite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from bucket_brigade.baselines.release.manifest import (
+    MANIFEST_FILENAME,
+    load_manifest,
+)
+
+# Resolve the bundle relative to the repo checkout (tests/ lives at the
+# repo root) so we always validate the *tracked* bytes, independent of
+# any installed/downloaded copy or $BUCKET_BRIGADE_BASELINES_DIR.
+_BUNDLE_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "bucket_brigade"
+    / "baselines"
+    / "release"
+    / "local"
+)
+_MANIFEST_PATH = _BUNDLE_DIR / MANIFEST_FILENAME
+
+_ARTIFACTS = load_manifest(_MANIFEST_PATH).artifacts
+
+
+def test_manifest_catalogs_at_least_one_artifact() -> None:
+    """Guard against a silently-empty manifest making the suite vacuous."""
+    assert len(_ARTIFACTS) > 0
+
+
+@pytest.mark.parametrize("entry", _ARTIFACTS, ids=lambda e: e.filename)
+def test_artifact_bytes_match_manifest(entry) -> None:
+    """Every manifest entry's file exists with matching sha256 and size."""
+    path = _BUNDLE_DIR / entry.filename
+    assert path.is_file(), (
+        f"Manifest entry {entry.filename!r} has no file at {path}. "
+        "Either restore the artifact or re-freeze the bundle."
+    )
+
+    data = path.read_bytes()
+
+    assert entry.sha256, (
+        f"Manifest entry {entry.filename!r} has an empty sha256; the "
+        "shipped bundle must be fully checksummed."
+    )
+    actual_sha = hashlib.sha256(data).hexdigest()
+    assert actual_sha == entry.sha256, (
+        f"sha256 drift for {entry.filename!r}: manifest says "
+        f"{entry.sha256[:12]}..., tracked bytes hash to "
+        f"{actual_sha[:12]}.... Post-freeze overwrites must update the "
+        "manifest via the freeze script or a save_manifest round-trip "
+        "(see issue #470); never overwrite bundle files in place."
+    )
+    assert len(data) == entry.size_bytes, (
+        f"size_bytes drift for {entry.filename!r}: manifest says "
+        f"{entry.size_bytes}, tracked file is {len(data)} bytes."
+    )


### PR DESCRIPTION
## Summary

Repairs the release-manifest sha256 drift found during the PR #469 evaluation: 4 phase-diagram genome files in the wheel-shipped `bucket_brigade/baselines/release/local/` bundle were overwritten by #420's full-grid regeneration after the 0.1.0 freeze (#401), without a manifest update. Adds the regression test the issue asks for so future post-freeze overwrites fail CI loudly.

## Investigation: which bytes won and why

Diffing #401 vs #420 for all 4 files shows the **semantic content is identical** — same genomes, same `team_payoff` (72.0095 for the k0.90 pair, -821.679 for the k0.50 pair), same `profile_label`s. The #420 rewrite only **dropped the `source_parameters` / `swept_parameters` metadata blocks**, which is exactly why the b0.50/b0.90 pairs became byte-identical (beta was only recorded in `swept_parameters`).

The post-#420 bytes are kept as canonical because:
- They were an intentional part of #420 (its Judge reviewed all 33 genome files in that directory) and are schema-consistent with the 29 full-grid siblings #420 added.
- They are what has shipped for ~13 months of repo time and what the current analyses (exploitability RESULTS.md, the #466/#469 anchor annotations) reference; since genomes/payoffs are unchanged from #401, downstream results are unaffected either way.
- Restoring #401 bytes would make the 4 c=0.50 cells schema-inconsistent with the rest of the grid.

## Changes

- `bucket_brigade/baselines/release/local/manifest.json`: sha256/size_bytes for the 4 drifted entries re-synced to the tracked bytes via the canonical `load_manifest` -> `dataclasses.replace(ArtifactEntry, ...)` -> `save_manifest` round-trip (no hand-edited hashes); a dated drift-and-repair provenance note appended to each entry's `notes` (after the existing #459/#466 anchor annotations, which are preserved verbatim); `release_version` bumped 0.1.1 -> 0.1.2.
- `bucket_brigade/baselines/release/freeze.py`: `DEFAULT_RELEASE_VERSION` bumped to 0.1.2 with a changelog comment (following the #469 precedent), plus a warning that a naive re-freeze would revert the #420 bytes and clear the full-grid cells (the freeze script only knows the 4-host preview sources).
- `tests/test_release_bundle_integrity.py` (new): parametrized test hashing every manifest artifact against the tracked bundle bytes — existence, non-empty sha256, sha256 match, size_bytes match. Fast (11 small JSON files, no marks).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Decide whether #420 or #401 bytes are canonical | Done | #420 bytes kept (see Investigation); genomes/payoffs verified byte-identical to #401, only metadata blocks differ |
| Re-sync manifest, bumping release_version | Done | 0.1.1 -> 0.1.2 via save_manifest round-trip; diff shows only the 4 entries + version changed |
| Regression test hashing every artifact against manifest.json | Done | New test; verified it fails on exactly the 4 drifted entries against the pre-repair manifest and passes post-repair |
| #466/#469 annotations remain intact | Done | Anchor-update notes preserved verbatim; repair note appended after them |

## Test Plan

- `pytest tests/test_release_bundle_integrity.py tests/test_release_manifest.py tests/test_release_paths.py tests/test_release_freeze.py tests/test_release_loaders.py tests/test_release_hub.py` — 52 passed.
- Negative check: stashed the manifest repair and re-ran the integrity test — 4 failed (exactly the drifted files), 8 passed; restored and all pass.
- `ruff format` (no changes) + `ruff check` (clean) on touched Python files.

## Out of scope (noted for follow-up)

#420 also added 29 full-grid genome files to `local/nash/phase_diagram/` that are absent from the manifest entirely (unreachable via the loader API), and the freeze script cannot reproduce the current bundle. Filed separately rather than expanding this PR.

Closes #470