### PR TITLE
fix(release): catalogue the 29 #420 full-grid phase-diagram genomes + refuse destructive re-freeze

### DIFF
--- a/bucket_brigade/baselines/release/freeze.py
+++ b/bucket_brigade/baselines/release/freeze.py
@@ -66,6 +66,7 @@ import hashlib
 import json
 import subprocess  # nosec B404 (only used to stamp manifest with git short SHA; argv is hardcoded)
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -88,12 +89,19 @@ from .manifest import (
 # bytes unchanged. 0.1.1 -> 0.1.2: manifest-only hash re-sync (#470)
 # for the 4 (c=0.50) phase-diagram cells that #420's full-grid
 # regeneration rewrote after the 0.1.0 freeze; shipped bytes unchanged
-# since #420. NOTE: re-running this freeze script regenerates those
-# cells from the preview sources (restoring the source_parameters /
-# swept_parameters blocks #420 dropped) and clears the full-grid cells
-# #420 added to local/nash/phase_diagram/ — review issue #470 before
-# re-freezing.
-DEFAULT_RELEASE_VERSION: str = "0.1.2"
+# since #420. 0.1.2 -> 0.1.3: manifest-only addition (#473) of the 29
+# full-grid phase-diagram genomes #420 shipped in local/nash/
+# phase_diagram/ without cataloguing; artifact bytes unchanged. Those
+# 29 cells are NOT reproducible by this script (the per-cell solver
+# outputs were never committed — only the aggregated summary at
+# experiments/nash/phase_diagram/results.json, which carries no genome
+# vectors), so :func:`freeze_release` now refuses to clear a bundle
+# containing files it cannot regenerate unless ``--force`` is passed.
+# NOTE: re-running this freeze script regenerates the 4 preview-derived
+# (c=0.50) cells from the preview sources (restoring the
+# source_parameters / swept_parameters blocks #420 dropped) — review
+# issues #470/#473 before re-freezing.
+DEFAULT_RELEASE_VERSION: str = "0.1.3"
 
 
 # Default subdirectory layout inside the release bundle. Mirrors the
@@ -145,6 +153,38 @@ _PHASE_DIAGRAM_CELL_NOTE_SUFFIXES: Dict[str, str] = {
     )
     for tag in ("b0.50_k0.90_c0.50", "b0.90_k0.90_c0.50")
 }
+
+
+class UnknownBundleFilesError(RuntimeError):
+    """Raised when a freeze would delete bundle files it cannot regenerate.
+
+    Issue #470/#473 background: PR #420 wrote 29 full-grid phase-diagram
+    genome files directly into the shipped ``local/nash/phase_diagram/``
+    bundle without committing the per-cell solver outputs they came
+    from. The freeze script only knows the preview sources, so a naive
+    re-freeze would silently ``rmtree`` those cells. Rather than lose
+    unreproducible artifacts, :func:`freeze_release` refuses up front
+    and lists the orphaned files; the operator can pass ``force=True``
+    (CLI ``--force``) after moving/backing up the files or deciding the
+    deletion is intended.
+    """
+
+    def __init__(self, bundle_dir: Path, unknown_files: Sequence[str]) -> None:
+        self.bundle_dir = Path(bundle_dir)
+        self.unknown_files = list(unknown_files)
+        listing = "\n".join(f"  - {f}" for f in self.unknown_files)
+        super().__init__(
+            f"Refusing to freeze into {self.bundle_dir}: it contains "
+            f"{len(self.unknown_files)} artifact file(s) this freeze run "
+            "cannot regenerate from its known sources and would therefore "
+            f"delete:\n{listing}\n"
+            "These are likely unreproducible artifacts written directly "
+            "into the bundle (see issues #470/#473 — e.g. the #420 "
+            "full-grid phase-diagram genomes, whose per-cell solver "
+            "outputs were never committed). Either move them out of the "
+            "bundle, stage their sources so the freeze can regenerate "
+            "them, or re-run with --force to delete them anyway."
+        )
 
 
 @dataclass(frozen=True)
@@ -537,6 +577,76 @@ def _freeze_ppo_checkpoints(repo_root: Path, bundle_dir: Path) -> List[ArtifactE
 # ---------------------------------------------------------------------------
 
 
+def _produce_artifacts(
+    repo_root: Path,
+    bundle_dir: Path,
+    include_phase_diagram: bool,
+    include_ppo: bool,
+) -> Tuple[
+    List[ArtifactEntry],
+    List[ArtifactEntry],
+    List[ArtifactEntry],
+    List[ArtifactEntry],
+]:
+    """Write every artifact file into ``bundle_dir`` and return entries.
+
+    Shared by the real freeze and the pre-flight staging pass in
+    :func:`find_unreproducible_files`, so both agree exactly on which
+    files a freeze run produces.
+    """
+    archetype_entries = _freeze_archetypes(bundle_dir)
+    nash_entries = _freeze_heterogeneous_ne(repo_root, bundle_dir)
+    pd_entries: List[ArtifactEntry] = []
+    if include_phase_diagram:
+        pd_entries = _freeze_phase_diagram_ne(repo_root, bundle_dir)
+    ppo_entries: List[ArtifactEntry] = []
+    if include_ppo:
+        ppo_entries = _freeze_ppo_checkpoints(repo_root, bundle_dir)
+    return archetype_entries, nash_entries, pd_entries, ppo_entries
+
+
+def _existing_artifact_files(bundle_dir: Path) -> set[str]:
+    """Relative POSIX paths of all files under the artifact subdirs."""
+    found: set[str] = set()
+    for sub in (ARCHETYPES_SUBDIR, NASH_SUBDIR, PPO_SUBDIR):
+        target = bundle_dir / sub
+        if not target.is_dir():
+            continue
+        for p in target.rglob("*"):
+            if p.is_file():
+                found.add(p.relative_to(bundle_dir).as_posix())
+    return found
+
+
+def find_unreproducible_files(
+    repo_root: Path,
+    bundle_dir: Path,
+    include_phase_diagram: bool = True,
+    include_ppo: bool = True,
+) -> List[str]:
+    """Files in ``bundle_dir``'s artifact subdirs a freeze would NOT rewrite.
+
+    Stages a throwaway freeze into a temporary directory to compute the
+    exact set of files this run would produce, then returns the sorted
+    relative paths of existing bundle files outside that set. A
+    non-empty result means a destructive freeze would permanently
+    delete artifacts that cannot be regenerated from the known sources
+    (see :class:`UnknownBundleFilesError`).
+    """
+    existing = _existing_artifact_files(Path(bundle_dir))
+    if not existing:
+        return []
+    with tempfile.TemporaryDirectory() as tmp:
+        groups = _produce_artifacts(
+            repo_root=Path(repo_root),
+            bundle_dir=Path(tmp),
+            include_phase_diagram=include_phase_diagram,
+            include_ppo=include_ppo,
+        )
+    producible = {entry.filename for group in groups for entry in group}
+    return sorted(existing - producible)
+
+
 def freeze_release(
     repo_root: Path,
     bundle_dir: Path,
@@ -544,6 +654,7 @@ def freeze_release(
     release_date: Optional[str] = None,
     include_phase_diagram: bool = True,
     include_ppo: bool = True,
+    force: bool = False,
 ) -> FreezeStats:
     """Gather every artifact and write the manifest into ``bundle_dir``.
 
@@ -562,12 +673,33 @@ def freeze_release(
             the phase-diagram preview. Most callers want this.
         include_ppo: If True, copy any staged PPO checkpoints into the
             bundle. No-op if none are staged.
+        force: If True, skip the pre-flight unreproducible-files check
+            and clear the artifact subdirs unconditionally (the pre-#473
+            behaviour).
 
     Returns:
         :class:`FreezeStats` summarising what was written.
+
+    Raises:
+        UnknownBundleFilesError: If ``bundle_dir`` contains artifact
+            files this run cannot regenerate and ``force`` is False.
     """
     bundle_dir = Path(bundle_dir)
     bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pre-flight (#473): refuse to delete artifact files this run
+    # cannot regenerate. PR #420 demonstrated the failure mode — genome
+    # files written straight into the shipped bundle with no committed
+    # source, which a naive re-freeze would silently rmtree.
+    if not force:
+        unknown = find_unreproducible_files(
+            repo_root=repo_root,
+            bundle_dir=bundle_dir,
+            include_phase_diagram=include_phase_diagram,
+            include_ppo=include_ppo,
+        )
+        if unknown:
+            raise UnknownBundleFilesError(bundle_dir, unknown)
 
     # Clear out any prior artifact subdirs so stale entries don't
     # linger across runs. The .gitkeep + README that ship in the
@@ -578,14 +710,12 @@ def freeze_release(
         if target.exists():
             _rmtree(target)
 
-    archetype_entries = _freeze_archetypes(bundle_dir)
-    nash_entries = _freeze_heterogeneous_ne(repo_root, bundle_dir)
-    pd_entries: List[ArtifactEntry] = []
-    if include_phase_diagram:
-        pd_entries = _freeze_phase_diagram_ne(repo_root, bundle_dir)
-    ppo_entries: List[ArtifactEntry] = []
-    if include_ppo:
-        ppo_entries = _freeze_ppo_checkpoints(repo_root, bundle_dir)
+    archetype_entries, nash_entries, pd_entries, ppo_entries = _produce_artifacts(
+        repo_root=repo_root,
+        bundle_dir=bundle_dir,
+        include_phase_diagram=include_phase_diagram,
+        include_ppo=include_ppo,
+    )
 
     if release_date is None:
         release_date = datetime.date.today().isoformat()
@@ -699,6 +829,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Print the manifest that *would* be written and exit without touching disk."
         ),
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Clear the destination artifact subdirs even if they contain "
+            "files this freeze cannot regenerate (skips the #473 "
+            "unreproducible-files guard). DESTRUCTIVE: review the guard's "
+            "file list (run without --force first) before using."
+        ),
+    )
     return parser
 
 
@@ -710,8 +850,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.dry_run:
         # In dry-run mode we still construct the bundle in a temp dir
         # so we exercise the same code path, then report and exit.
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             stats = freeze_release(
                 repo_root=repo_root,
@@ -724,16 +862,38 @@ def main(argv: Optional[List[str]] = None) -> int:
             print("(dry-run)")
             print(stats.short_summary())
             print(f"  intended destination: {bundle_dir}")
+        # Also run the #473 pre-flight against the *intended*
+        # destination so operators see what a real (non---force) run
+        # would refuse to delete.
+        unknown = find_unreproducible_files(
+            repo_root=repo_root,
+            bundle_dir=bundle_dir,
+            include_phase_diagram=not args.no_phase_diagram,
+            include_ppo=not args.no_ppo,
+        )
+        if unknown:
+            print(
+                f"  WARNING: {len(unknown)} file(s) in the destination "
+                "cannot be regenerated by this freeze; a real run will "
+                "refuse without --force:"
+            )
+            for f in unknown:
+                print(f"    - {f}")
         return 0
 
-    stats = freeze_release(
-        repo_root=repo_root,
-        bundle_dir=bundle_dir,
-        release_version=args.release_version,
-        release_date=args.release_date,
-        include_phase_diagram=not args.no_phase_diagram,
-        include_ppo=not args.no_ppo,
-    )
+    try:
+        stats = freeze_release(
+            repo_root=repo_root,
+            bundle_dir=bundle_dir,
+            release_version=args.release_version,
+            release_date=args.release_date,
+            include_phase_diagram=not args.no_phase_diagram,
+            include_ppo=not args.no_ppo,
+            force=args.force,
+        )
+    except UnknownBundleFilesError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     print(stats.short_summary())
     return 0
 

--- a/bucket_brigade/baselines/release/local/README.md
+++ b/bucket_brigade/baselines/release/local/README.md
@@ -46,7 +46,8 @@ in-repo sources:
 # From the repo root:
 python -m bucket_brigade.baselines.release.freeze
 
-# Preview without writing:
+# Preview without writing (also reports files a real run would refuse
+# to delete):
 python -m bucket_brigade.baselines.release.freeze --dry-run
 ```
 
@@ -55,6 +56,18 @@ Sources read:
 - Archetypes: `bucket_brigade/agents/archetypes.py`
 - Heterogeneous NE: `experiments/nash/heterogeneous/<scenario>/results.json`
 - Phase-diagram cells: `experiments/nash/phase_diagram/preview/*/cells/*/results.json`
+
+**Unreproducible-files guard (#473)**: the freeze refuses to run if the
+bundle contains artifact files it cannot regenerate from the sources
+above, instead of silently deleting them. The 29 full-grid
+phase-diagram genomes added by #420 are exactly such files — their
+per-cell solver outputs were never committed (only the aggregated
+summary at `experiments/nash/phase_diagram/results.json`, which has no
+genome vectors), so the tracked bytes here are the canonical record.
+Pass `--force` only after reviewing the refusal list; a forced freeze
+deletes those files permanently. Manifest changes for unreproducible
+artifacts go through a `load_manifest` -> `ArtifactEntry` ->
+`save_manifest` round-trip instead (see #470/#472/#473).
 
 To add PPO checkpoints (after #384 lands), stage the trained
 checkpoints under

--- a/bucket_brigade/baselines/release/local/manifest.json
+++ b/bucket_brigade/baselines/release/local/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_version": "0.1.2",
+  "release_version": "0.1.3",
   "release_date": "2026-06-08",
   "source_commit": "9adf1d3a",
   "huggingface_repo": "rjwalters/bucket-brigade-baselines",
@@ -70,12 +70,174 @@
     },
     {
       "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.10_c1.00",
+      "filename": "nash/phase_diagram/b0.10_k0.10_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "a9b74a0fdbaaaef2fa7d2eae06ec5f767ae23d1929b1a81b5fac9e59f28cc1d2",
+      "size_bytes": 1709,
+      "notes": "Phase-diagram cell b0.10_k0.10_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.30_c1.00",
+      "filename": "nash/phase_diagram/b0.10_k0.30_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "e29f8c9083d62c8865c47a281e9425a5a5a15c1f2fe2d8de5327159958fe5be1",
+      "size_bytes": 1613,
+      "notes": "Phase-diagram cell b0.10_k0.30_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.30_c2.00",
+      "filename": "nash/phase_diagram/b0.10_k0.30_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "5490af3f9f5bd7524e93ca93815b00b6a447b8f6f0890f3e8a1217d8d47e47c8",
+      "size_bytes": 1623,
+      "notes": "Phase-diagram cell b0.10_k0.30_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.50_c0.50",
+      "filename": "nash/phase_diagram/b0.10_k0.50_c0.50.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "1594ed13973c26458743d5397487bf2176fd39b895c7f21b4d8f578917ca1eb7",
+      "size_bytes": 1812,
+      "notes": "Phase-diagram cell b0.10_k0.50_c0.50; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.50_c1.00",
+      "filename": "nash/phase_diagram/b0.10_k0.50_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "312112b240c7f6da3a941839360d1de1681b7eae7a0b4f1425767404062ed727",
+      "size_bytes": 1555,
+      "notes": "Phase-diagram cell b0.10_k0.50_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.50_c2.00",
+      "filename": "nash/phase_diagram/b0.10_k0.50_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "97b78426b317eb48cc6e23a441de0ed315e464ac2aeafdd8f61b8ae54d43c94d",
+      "size_bytes": 1704,
+      "notes": "Phase-diagram cell b0.10_k0.50_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.70_c1.00",
+      "filename": "nash/phase_diagram/b0.10_k0.70_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "08677985809e22b77b28adca0067982fef07ba5afc4e6882e04d55c469d38317",
+      "size_bytes": 1562,
+      "notes": "Phase-diagram cell b0.10_k0.70_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.70_c2.00",
+      "filename": "nash/phase_diagram/b0.10_k0.70_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "f7d6e90714b8771cea63ec126096917025c8a2eb2958dae1e95d39a7a10c17f0",
+      "size_bytes": 1563,
+      "notes": "Phase-diagram cell b0.10_k0.70_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.90_c0.50",
+      "filename": "nash/phase_diagram/b0.10_k0.90_c0.50.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "6cbbbbf775df644b7d9f97002d75a2602dfcba9e2644845e1514e3efdeb8f7a6",
+      "size_bytes": 1579,
+      "notes": "Phase-diagram cell b0.10_k0.90_c0.50; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.90_c1.00",
+      "filename": "nash/phase_diagram/b0.10_k0.90_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "b79e37de9b5f55fcd48d8421303e9376b3c0422b02b86ea800a73d3157eef4d5",
+      "size_bytes": 1875,
+      "notes": "Phase-diagram cell b0.10_k0.90_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.10_k0.90_c2.00",
+      "filename": "nash/phase_diagram/b0.10_k0.90_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "85656e0d71d110b81ca049a36a58223d51508c4e686d078e498f2e80105b9aaf",
+      "size_bytes": 1877,
+      "notes": "Phase-diagram cell b0.10_k0.90_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.10_c1.00",
+      "filename": "nash/phase_diagram/b0.50_k0.10_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "a9b74a0fdbaaaef2fa7d2eae06ec5f767ae23d1929b1a81b5fac9e59f28cc1d2",
+      "size_bytes": 1709,
+      "notes": "Phase-diagram cell b0.50_k0.10_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.30_c1.00",
+      "filename": "nash/phase_diagram/b0.50_k0.30_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "e29f8c9083d62c8865c47a281e9425a5a5a15c1f2fe2d8de5327159958fe5be1",
+      "size_bytes": 1613,
+      "notes": "Phase-diagram cell b0.50_k0.30_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.30_c2.00",
+      "filename": "nash/phase_diagram/b0.50_k0.30_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "5490af3f9f5bd7524e93ca93815b00b6a447b8f6f0890f3e8a1217d8d47e47c8",
+      "size_bytes": 1623,
+      "notes": "Phase-diagram cell b0.50_k0.30_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
       "name": "phase_diagram_b0.50_k0.50_c0.50",
       "filename": "nash/phase_diagram/b0.50_k0.50_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
       "sha256": "8800300a10e5dccb2b6568954bb41692fea77d12af62279ee932774713e046a8",
       "size_bytes": 1561,
       "notes": "Phase-diagram cell b0.50_k0.50_c0.50 from alc-2; best converged NE for the (\u03b2, \u03ba, c) point. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.50_c1.00",
+      "filename": "nash/phase_diagram/b0.50_k0.50_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "312112b240c7f6da3a941839360d1de1681b7eae7a0b4f1425767404062ed727",
+      "size_bytes": 1555,
+      "notes": "Phase-diagram cell b0.50_k0.50_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.50_c2.00",
+      "filename": "nash/phase_diagram/b0.50_k0.50_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "97b78426b317eb48cc6e23a441de0ed315e464ac2aeafdd8f61b8ae54d43c94d",
+      "size_bytes": 1704,
+      "notes": "Phase-diagram cell b0.50_k0.50_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.70_c1.00",
+      "filename": "nash/phase_diagram/b0.50_k0.70_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "08677985809e22b77b28adca0067982fef07ba5afc4e6882e04d55c469d38317",
+      "size_bytes": 1562,
+      "notes": "Phase-diagram cell b0.50_k0.70_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.70_c2.00",
+      "filename": "nash/phase_diagram/b0.50_k0.70_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "f7d6e90714b8771cea63ec126096917025c8a2eb2958dae1e95d39a7a10c17f0",
+      "size_bytes": 1563,
+      "notes": "Phase-diagram cell b0.50_k0.70_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
     },
     {
       "kind": "nash",
@@ -88,6 +250,51 @@
     },
     {
       "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.90_c1.00",
+      "filename": "nash/phase_diagram/b0.50_k0.90_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "b79e37de9b5f55fcd48d8421303e9376b3c0422b02b86ea800a73d3157eef4d5",
+      "size_bytes": 1875,
+      "notes": "Phase-diagram cell b0.50_k0.90_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.50_k0.90_c2.00",
+      "filename": "nash/phase_diagram/b0.50_k0.90_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "85656e0d71d110b81ca049a36a58223d51508c4e686d078e498f2e80105b9aaf",
+      "size_bytes": 1877,
+      "notes": "Phase-diagram cell b0.50_k0.90_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.10_c1.00",
+      "filename": "nash/phase_diagram/b0.90_k0.10_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "a9b74a0fdbaaaef2fa7d2eae06ec5f767ae23d1929b1a81b5fac9e59f28cc1d2",
+      "size_bytes": 1709,
+      "notes": "Phase-diagram cell b0.90_k0.10_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.30_c1.00",
+      "filename": "nash/phase_diagram/b0.90_k0.30_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "e29f8c9083d62c8865c47a281e9425a5a5a15c1f2fe2d8de5327159958fe5be1",
+      "size_bytes": 1613,
+      "notes": "Phase-diagram cell b0.90_k0.30_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.30_c2.00",
+      "filename": "nash/phase_diagram/b0.90_k0.30_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "5490af3f9f5bd7524e93ca93815b00b6a447b8f6f0890f3e8a1217d8d47e47c8",
+      "size_bytes": 1623,
+      "notes": "Phase-diagram cell b0.90_k0.30_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
       "name": "phase_diagram_b0.90_k0.50_c0.50",
       "filename": "nash/phase_diagram/b0.90_k0.50_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
@@ -97,12 +304,66 @@
     },
     {
       "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.50_c1.00",
+      "filename": "nash/phase_diagram/b0.90_k0.50_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "312112b240c7f6da3a941839360d1de1681b7eae7a0b4f1425767404062ed727",
+      "size_bytes": 1555,
+      "notes": "Phase-diagram cell b0.90_k0.50_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.50_c2.00",
+      "filename": "nash/phase_diagram/b0.90_k0.50_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "97b78426b317eb48cc6e23a441de0ed315e464ac2aeafdd8f61b8ae54d43c94d",
+      "size_bytes": 1704,
+      "notes": "Phase-diagram cell b0.90_k0.50_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.70_c1.00",
+      "filename": "nash/phase_diagram/b0.90_k0.70_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "08677985809e22b77b28adca0067982fef07ba5afc4e6882e04d55c469d38317",
+      "size_bytes": 1562,
+      "notes": "Phase-diagram cell b0.90_k0.70_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.70_c2.00",
+      "filename": "nash/phase_diagram/b0.90_k0.70_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "f7d6e90714b8771cea63ec126096917025c8a2eb2958dae1e95d39a7a10c17f0",
+      "size_bytes": 1563,
+      "notes": "Phase-diagram cell b0.90_k0.70_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
       "name": "phase_diagram_b0.90_k0.90_c0.50",
       "filename": "nash/phase_diagram/b0.90_k0.90_c0.50.json",
       "scenario_id": "minimal_specialization-v1",
       "sha256": "97146cdcc976dbbad2d6891371d26b16171827f8d8dce0b58ed4c040fc91bbab",
       "size_bytes": 1582,
       "notes": "Phase-diagram cell b0.90_k0.90_c0.50 from alc-6; best converged NE for the (\u03b2, \u03ba, c) point. Anchor update (#459/#466): this solver-selected profile (hero|FF|FF|FF, solver team_payoff 72.0095, winner's-curse-biased) is an epsilon-NE at epsilon=50, but the FF|hero|hero|FF profile frozen at b0.10_k0.90_c0.50.json (beta-inert, same game) is also an epsilon-NE and decisively better (CRN paired +9.55 +/- 2.73/episode; CRN team payoff 55.36 +/- 3.44 vs 45.80 +/- 3.58). Cite b0.10_k0.90_c0.50.json as this cell's NE anchor; this file is retained unchanged as the historical solver record. See experiments/nash/phase_diagram/exploitability/RESULTS.md. Manifest repair (#470, 2026-07-04): sha256/size_bytes re-synced to the tracked bytes shipped since #420, whose full-grid phase-diagram regeneration rewrote this file after the 0.1.0 freeze (#401) without updating the manifest. The #420 rewrite dropped only the source_parameters/swept_parameters metadata blocks; genome, payoffs, and profile_label are byte-for-byte unchanged from the #401 freeze, so downstream analyses are unaffected."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.90_c1.00",
+      "filename": "nash/phase_diagram/b0.90_k0.90_c1.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "b79e37de9b5f55fcd48d8421303e9376b3c0422b02b86ea800a73d3157eef4d5",
+      "size_bytes": 1875,
+      "notes": "Phase-diagram cell b0.90_k0.90_c1.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
+    },
+    {
+      "kind": "nash",
+      "name": "phase_diagram_b0.90_k0.90_c2.00",
+      "filename": "nash/phase_diagram/b0.90_k0.90_c2.00.json",
+      "scenario_id": "minimal_specialization-v1",
+      "sha256": "85656e0d71d110b81ca049a36a58223d51508c4e686d078e498f2e80105b9aaf",
+      "size_bytes": 1877,
+      "notes": "Phase-diagram cell b0.90_k0.90_c2.00; best-equilibrium NE genome for the (\u03b2, \u03ba, c) point, written by #420's full-grid regeneration (commit 73b49b08). Catalogued retroactively (#473, 2026-07-04): #420 shipped this file inside the bundle without a manifest entry, leaving it unreachable via the loader API and without an integrity hash. The per-cell solver outputs were not committed (only the aggregated summary at experiments/nash/phase_diagram/results.json, which carries no genome vectors), so this artifact is not reproducible by the freeze script; the tracked bytes are the canonical record."
     }
   ],
   "extra": {

--- a/tests/test_release_bundle_integrity.py
+++ b/tests/test_release_bundle_integrity.py
@@ -4,6 +4,9 @@ Validates every artifact catalogued in the wheel-shipped
 ``bucket_brigade/baselines/release/local/manifest.json`` against the
 **tracked bytes** in the repo: each file must exist, its SHA-256 must
 equal the manifest ``sha256``, and its size must equal ``size_bytes``.
+Also validates the inverse (#473): every file shipped inside the bundle
+is catalogued in the manifest (or explicitly allowlisted), so nothing
+can ship in the wheel while being unreachable via the loader API.
 
 Why this exists
 ---------------
@@ -82,3 +85,62 @@ def test_artifact_bytes_match_manifest(entry) -> None:
         f"size_bytes drift for {entry.filename!r}: manifest says "
         f"{entry.size_bytes}, tracked file is {len(data)} bytes."
     )
+
+
+# Non-artifact files that legitimately live in the bundle without a
+# manifest entry. Anything else on disk MUST be catalogued.
+_UNCATALOGUED_ALLOWLIST = {
+    MANIFEST_FILENAME,  # the manifest itself
+    "README.md",  # bundle layout documentation
+    ".gitkeep",  # keeps the dir present pre-freeze
+}
+
+
+def test_every_bundle_file_is_catalogued_in_manifest() -> None:
+    """Inverse coverage check (issue #473).
+
+    PR #420 wrote 29 genome files into the shipped bundle without
+    manifest entries — they went out in the wheel unreachable via
+    ``resolve_artifact_path()`` and with no integrity record. This test
+    catches the next such overwrite: every file under the bundle dir
+    must be either a manifest artifact or explicitly allowlisted above.
+    """
+    catalogued = {entry.filename for entry in _ARTIFACTS}
+    on_disk = {
+        p.relative_to(_BUNDLE_DIR).as_posix()
+        for p in _BUNDLE_DIR.rglob("*")
+        if p.is_file()
+    }
+    uncatalogued = sorted(on_disk - catalogued - _UNCATALOGUED_ALLOWLIST)
+    assert not uncatalogued, (
+        f"{len(uncatalogued)} file(s) ship inside the release bundle but "
+        f"are not catalogued in the manifest: {uncatalogued}. Add manifest "
+        "entries via a save_manifest round-trip (or re-freeze), or move "
+        "the files out of the wheel-shipped local/ dir. See issue #473."
+    )
+
+
+def test_full_grid_phase_diagram_cell_loads_via_loader_api() -> None:
+    """One #420 full-grid cell round-trips through the public loader.
+
+    ``b0.10_k0.90_c0.50`` is the cell the #459/#466 anchor annotations
+    cite; before #473 it shipped in the wheel but was unreachable
+    because it had no manifest entry. Loading it end-to-end proves the
+    retroactively-catalogued entries are wired into the loader API.
+    """
+    from bucket_brigade.baselines.release.loaders import load_nash, load_nash_genomes
+
+    payload = load_nash(
+        "minimal_specialization-v1",
+        name="phase_diagram_b0.10_k0.90_c0.50",
+        directory=_BUNDLE_DIR,
+    )
+    assert payload["scenario_id"] == "minimal_specialization-v1"
+    assert len(payload["positions"]) == 4
+
+    genomes = load_nash_genomes(
+        "minimal_specialization-v1",
+        name="phase_diagram_b0.10_k0.90_c0.50",
+        directory=_BUNDLE_DIR,
+    )
+    assert genomes.shape == (4, 10)

--- a/tests/test_release_freeze.py
+++ b/tests/test_release_freeze.py
@@ -29,6 +29,8 @@ from bucket_brigade.baselines.release.freeze import (
     DEFAULT_RELEASE_VERSION,
     _ARCHETYPE_PARAM_NAMES,
     _select_best_converged_ne,
+    UnknownBundleFilesError,
+    find_unreproducible_files,
     freeze_release,
 )
 
@@ -232,23 +234,72 @@ def test_freeze_handles_missing_nash_sources_gracefully(tmp_path: Path) -> None:
     assert stats.num_nash_phase_diagram_cells == 0
 
 
-def test_freeze_clears_stale_artifact_subdirs(tmp_path: Path) -> None:
-    """Re-running the freeze removes prior subdir contents so an
-    archetype renamed or removed upstream doesn't linger as a stale
-    file in ``local/``."""
+def test_freeze_refuses_to_delete_unreproducible_files(tmp_path: Path) -> None:
+    """A freeze into a bundle containing artifact files it cannot
+    regenerate refuses loudly instead of rmtree-ing them (issue #473 —
+    the #420 full-grid genomes were exactly such files). Nothing in the
+    destination is modified by the refused run."""
+    repo = tmp_path / "repo"
+    bundle = tmp_path / "bundle"
+    _stage_fake_repo(repo)
+    freeze_release(repo_root=repo, bundle_dir=bundle, release_date="2026-06-08")
+    snapshot_before = _snapshot_bundle(bundle)
+
+    # Inject a file the freeze sources cannot reproduce (analogous to
+    # a #420-style direct write into the shipped bundle).
+    orphan = bundle / "nash" / "phase_diagram" / "b9.99_k9.99_c9.99.json"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text("{}")
+
+    with pytest.raises(UnknownBundleFilesError) as excinfo:
+        freeze_release(repo_root=repo, bundle_dir=bundle, release_date="2026-06-08")
+    assert "b9.99_k9.99_c9.99.json" in str(excinfo.value)
+    assert excinfo.value.unknown_files == ["nash/phase_diagram/b9.99_k9.99_c9.99.json"]
+
+    # The refused run must not have touched the bundle.
+    assert orphan.exists()
+    snapshot_after = _snapshot_bundle(bundle)
+    snapshot_after.pop("nash/phase_diagram/b9.99_k9.99_c9.99.json")
+    assert snapshot_after == snapshot_before
+
+
+def test_freeze_force_clears_stale_artifact_subdirs(tmp_path: Path) -> None:
+    """With ``force=True`` the freeze keeps the pre-#473 behaviour:
+    prior subdir contents are removed so an artifact renamed or removed
+    upstream doesn't linger as a stale file in ``local/``."""
     repo = tmp_path / "repo"
     bundle = tmp_path / "bundle"
     _stage_fake_repo(repo)
     freeze_release(repo_root=repo, bundle_dir=bundle, release_date="2026-06-08")
 
-    # Inject a fake stale file under archetypes/. The next freeze must
+    # Inject a fake stale file under archetypes/. A forced freeze must
     # remove it.
     stale = bundle / "archetypes" / "ghost.json"
     stale.write_text("{}")
     assert stale.exists()
 
-    freeze_release(repo_root=repo, bundle_dir=bundle, release_date="2026-06-08")
+    freeze_release(
+        repo_root=repo, bundle_dir=bundle, release_date="2026-06-08", force=True
+    )
     assert not stale.exists()
+
+
+def test_find_unreproducible_files_reports_only_orphans(tmp_path: Path) -> None:
+    """The pre-flight helper returns exactly the files a freeze cannot
+    regenerate: empty for a bundle the sources fully cover, and the
+    orphan's relative path once one is injected."""
+    repo = tmp_path / "repo"
+    bundle = tmp_path / "bundle"
+    _stage_fake_repo(repo)
+    freeze_release(repo_root=repo, bundle_dir=bundle, release_date="2026-06-08")
+
+    assert find_unreproducible_files(repo_root=repo, bundle_dir=bundle) == []
+
+    orphan = bundle / "nash" / "orphan.json"
+    orphan.write_text("{}")
+    assert find_unreproducible_files(repo_root=repo, bundle_dir=bundle) == [
+        "nash/orphan.json"
+    ]
 
 
 def test_freeze_uses_default_release_version_when_unspecified(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two-part fix for the release-bundle gaps left after #420 / #472:

1. **Manifest completeness** — the 29 full-grid phase-diagram genomes that PR #420 wrote into the wheel-shipped `local/nash/phase_diagram/` are now catalogued in `manifest.json` (11 -> 40 artifacts), making them reachable via `resolve_artifact_path()` / `load_nash()` and covered by the #472 per-artifact integrity test.
2. **Freeze reproducibility** — `freeze_release()` now refuses (loudly, exit 1) to clear a bundle containing artifact files it cannot regenerate, instead of silently `rmtree`-ing them.

## Freeze-path decision: loud-refusal guard (not full-grid source wiring)

Wiring the full-grid source into `freeze.py` is **not possible from in-repo data**: the #420 per-cell solver outputs (which contain the genome vectors) were never committed. Only 7 preview tags have tracked `preview/*/cells/*/results.json`; the committed full-grid `experiments/nash/phase_diagram/results.json` is an aggregate of `summary.json` files and carries **no genome vectors**. The tracked bundle bytes are therefore the canonical record for the 29 cells, and the correct protection is a guard that prevents their deletion:

- `freeze_release()` stages a throwaway freeze into a temp dir to compute exactly the set of files this run can produce, then raises `UnknownBundleFilesError` (listing the orphans) if the destination contains artifact files outside that set.
- `--force` restores the old destructive behaviour after operator review; `--dry-run` now also prints the refusal list against the intended destination.
- Verified end-to-end against the real bundle: dry-run warns about exactly the 29 files; a real run refuses with exit 1 and leaves the bundle untouched.

## Changes

- `bucket_brigade/baselines/release/local/manifest.json`: +29 nash entries (sha256/size/provenance notes citing #420 commit 73b49b08 and the missing-source situation) via the canonical `load_manifest -> ArtifactEntry -> save_manifest` round-trip; `release_version` 0.1.2 -> 0.1.3 per the #469/#472 precedent. Header fields (`release_date`, `source_commit`) unchanged, matching #472. Zero artifact bytes changed.
- `bucket_brigade/baselines/release/freeze.py`: `UnknownBundleFilesError`, `find_unreproducible_files()` pre-flight, `force` parameter + `--force` CLI flag, dry-run refusal report, `DEFAULT_RELEASE_VERSION` 0.1.3 with updated provenance comment.
- `tests/test_release_bundle_integrity.py`: inverse coverage test (every bundle file is catalogued or allowlisted — this is the test that catches the next #420-style overwrite; it fails on pre-PR main with exactly the 29 files) + end-to-end loader test for the `b0.10_k0.90_c0.50` NE anchor cell (#459/#466).
- `tests/test_release_freeze.py`: guard-refusal test (bundle left untouched, orphan listed), `force=True` stale-clear test (replaces the old destructive-behaviour test), `find_unreproducible_files()` unit test.
- `bucket_brigade/baselines/release/local/README.md`: document the guard and the unreproducible full-grid cells in the operator workflow.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 29 full-grid genomes catalogued with sha256 records | Done | Manifest 11 -> 40 entries; all 40 hashes verified against tracked bytes (integrity suite: 40 parametrized checks pass) |
| Genomes reachable via loader API | Done | `load_nash("minimal_specialization-v1", name="phase_diagram_b0.10_k0.90_c0.50")` + `load_nash_genomes` round-trip test passes (shape (4, 10)) |
| Re-freeze can no longer silently delete the full-grid cells | Done | `python -m bucket_brigade.baselines.release.freeze` against the real bundle exits 1 listing the 29 files; bundle untouched |
| Reverse check: every bundle file catalogued in manifest | Done | `test_every_bundle_file_is_catalogued_in_manifest` (fails on pre-PR main with the 29 files, passes here) |
| Version bump per #469/#472 precedent | Done | 0.1.2 -> 0.1.3 in manifest + `DEFAULT_RELEASE_VERSION` |

## Test Plan

- `pytest tests/test_release_*.py` — 85 passed, 2 skipped (pre-existing wheel-build skips)
- `ruff format --check` + `ruff check` clean on all touched Python files
- Manual CLI verification of `--dry-run` warning and non-forced refusal against the shipped bundle

Closes #473